### PR TITLE
Fix off-by-one error in accordion demo item list

### DIFF
--- a/src/accordion/docs/demo.js
+++ b/src/accordion/docs/demo.js
@@ -15,6 +15,7 @@ function AccordionDemoCtrl($scope) {
   $scope.items = ['Item 1', 'Item 2', 'Item 3'];
 
   $scope.addItem = function() {
-    $scope.items.push('Item ' + $scope.items.length);
+    var newItemNo = $scope.items.length + 1;
+    $scope.items.push('Item ' + newItemNo);
   };
 }


### PR DESCRIPTION
Add 1 to items.length before pushing, otherwise we get two items with the same item number.
