### PR TITLE
Allow html in title attributes in tab-pane directive

### DIFF
--- a/template/tabs/tabs.html
+++ b/template/tabs/tabs.html
@@ -1,7 +1,7 @@
 <div class="tabbable">
   <ul class="nav nav-tabs">
     <li ng-repeat="pane in panes" ng-class="{active:pane.selected}">
-      <a href="" ng-click="select(pane)">{{pane.heading}}</a>
+      <a href="" ng-click="select(pane)" ng-bind-html-unsafe="pane.heading"></a>
     </li>
   </ul>
   <div class="tab-content" ng-transclude></div>


### PR DESCRIPTION
It is common to add icons in tab title, usually with <i class="icon-xxxx"> while using bootstrap. 
So I think the default template should allow this, either using ng-bind-html-unsafe or ng-bind-html with ngSanitize, 
