### PR TITLE
Update src/alert/alert.js

### DIFF
--- a/src/alert/alert.js
+++ b/src/alert/alert.js
@@ -8,7 +8,7 @@ angular.module("ui.bootstrap.alert", []).directive('alert', function () {
       close:'&'
     },
     link:function (scope, element, attrs) {
-      scope.type = scope.type || 'info';
+      scope.type = scope.type || 'default';
       scope.dismiss = function () {
         scope.close();
       };


### PR DESCRIPTION
`alert` directive should not default to `alert-info`. Instead,
allow the absence of an explicit alert type to use the default
(yellow) bootstrap background color. I'm using `default` here,
which causes the CSS class `alert-default` to be applied, which
does not exist. Perhaps `unspecified` or `unknown` would be better.
Or we could rewrite `template/alert/alert.html` and `src/alert/alert.js`
so no style is applied when the type is unspecified.
