### PR TITLE
attempt to fix the backdrop fading issue w/ multiple dialog

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -173,7 +173,7 @@ dialogModule.provider("$dialog", function(){
       if(this.options.dialogFade){
         elements.push(this.modalEl);
       }
-      if(this.options.backdropFade){
+      if(this.options.backdropFade && activeBackdrops.value === 1 ){
         elements.push(this.backdropEl);
       }
 


### PR DESCRIPTION
When there are two or more backdrops with backdropFade = true, backdrop would be 'fade' when one of the dialog closes.
