### PR TITLE
feat(typeahead): add the typeahead directive

### DIFF
--- a/src/typeahead/docs/demo.html
+++ b/src/typeahead/docs/demo.html
@@ -1,0 +1,4 @@
+<div class='container-fluid' ng-controller="TypeaheadCtrl">
+    <pre>Model: {{selected| json}}</pre>
+    <input type="text" ng-model="selected" typeahead-source="states" typeahead-items="10">
+</div>

--- a/src/typeahead/docs/demo.js
+++ b/src/typeahead/docs/demo.js
@@ -1,0 +1,5 @@
+function TypeaheadCtrl($scope) {
+
+  $scope.selected = undefined;
+  $scope.states = ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'];
+}

--- a/src/typeahead/docs/readme.md
+++ b/src/typeahead/docs/readme.md
@@ -1,0 +1,6 @@
+Typeahead is a AngularJS version of [Twitter Bootstrap typeahead plugin](http://twitter.github.com/bootstrap/javascript.html#typeahead)
+
+This directive can be used to quickly create elegant typeheads with any form text input.
+
+The version from this repository supports all of the original configuration parameters and additionally is well integrated with the AngularJS support for promises (`$q`).
+The source function can return a promise and the typeahead will be filled in upon promise resolution.

--- a/src/typeahead/readme.md
+++ b/src/typeahead/readme.md
@@ -1,0 +1,11 @@
+Supported configuration options:
+
+* `typeaheadSource` - source of data - can be either an array or a function. If it is a function it will be called with one argument - input provided by a user
+* `typeaheadItems` - maximum number of matches displayed - defaults to `4`
+* `typeaheadMinLength` - minimal number of characters to be provided before matches are displayed. Defaults to `1`
+* `typeaheadOrder` - custom ordering function. If not provided matches won't be sorted
+* `typeaheadMatcher` - custom matching function. Of provided it will be called with 2 arguments: source of matches and value entered by a user
+* `typeaheadUpdater` - a transformation function that can be used to pre-process selected item before it is provided as a selected value
+* `typeaheadHighlighter` - a custom function to control matches rendering and higlighting
+
+All of the above options are very similar to the original ones.

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -1,0 +1,208 @@
+ddescribe('typeahead', function () {
+
+  var $scope, $compile, $sniffer;
+  var changeInputValueTo;
+
+  beforeEach(module('ui.bootstrap.typeahead'));
+  beforeEach(module('template/typeahead/typeahead.html'));
+  beforeEach(inject(function(_$rootScope_, _$compile_, $sniffer) {
+    $scope = _$rootScope_;
+    $scope.source = ['foo', 'bar', 'baz'];
+    $compile = _$compile_;
+
+    changeInputValueTo = function(element, value) {
+      var inputEl = findInput(element);
+      inputEl.val(value);
+      inputEl.trigger( $sniffer.hasEvent('input') ? 'input' : 'change');
+      $scope.$digest();
+    };
+  }));
+
+  //utility functions
+  var prepareInputEl = function(inputTpl) {
+    var el = $compile(angular.element(inputTpl))($scope);
+    $scope.$digest();
+    return el;
+  };
+
+  var findInput = function(element) {
+    return element.find('input');
+  };
+
+  var findDropDown = function(element) {
+    return element.find('div.dropdown');
+  };
+
+  var findMatches = function(element) {
+    return findDropDown(element).find('li');
+  };
+
+  var triggerKeyDown = function(element, keyCode) {
+    var inputEl = findInput(element);
+    var e = $.Event("keydown");
+    e.which = keyCode;
+    inputEl.trigger(e);
+  };
+
+  //custom matchers
+  beforeEach(function () {
+    this.addMatchers({
+      toBeClosed: function() {
+        var typeaheadEl = findDropDown(this.actual);
+        this.message = function() {
+          return "Expected '" + angular.mock.dump(this.actual) + "' to be closed.";
+        };
+        return !typeaheadEl.hasClass('open') && findMatches(this.actual).length === 0;
+
+      }, toBeOpenWithActive: function(noOfMatches, activeIdx) {
+
+        var typeaheadEl = findDropDown(this.actual);
+        var liEls = findMatches(this.actual);
+
+        this.message = function() {
+          return "Expected '" + angular.mock.dump(this.actual) + "' to be opened.";
+        };
+        return typeaheadEl.hasClass('open') && liEls.length === noOfMatches && $(liEls[activeIdx]).hasClass('active');
+      }
+    });
+  });
+
+  //coarse grained, "integration" tests
+
+  describe('initial state and model changes', function () {
+
+    it('should be closed by default', function () {
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source'></div>");
+      expect(element).toBeClosed();
+    });
+
+    it('should not get open on model change', function () {
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source'></div>");
+      $scope.$apply(function(){
+        $scope.result = 'foo';
+      });
+      expect(element).toBeClosed();
+    });
+  });
+
+  describe('basic functionality', function () {
+
+    it('should open and close typeahead based on matches', function () {
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source'></div>");
+      changeInputValueTo(element, 'ba');
+      expect(element).toBeOpenWithActive(2, 0);
+    });
+
+    it('should not open typeahead if input value smaller than a defined threshold', function () {
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source' typeahead-min-length='2'></div>");
+      changeInputValueTo(element, 'b');
+      expect(element).toBeClosed();
+    });
+
+    it('should support the typeahead-max-items attribute', function () {
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source' typeahead-items='1'></div>");
+      changeInputValueTo(element, 'b');
+      expect(element).toBeOpenWithActive(1, 0);
+    });
+
+    it('should support the typeahead-order attribute', function () {
+
+      $scope.orderFn = function(match) {
+        return match === 'baz' ? 0 : 1;
+      };
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source' typeahead-order='orderFn'></div>");
+      changeInputValueTo(element, 'b');
+      triggerKeyDown(element, 13);
+      expect($scope.result).toEqual('baz');
+    });
+
+    it('should support custom filtering functions', function () {
+      $scope.matcherFn = function(sourceItem, queryStr) {
+        return sourceItem == 'foo';
+      };
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source' typeahead-matcher='matcherFn'></div>");
+      changeInputValueTo(element, 'b');
+      triggerKeyDown(element, 13);
+      expect($scope.result).toEqual('foo');
+    });
+
+    it('should support custom model selecting function', function () {
+      $scope.updaterFn = function(selectedItem) {
+        return 'prefix' + selectedItem;
+      };
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source' typeahead-updater='updaterFn'></div>");
+      changeInputValueTo(element, 'f');
+      triggerKeyDown(element, 13);
+      expect($scope.result).toEqual('prefixfoo');
+    });
+
+    it('should highlight matches by default', function () {
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source'></div>");
+      changeInputValueTo(element, 'fo');
+
+      var matchHighlight = findMatches(element).find('a').html();
+      expect(matchHighlight).toEqual('<strong>fo</strong>o');
+    });
+
+    it('should support custom model rendering function', function () {
+      $scope.highlighterFn = function(sourceItem) {
+        return 'prefix' + sourceItem;
+      };
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source' typeahead-highlighter='highlighterFn'></div>");
+      changeInputValueTo(element, 'fo');
+      var matchHighlight = findMatches(element).find('a').html();
+      expect(matchHighlight).toEqual('prefixfoo');
+    });
+  });
+
+  describe('selecting a match', function () {
+
+    it('should select a match on enter', function () {
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source'></div>");
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'b');
+      triggerKeyDown(element, 13);
+
+      expect($scope.result).toEqual('bar');
+      expect(inputEl.val()).toEqual('bar');
+    });
+
+    it('should select a match on tab', function () {
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source'></div>");
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'b');
+      triggerKeyDown(element, 9);
+
+      expect($scope.result).toEqual('bar');
+      expect(inputEl.val()).toEqual('bar');
+    });
+
+    it('should select match on click', function () {
+
+      var element = prepareInputEl("<div><input ng-model='result' typeahead-source='source'></div>");
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'b');
+      var match = $(findMatches(element)[1]).find('a')[0];
+
+      $(match).click();
+      $scope.$digest();
+
+      expect($scope.result).toEqual('baz');
+      expect(inputEl.val()).toEqual('baz');
+    });
+  });
+
+});

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -1,0 +1,205 @@
+angular.module('ui.bootstrap.typeahead', [])
+
+  .directive('typeaheadSource', ['$compile', '$filter', '$q', function ($compile, $filter, $q) {
+
+  var hotKeys = [9, 13, 27, 38, 40];
+
+  var defaultFilterFn = function(sourceItems, query) {
+    return $filter('filter')(sourceItems, query);
+  };
+
+  var defaultUpdaterFn = function(sourceItem) {
+    return sourceItem;
+  };
+
+  var customFilterFnFactory = function (filterItemFn) {
+    return function (sourceItems, query) {
+      var result = [];
+      angular.forEach(sourceItems, function (sourceItem) {
+        if (filterItemFn(sourceItem, query)) {
+          result.push(sourceItem);
+        }
+      });
+      return result;
+    };
+  };
+
+  var checkAndConvertSource = function(sourceCandidate) {
+    var source = sourceCandidate;
+    if (angular.isArray(sourceCandidate)) {
+      source = function(inputValue) {
+        return sourceCandidate;
+      };
+    }
+    if(!angular.isFunction(source)) {
+      throw "Source for typeahead must be either an array or a function";
+    }
+    return source;
+  };
+
+  return {
+    require:'ngModel',
+    link:function (originalScope, element, attrs, modelCtrl) {
+
+      //create a child scope for the typeahead directive so we are not polluting original scope
+      //with typeahead-specific data (matches, query etc.)
+      var scope = originalScope.$new();
+      originalScope.$on('$destroy', function(){
+        scope.$destroy();
+      });
+
+      //source of data - can be either an array or a function
+      var source = checkAndConvertSource(scope.$eval(attrs.typeaheadSource));
+
+      //max no of items dispalyed in typeahead dropdown
+      var maxItems = scope.$eval(attrs.typeaheadItems) || 4;
+
+      //minimal no of characters that needs to be entered before typeahead kicks-in
+      var minSearch = scope.$eval(attrs.typeaheadMinLength) || 1;
+
+      //expression to be used for matches rendering - expression must be one supported by the orderBy filter
+      var orderExp = scope.$eval(attrs.typeaheadOrder);
+
+      //filtering logic
+      var filterItemFn = scope.$eval(attrs.typeaheadMatcher);
+      var filterFn = angular.isFunction(filterItemFn) ? customFilterFnFactory(filterItemFn): defaultFilterFn;
+
+      //custom model updating logic
+      var updaterFn = scope.$eval(attrs.typeaheadUpdater) || defaultUpdaterFn;
+
+      var resetMatches = function() {
+        scope.matches = [];
+        scope.activeIdx = -1;
+      };
+
+      // was an item selected by a user?
+      var selected = false;
+
+      var getMatchesAsync = function(inputValue) {
+
+        $q.when(source(inputValue)).then(function(matches) {
+          //it might happen that several async queries were in progress if a user were typing fast
+          //but we are interested only in responses that correspond to the current view value
+          if (inputValue === modelCtrl.$viewValue){
+            var filteredMatches = $filter('limitTo')(filterFn(matches, inputValue), maxItems) || [];
+            if (filteredMatches.length > 0) {
+              scope.matches = filteredMatches;
+              if (orderExp) {
+                scope.matches = $filter('orderBy')(scope.matches, orderExp);
+              }
+              scope.activeIdx = 0;
+            } else {
+              resetMatches();
+            }
+          }
+        }, resetMatches);
+      };
+
+      resetMatches();
+
+      scope.highlighter = scope.$eval(attrs.typeaheadHighlighter);
+      //we need to propagate user's query so we can higlight matches
+      scope.query = undefined;
+
+      //plug into $parsers pipeline to open a typeahead on view changes initiated from DOM
+      modelCtrl.$parsers.push(function (inputValue) {
+
+        scope.activeIdx = -1;
+        if (inputValue && inputValue.length >= minSearch) {
+
+          if (!selected) {
+            scope.query = inputValue;
+            getMatchesAsync(inputValue);
+          } else {
+            scope.matches = [];
+            selected = false;
+          }
+
+        } else {
+          scope.matches = [];
+        }
+
+        return inputValue;
+      });
+
+      scope.select = function (activeIdx) {
+        //called from within the $digest() cycle
+        selected = true;
+        modelCtrl.$setViewValue(updaterFn(scope.matches[activeIdx]));
+        modelCtrl.$render();
+      };
+
+      //bind keyboard events: arrows up(38) / down(40), enter(13) and tab(9), esc(9)
+      element.bind('keydown', function (evt) {
+
+        //typeahead is open and an "interesting" key was pressed
+        if (scope.matches.length === 0 || hotKeys.indexOf(evt.which) === -1) {
+          return;
+        }
+
+        evt.preventDefault();
+
+        if (evt.which === 40) {
+          scope.activeIdx = (scope.activeIdx + 1) % scope.matches.length;
+          scope.$digest();
+
+        } else if (evt.which === 38) {
+          scope.activeIdx = (scope.activeIdx ? scope.activeIdx : scope.matches.length) - 1;
+          scope.$digest();
+
+        } else if (evt.which === 13 || evt.which === 9) {
+          scope.$apply(function () {
+            scope.select(scope.activeIdx);
+          });
+
+        } else if (evt.which === 27) {
+          scope.matches = [];
+          scope.$digest();
+        }
+      });
+
+      var tplElCompiled = $compile("<typeahead-popup matches='matches' active='activeIdx' select='select(activeIdx)' "+
+      "highlighter='highlighter' query='query'></typeahead-popup>")(scope);
+      element.after(tplElCompiled);
+    }
+  };
+}])
+
+  .directive('typeaheadPopup', function () {
+
+    var defaultHighlighter = function(matchItem, query) {
+      return (query) ? matchItem.replace(new RegExp(query, 'gi'), '<strong>$&</strong>') : query;
+    };
+
+    return {
+      restrict:'E',
+      scope:{
+        matches:'=',
+        query:'=',
+        active:'=',
+        select:'&'
+      },
+      replace:true,
+      templateUrl:'template/typeahead/typeahead.html',
+      link:function (scope, element, attrs) {
+
+        scope.isOpen = function () {
+          return scope.matches.length > 0;
+        };
+
+        scope.isActive = function (matchIdx) {
+          return scope.active == matchIdx;
+        };
+
+        scope.selectActive = function (matchIdx) {
+          scope.active = matchIdx;
+        };
+
+        scope.selectMatch = function (activeIdx) {
+          scope.select({activeIdx:activeIdx});
+        };
+
+        scope.highlighter = scope.$parent.$eval(attrs.highlighter) || defaultHighlighter;
+      }
+    };
+  });

--- a/template/typeahead/typeahead.html
+++ b/template/typeahead/typeahead.html
@@ -1,0 +1,7 @@
+<div class="dropdown clearfix" ng-class="{open: isOpen()}">
+    <ul class="typeahead dropdown-menu">
+        <li ng-repeat="value in matches" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)">
+            <a tabindex="-1" ng-click="selectMatch($index)" ng-bind-html-unsafe="highlighter(value, query)"></a>
+        </li>
+    </ul>
+</div>


### PR DESCRIPTION
After a lengthy discussion in https://github.com/angular-ui/bootstrap/issues/114 and several options for the syntax here is the finished PR for the typeahead directive.

The current version uses the same interface as the original one which works but feels very non-AngularJS. I was toying with different ideas but the only other thing that kind of made sense was string=based syntax similar to the one used by the `select` directive. The problem with this is that select's syntax is not very intuitive either.

The other issue is that atm I'm using unsafe binding of HTML (to support matches highlighting). This is definitively not something I would like to do but for me this is one more evidence that we need `ngSanitize`

Anyway, the current version supports _all_ the bootstrap's options so if anyone has an idea of a better syntax we can (easily?) change things. It also has integration with `$q` so functions going for matchers can be async!
