### PR TITLE
fix(pagination): max-size should not change based on the number of pages

### DIFF
--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -15,13 +15,9 @@ angular.module('ui.bootstrap.pagination', [])
       scope.$watch('numPages + currentPage + maxSize', function() {
         scope.pages = [];
         
-        if(angular.isDefined(scope.maxSize) && scope.maxSize > scope.numPages) {
-            scope.maxSize = scope.numPages;
-        }
-
         //set the default maxSize to numPages
-        var maxSize = scope.maxSize ? scope.maxSize : scope.numPages;
-        var startPage = scope.currentPage - Math.floor(maxSize/2);        
+        var maxSize = ( scope.maxSize && scope.maxSize < scope.numPages ) ? scope.maxSize : scope.numPages;
+        var startPage = scope.currentPage - Math.floor(maxSize/2);
         
         //adjust the startPage within boundary
         if(startPage < 1) {

--- a/src/pagination/test/pagination.spec.js
+++ b/src/pagination/test/pagination.spec.js
@@ -182,7 +182,12 @@ describe('pagination directive with max size option', function () {
     $rootScope.maxSize = 15;
     $rootScope.$digest();
     expect(element.find('li').length).toBe(12);
-    expect($rootScope.maxSize).toBe(10);
+  });
+
+  it('should not change value of max-size expression, if max-size is greater than num-pages ', function() {
+    $rootScope.maxSize = 15;
+    $rootScope.$digest();
+    expect($rootScope.maxSize).toBe(15);
   });
 
 });  


### PR DESCRIPTION
If number of pages is less than the max-size then only the number of pages that are available should be displayed, but this should not then update the max-size expression, since if the number of pages then increases we have lost the max-size value that the user set.
