### PR TITLE
Adding config objects

### DIFF
--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -1,11 +1,18 @@
-angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse']);
-angular.module('ui.bootstrap.accordion').controller('AccordionController', ['$scope', '$attrs', function ($scope, $attrs) {
+angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse'])
+
+.constant('accordionConfig', {
+  closeOthers: true
+})
+
+.controller('AccordionController', ['$scope', '$attrs', 'accordionConfig', function ($scope, $attrs, accordionConfig) {
+  
   // This array keeps track of the accordion groups
   this.groups = [];
 
   // Ensure that all the groups in this accordion are closed, unless close-others explicitly says not to
   this.closeOthers = function(openGroup) {
-    if ( angular.isUndefined($attrs.closeOthers) || $scope.$eval($attrs.closeOthers) ) {
+    var closeOthers = angular.isDefined($attrs.closeOthers) ? $scope.$eval($attrs.closeOthers) : accordionConfig.closeOthers;
+    if ( closeOthers ) {
       angular.forEach(this.groups, function (group) {
         if ( group !== openGroup ) {
           group.isOpen = false;

--- a/src/accordion/test/accordionSpec.js
+++ b/src/accordion/test/accordionSpec.js
@@ -50,12 +50,34 @@ describe('accordion', function () {
         expect(group2.isOpen).toBe(false);
         expect(group3.isOpen).toBe(true);
       });
+
       it('should not close other groups if close-others attribute is false', function() {
         $attrs.closeOthers = 'false';
         ctrl.closeOthers(group2);
         expect(group1.isOpen).toBe(true);
         expect(group2.isOpen).toBe(true);
         expect(group3.isOpen).toBe(true);
+      });
+
+      describe('setting accordionConfig', function() {
+        var originalCloseOthers;
+        beforeEach(inject(function(accordionConfig) {
+          originalCloseOthers = accordionConfig.closeOthers;
+          accordionConfig.closeOthers = false;
+          dump(accordionConfig);
+        }));
+        afterEach(inject(function(accordionConfig) {
+          // return it to the original value
+          accordionConfig.closeOthers = originalCloseOthers;
+          dump(accordionConfig);
+        }));
+
+        it('should not close other groups if accordionConfig.closeOthers is false', function() {
+          ctrl.closeOthers(group2);
+          expect(group1.isOpen).toBe(true);
+          expect(group2.isOpen).toBe(true);
+          expect(group3.isOpen).toBe(true);
+        });
       });
     });
 


### PR DESCRIPTION
Here is a first commit. Anyone like to comment before I start on the other directives?

In the case of the accordion there is only one item that can be configured at this stage and so I have kind of hard coded it into the directive.

It occurred to me that often we would have a common pattern of watching the attributes and the config and then merging them when they change.  It seems a good idea to factor out this pattern into a service of it own - maybe $config.  What do you think?
