### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+ language: node_js
+ node_js:
+   - "0.8"
+
+ before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - npm install --quiet -g grunt@0.3.x testacular@0.2.x
+
+ script: grunt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-bootstrap-ui
-============
+# bootstrap - [AngularJS](http://angularjs.org/) directives specific to [twitter bootstrap](http://twitter.github.com/bootstrap/)
 
-Directives specific to twitter bootstrap
+***
+
+[![Build Status](https://secure.travis-ci.org/angular-ui/bootstrap.png)](http://travis-ci.org/angular-ui/bootstrap)
 
 ## Development
 ### Prepare your environment

--- a/grunt.js
+++ b/grunt.js
@@ -56,8 +56,13 @@ module.exports = function(grunt) {
   };
 
   grunt.registerTask('test', 'run tests on single-run server', function() {
-    //Can augment options with command line arguments
-    var options = ['--single-run', '--no-auto-watch'].concat(this.args);
+    var options = ['--single-run', '--no-auto-watch'];
+    if (process.env.TRAVIS) {
+      options =  options.concat(['--browsers=Firefox']);
+    } else {
+      //Can augment options with command line arguments
+      options =  options.concat(this.args);
+    }
     runTestacular('start', options);
   });
 


### PR DESCRIPTION
Added Travis CI support. Even if we are going to have Google CI server in place it will only work for branches in the repo so for our commits / PR.

Travis CI is still useful for contributions (PRs) from outside of the core team to get the early feedback as soon as possible.

For the moment the modal tests are failing we need to fix it before plugging GoogleCI.
