### PR TITLE
chore(build): add changelog task for grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -287,6 +287,55 @@ module.exports = function(grunt) {
     var options = ['--no-single-run', '--auto-watch'].concat(this.args);
     runTestacular('start', options);
   });
+
+  //changelog generation
+  grunt.registerTask('changelog', 'generates changelog markdown from git commits', function () {
+
+    var changeFrom = this.args[0], changeTo = this.args[1] || 'HEAD';
+
+    var done = grunt.task.current.async();
+    var child = grunt.util.spawn({
+      cmd:process.platform === 'win32' ? 'git.cmd' : 'git',
+      args:['log', changeFrom + '..' + changeTo, '--oneline']
+    }, function (err, result, code) {
+
+      var changelog = {
+        chore: {}, demo: {}, docs: {}, feat: {}, fix: {}, refactor: {}, style: {}, test: {}
+      };
+
+      var COMMIT_MSG_REGEXP = /^(chore|demo|docs|feat|fix|refactor|style|test)\((.+)\):? (.+)$/;
+      var gitlog = ('' + result).split('\n').reverse();
+
+      if (code) {
+        console.log(err);
+        done(false);
+      } else {
+
+        gitlog.forEach(function (logItem) {
+          var sha1 = logItem.slice(0, 7);
+          var fullMsg = logItem.slice(8);
+
+          var msgMatches = fullMsg.match(COMMIT_MSG_REGEXP);
+          var changeType = msgMatches[1];
+          var directive = msgMatches[2];
+          var directiveMsg = msgMatches[3];
+
+          if (!changelog[changeType][directive]) {
+            changelog[changeType][directive] = [];
+          }
+          changelog[changeType][directive].push({sha1:sha1, msg:directiveMsg});
+        });
+
+        console.log(grunt.template.process(grunt.file.read('misc/changelog.tpl.md'), {data: {
+          changelog: changelog,
+          today: grunt.template.today('yyyy-mm-dd'),
+          version : grunt.config('pkg.version')
+        }}));
+
+        done();
+      }
+    });
+  });
   
   return grunt;
 };

--- a/misc/changelog.tpl.md
+++ b/misc/changelog.tpl.md
@@ -1,0 +1,12 @@
+# <%= version%> (<%= today%>)
+
+## Features
+
+<% _(changelog.feat).forEach(function(changes, directive) { %>- **<%= directive%>:**
+<% changes.forEach(function(change) { %>  - <%= change.msg%> ([<%= change.sha1%>](https://github.com/angular-ui/bootstrap/commit/<%= change.sha1%>))
+<% }) %><% }) %>
+## Bug fixes
+
+<% _(changelog.fix).forEach(function(changes, directive) { %>- **<%= directive%>:**
+<% changes.forEach(function(change) { %>  - <%= change.msg%> ([<%= change.sha1%>](https://github.com/angular-ui/bootstrap/commit/<%= change.sha1%>))
+<% }) %><% }) %>


### PR DESCRIPTION
Added a very first, simple version of a Grunt tasks to generate changelog from git commits. More or less used it to generate the current changelog: 
https://github.com/angular-ui/bootstrap/blob/master/CHANGELOG.md

It is not pretty, the task could be made simpler but wanted to push it so others can have a look and improve!
