### PR TITLE
feat(pagination/pager): add pager directive & more config options

### DIFF
--- a/src/pagination/docs/demo.html
+++ b/src/pagination/docs/demo.html
@@ -1,16 +1,15 @@
-<div ng-controller="PaginationDemoCtrl">
-    <div class="well">
-        <pagination num-pages="noOfPages" current-page="currentPage"></pagination>
-        <pagination num-pages="noOfPages" current-page="currentPage" class="pagination-small" previous-text="&laquo;" next-text="&raquo;"></pagination>
-        <pagination boundary-links="true" num-pages="noOfPages" current-page="currentPage" max-size="maxSize"></pagination>
-        <pagination direction-links="false" boundary-links="true" num-pages="noOfPages" current-page="currentPage"  max-size="maxSize"></pagination>
-        <pagination direction-links="false" num-pages="noOfPages" current-page="currentPage"></pagination>
-        <button class="btn" ng-click="setPage(3)">Set current page to: 3</button>
-        The selected page no: {{currentPage}}
-    </div>
+<div ng-controller="PaginationDemoCtrl" class="well well-small">
+    <h4>Default</h4>
+    <pagination num-pages="noOfPages" current-page="currentPage"></pagination>
+    <pagination boundary-links="true" num-pages="noOfPages" current-page="currentPage" class="pagination-small" previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></pagination>
+    <pagination direction-links="false" num-pages="noOfPages" current-page="currentPage"></pagination>
 
-    <div class="well">
-        <pagination num-pages="bigNoOfPages" current-page="bigCurrentPage"  max-size="10" grouped-max-mode="true" class="pagination-mini" previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;" boundary-links="true"></pagination>
-        Selected: {{bigCurrentPage}} of {{bigNoOfPages}}
-    </div>
+    <pager align="true" num-pages="noOfPages" current-page="currentPage"></pager>
+
+    <button class="btn" ng-click="setPage(3)">Set current page to: 3</button>
+    The selected page no: {{currentPage}}
+
+    <h4>Max-size</h4>
+    <pagination num-pages="bigNoOfPages" current-page="bigCurrentPage" max-size="maxSize" class="pagination-mini" boundary-links="true"></pagination>
+    <pagination rotate="false" num-pages="bigNoOfPages" current-page="bigCurrentPage" max-size="maxSize" class="pagination-mini" boundary-links="true"></pagination>
 </div>

--- a/src/pagination/docs/demo.js
+++ b/src/pagination/docs/demo.js
@@ -1,12 +1,12 @@
 var PaginationDemoCtrl = function ($scope) {
   $scope.noOfPages = 7;
   $scope.currentPage = 4;
+
+  $scope.bigNoOfPages = 18;
+  $scope.bigCurrentPage = 1;
   $scope.maxSize = 5;
 
   $scope.setPage = function (pageNo) {
     $scope.currentPage = pageNo;
   };
-
-  $scope.bigNoOfPages = 53;
-  $scope.bigCurrentPage = 17;
 };

--- a/src/pagination/docs/readme.md
+++ b/src/pagination/docs/readme.md
@@ -1,6 +1,7 @@
-A lightweight pagination directive that is focused on ... providing pagination!
+A lightweight & flexible pagination directive that is focused on ... providing pagination!
 
 It will take care of visualising a pagination bar. Additionally it will make sure that the state (enabled / disabled) of the Previous / Next and First / Last buttons (if exist) is maintained correctly.
 
-It also provides optional attribute max-size to limit the size of pagination bar.
-It also provides optional boolean attribute grouped-max-size for easier navigation in big data sets.
+It also provides optional attributes max-size and rotate to limit the size of pagination bar and whether to keep current page in the middle of the visible ones.
+
+There is also a pager directive with just previous and next links for simple pagination implementations.

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -7,9 +7,181 @@ angular.module('ui.bootstrap.pagination', [])
   previousText: 'Previous',
   nextText: 'Next',
   lastText: 'Last',
-  groupedMaxMode: false,
-  ellipsisText: '...'
+  rotate: true, // Whether to keep current page in the middle of visible ones
+  ellipsisText: '...',
+  showSingle: true
 })
+
+.controller('PaginationController', ['$scope', '$attrs', function ($scope, $attrs) {
+
+  var self = this;
+
+  this.build = function(type, config) {
+    $scope.options = getOptions(config);
+
+    switch (type) {
+      case 'pagination':
+        $scope.$watch('numPages + currentPage + maxSize', function() {
+          $scope.pages = [];
+
+          addNumberLinks();
+          addEllipsisLinks();
+          addDirectionLinks();
+          addBoundaryLinks();
+
+          limitCurrentPage();
+        });
+        break;
+
+      case 'pager':
+        $scope.$watch('numPages + currentPage', function() {
+          limitCurrentPage();
+        });
+        break;
+
+      default:
+        throw new Error('Unknown pagination type.');
+    }
+  };
+
+  // Adjust current page within boundary
+  function limitCurrentPage() {
+    if ( $scope.currentPage > $scope.numPages ) {
+      $scope.selectPage($scope.numPages);
+    }
+  }
+
+  // Get configuration parameters from attributes & global config
+  function getOptions(config) {
+    var options = {};
+    angular.forEach(config, function(value, key) {
+      if (angular.isDefined($attrs[key])) {
+        options[key] = (angular.isString(value)) ? $attrs[key] : $scope.$eval($attrs[key]);
+      } else {
+        options[key] = value;
+      }
+    });
+    return options;
+  }
+
+  // Create page object used in template
+  function makePage(number, text, isActive, isDisabled) {
+    return {
+      number: number,
+      text: text,
+      active: isActive,
+      disabled: isDisabled
+    };
+  }
+
+  // Add page number links
+  function addNumberLinks() {
+    angular.extend(self, getPageNumberLimits());
+
+    for (var number = self.startNumber; number <= self.lastNumber; number++) {
+      $scope.pages.push(makePage(number, number, $scope.isActive(number), false));
+    }
+  }
+
+  // Add previous & next links
+  function addDirectionLinks() {
+    if ( $scope.options.directionLinks ) {
+      var previousPage = makePage($scope.currentPage - 1, $scope.options.previousText, false, $scope.noPrevious());
+      $scope.pages.unshift(previousPage);
+
+      var nextPage = makePage($scope.currentPage + 1, $scope.options.nextText, false, $scope.noNext());
+      $scope.pages.push(nextPage);
+    }
+  }
+
+  // Add first & last links
+  function addBoundaryLinks() {
+    if ( $scope.options.boundaryLinks ) {
+      var firstPage = makePage(1, $scope.options.firstText, false, $scope.noPrevious());
+      $scope.pages.unshift(firstPage);
+
+      var lastPage = makePage($scope.numPages, $scope.options.lastText, false, $scope.noNext());
+      $scope.pages.push(lastPage);
+    }
+  }
+
+  // Add ellipsis link to move to next page set
+  function addEllipsisLinks() {
+    if ( ! $scope.options.rotate ) {
+      if (self.startNumber > 1) {
+        var previousEllipsis = makePage(self.startNumber - 1, $scope.options.ellipsisText, false, false);
+        $scope.pages.unshift(previousEllipsis);
+      }
+
+      if (self.lastNumber < $scope.numPages - 1) {
+        var nextEllipsis = makePage(self.lastNumber + 1, $scope.options.ellipsisText, false, false);
+        $scope.pages.push(nextEllipsis);
+      }
+    }
+  }
+
+  // Compute start & last visible page numbers
+  function getPageNumberLimits() {
+    var startNumber, lastNumber;
+
+    if ( $scope.maxSize && $scope.maxSize < $scope.numPages ) { 
+      if ( $scope.options.rotate ) {
+        // Current page is displayed in the middle of the visible ones
+        startNumber = $scope.currentPage - Math.floor( $scope.maxSize / 2 );
+
+        //adjust the startPage within boundary
+        if(startNumber < 1) {
+            startNumber = 1;
+        }
+
+        lastNumber = startNumber + $scope.maxSize - 1;
+
+        // Adjust start page if limit is exceeded
+        if (lastNumber > $scope.numPages) {
+            startNumber = $scope.numPages - $scope.maxSize + 1;
+            lastNumber = $scope.numPages;
+        }
+      } else {
+        // Visible pages are paginated with maxSize
+        startNumber = ((Math.ceil($scope.currentPage / $scope.maxSize) - 1) * $scope.maxSize) + 1;
+
+        // Adjust last page if limit is exceeded
+        lastNumber = Math.min(startNumber + $scope.maxSize - 1, $scope.numPages);
+      }
+    } else {
+      // Display all pages
+      startNumber = 1;
+      lastNumber  = $scope.numPages;
+    }
+
+    return { startNumber: startNumber, lastNumber: lastNumber };
+  }
+
+  $scope.noPrevious = function() {
+    return $scope.currentPage === 1;
+  };
+  $scope.noNext = function() {
+    return $scope.currentPage === $scope.numPages;
+  };
+
+  $scope.isActive = function(page) {
+    return $scope.currentPage === page;
+  };
+
+  // Called from template
+  $scope.selectPage = function(page) {
+    if ( ! $scope.isActive(page) && page > 0 && page <= $scope.numPages) {
+      $scope.currentPage = page;
+      $scope.onSelectPage({ page: page });
+    }
+  };
+
+  // Whether to display pagination list on single page
+  $scope.show = function() {
+    return ( $scope.numPages > 1 || $scope.options.showSingle );
+  };
+
+}])
 
 .directive('pagination', ['paginationConfig', function(paginationConfig) {
   return {
@@ -20,128 +192,35 @@ angular.module('ui.bootstrap.pagination', [])
       maxSize: '=',
       onSelectPage: '&'
     },
+    controller: 'PaginationController',
     templateUrl: 'template/pagination/pagination.html',
     replace: true,
-    link: function(scope, element, attrs) {
+    link: function(scope, element, attrs, paginationCtrl) {
+      paginationCtrl.build('pagination', paginationConfig);
+    }
+  };
+}])
 
-      // Setup configuration parameters
-      var boundaryLinks = angular.isDefined(attrs.boundaryLinks) ? scope.$eval(attrs.boundaryLinks) : paginationConfig.boundaryLinks;
-      var directionLinks = angular.isDefined(attrs.directionLinks) ? scope.$eval(attrs.directionLinks) : paginationConfig.directionLinks;
-      var firstText = angular.isDefined(attrs.firstText) ? attrs.firstText : paginationConfig.firstText;
-      var previousText = angular.isDefined(attrs.previousText) ? attrs.previousText : paginationConfig.previousText;
-      var nextText = angular.isDefined(attrs.nextText) ? attrs.nextText : paginationConfig.nextText;
-      var lastText = angular.isDefined(attrs.lastText) ? attrs.lastText : paginationConfig.lastText;
-      var groupedMaxMode = angular.isDefined(attrs.groupedMaxMode) ? scope.$eval(attrs.groupedMaxMode) : paginationConfig.groupedMaxMode;
-      var ellipsisText = angular.isDefined(attrs.ellipsisText) ? attrs.ellipsisText : paginationConfig.ellipsisText;
+.constant('pagerConfig', {
+  previousText: 'Previous',
+  nextText: 'Next',
+  align: false,
+  showSingle: false
+})
 
-      // Create page object used in template
-      function makePage(number, text, isActive, isDisabled) {
-        return {
-          number: number,
-          text: text,
-          active: isActive,
-          disabled: isDisabled
-        };
-      }
-
-      // Compute start & last page based on maxMode
-      function getMaxLimits(current, size, numPages) {
-        var start;
-
-        if ( groupedMaxMode ) {
-          // Visible pages are paginated with maxSize
-          start = ((Math.ceil(current / size) - 1) * size) + 1;
-
-          // Adjust maxSize if limit is exceeded
-          if ((start + size - 1) > numPages) {
-            size = numPages - start + 1;
-          }
-        } else {
-          // Current page is displayed in the middle of the visible ones
-          start = current - Math.floor(size/2);
-
-          //adjust the startPage within boundary
-          if(start < 1) {
-              start = 1;
-          }
-          // Adjust start page if limit is exceeded
-          if ((start + size - 1) > numPages) {
-              start = numPages - size + 1;
-          }
-        }
-
-        return {
-          start: start,
-          size: size
-        };
-      }
-
-      scope.$watch('numPages + currentPage + maxSize', function() {
-        scope.pages = [];
-        
-        //set the default maxSize to numPages
-        var maxSize, startPage;
-
-        if ( scope.maxSize && scope.maxSize < scope.numPages ) {
-          var limits = getMaxLimits(scope.currentPage, scope.maxSize, scope.numPages);
-
-          maxSize = limits.size;
-          startPage = limits.start;
-        } else {
-          // Display all pages
-          maxSize = scope.numPages;
-          startPage = 1;
-        }
-
-        // Add page number links
-        var maxPage = startPage + maxSize;
-        for (var number = startPage; number < maxPage; number++) {
-          scope.pages.push(makePage(number, number, scope.isActive(number), false));
-        }
-
-        // Add ellipsis links
-        if ( groupedMaxMode ) {
-          if (startPage > 1) {
-            scope.pages.unshift(makePage(startPage - 1, ellipsisText, false, false));
-          }
-          if (maxPage < scope.numPages) {
-            scope.pages.push(makePage(maxPage, ellipsisText, false, false));
-          }
-        }
-
-        // Add previous & next links
-        if (directionLinks) {
-          scope.pages.unshift(makePage(scope.currentPage - 1, previousText, false, scope.noPrevious()));
-          scope.pages.push(makePage(scope.currentPage + 1, nextText, false, scope.noNext()));
-        }
-
-        // Add first & last links
-        if (boundaryLinks) {
-          scope.pages.unshift(makePage(1, firstText, false, scope.noPrevious()));
-          scope.pages.push(makePage(scope.numPages, lastText, false, scope.noNext()));
-        }
-
-
-        if ( scope.currentPage > scope.numPages ) {
-          scope.selectPage(scope.numPages);
-        }
-      });
-      scope.noPrevious = function() {
-        return scope.currentPage === 1;
-      };
-      scope.noNext = function() {
-        return scope.currentPage === scope.numPages;
-      };
-      scope.isActive = function(page) {
-        return scope.currentPage === page;
-      };
-
-      scope.selectPage = function(page) {
-        if ( ! scope.isActive(page) && page > 0 && page <= scope.numPages) {
-          scope.currentPage = page;
-          scope.onSelectPage({ page: page });
-        }
-      };
+.directive('pager', ['pagerConfig', function(pagerConfig) {
+  return {
+    restrict: 'EA',
+    scope: {
+      numPages: '=',
+      currentPage: '=',
+      onSelectPage: '&'
+    },
+    controller: 'PaginationController',
+    templateUrl: 'template/pagination/pager.html',
+    replace: true,
+    link: function(scope, element, attrs, paginationCtrl) {
+      paginationCtrl.build('pager', pagerConfig);
     }
   };
 }]);

--- a/src/pagination/test/pager.spec.js
+++ b/src/pagination/test/pager.spec.js
@@ -1,0 +1,205 @@
+describe('pager directive with default configuration', function () {
+  var $rootScope, element;
+  beforeEach(module('ui.bootstrap.pagination'));
+  beforeEach(module('template/pagination/pager.html'));
+  beforeEach(inject(function(_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $rootScope.numPages = 5;
+    $rootScope.currentPage = 3;
+    element = $compile('<pager num-pages="numPages" current-page="currentPage"></pager>')($rootScope);
+    $rootScope.$digest();
+  }));
+
+  it('has a "pager" css class', function() {
+    expect(element.hasClass('pager')).toBe(true);
+  });
+
+  it('contains 2 li elements', function() {
+    expect(element.find('li').length).toBe(2);
+    expect(element.find('li').eq(0).text()).toBe('Previous');
+    expect(element.find('li').eq(-1).text()).toBe('Next');
+  });
+
+  it('aligns previous & next page', function() {
+    expect(element.find('li').eq(0).hasClass('previous')).toBe(false);
+    expect(element.find('li').eq(-1).hasClass('next')).toBe(false);
+  });
+
+  it('disables the "previous" link if current-page is 1', function() {
+    $rootScope.currentPage = 1;
+    $rootScope.$digest();
+    expect(element.find('li').eq(0).hasClass('disabled')).toBe(true);
+  });
+
+  it('disables the "next" link if current-page is num-pages', function() {
+    $rootScope.currentPage = 5;
+    $rootScope.$digest();
+    expect(element.find('li').eq(-1).hasClass('disabled')).toBe(true);
+  });
+
+  it('changes currentPage if the "previous" link is clicked', function() {
+    var previous = element.find('li').eq(0).find('a').eq(0);
+    previous.click();
+    $rootScope.$digest();
+    expect($rootScope.currentPage).toBe(2);
+  });
+
+  it('changes currentPage if the "next" link is clicked', function() {
+    var next = element.find('li').eq(-1).find('a').eq(0);
+    next.click();
+    $rootScope.$digest();
+    expect($rootScope.currentPage).toBe(4);
+  });
+
+  it('does not change the current page on "previous" click if already at first page', function() {
+    var previous = element.find('li').eq(0).find('a').eq(0);
+    $rootScope.currentPage = 1;
+    $rootScope.$digest();
+    previous.click();
+    $rootScope.$digest();
+    expect($rootScope.currentPage).toBe(1);
+  });
+
+  it('does not change the current page on "next" click if already at last page', function() {
+    var next = element.find('li').eq(-1).find('a').eq(0);
+    $rootScope.currentPage = 5;
+    $rootScope.$digest();
+    next.click();
+    $rootScope.$digest();
+    expect($rootScope.currentPage).toBe(5);
+  });
+
+  it('executes the onSelectPage expression when the current page changes', function() {
+    $rootScope.selectPageHandler = jasmine.createSpy('selectPageHandler');
+    element = $compile('<pager num-pages="numPages" current-page="currentPage" on-select-page="selectPageHandler(page)"></pager>')($rootScope);
+    $rootScope.$digest();
+    var next = element.find('li').eq(-1).find('a').eq(0);
+    next.click();
+    $rootScope.$digest();
+    expect($rootScope.selectPageHandler).toHaveBeenCalledWith(4);
+  });
+
+  it('does not changes the number of items when numPages changes', function() {
+    $rootScope.numPages = 8;
+    $rootScope.$digest();
+    expect(element.find('li').length).toBe(2);
+    expect(element.find('li').eq(0).text()).toBe('Previous');
+    expect(element.find('li').eq(-1).text()).toBe('Next');
+  });
+
+  it('sets the current page to the last page if the numPages is changed to less than the current page', function() {
+    $rootScope.selectPageHandler = jasmine.createSpy('selectPageHandler');
+    element = $compile('<pager num-pages="numPages" current-page="currentPage" on-select-page="selectPageHandler(page)"></pager>')($rootScope);
+    $rootScope.$digest();
+    $rootScope.numPages = 2;
+    $rootScope.$digest();
+    expect(element.find('li').length).toBe(2);
+    expect($rootScope.currentPage).toBe(2);
+    expect($rootScope.selectPageHandler).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('pager directive that auto-hides', function () {
+  var $rootScope, element;
+  beforeEach(module('ui.bootstrap.pagination'));
+  beforeEach(module('template/pagination/pager.html'));
+  beforeEach(inject(function(_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $rootScope.numPages = 5;
+    $rootScope.currentPage = 3;
+    element = $compile('<pager show-single="false" num-pages="numPages" current-page="currentPage"></pager>')($rootScope);
+    $rootScope.$digest();
+  }));
+
+  it('has visible element for more than one page', function() {
+    expect(element.css('display')).not.toBe('none');
+  });
+
+  it('hides when there is only one page', function() {
+    $rootScope.numPages = 1;
+    $rootScope.$digest();
+    expect(element.css('display')).toBe('none');
+  });
+});
+
+describe('setting pagerConfig', function() {
+  var $rootScope, element;
+  var originalConfig = {};
+  beforeEach(module('ui.bootstrap.pagination'));
+  beforeEach(module('template/pagination/pager.html'));
+  beforeEach(inject(function(_$compile_, _$rootScope_, pagerConfig) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $rootScope.numPages = 5;
+    $rootScope.currentPage = 3;
+    angular.extend(originalConfig, pagerConfig);
+    pagerConfig.previousText = 'PR';
+    pagerConfig.nextText = 'NE';
+    pagerConfig.align = true;
+    pagerConfig.showSingle = true;
+    element = $compile('<pager num-pages="numPages" current-page="currentPage"></pager>')($rootScope);
+    $rootScope.$digest();
+  }));
+  afterEach(inject(function(pagerConfig) {
+    // return it to the original state
+    angular.extend(pagerConfig, originalConfig);
+  }));
+
+  it('contains 2 li elements', function() {
+    expect(element.find('li').length).toBe(2);
+  });
+
+  it('should change paging text', function () {
+    expect(element.find('li').eq(0).text()).toBe('PR');
+    expect(element.find('li').eq(-1).text()).toBe('NE');
+  });
+
+  it('should not align previous & next page link', function () {
+    expect(element.find('li').eq(0).hasClass('previous')).toBe(true);
+    expect(element.find('li').eq(-1).hasClass('next')).toBe(true);
+  });
+
+  it('show element even if there is only one page', function() {
+    $rootScope.numPages = 1;
+    $rootScope.$digest();
+    expect(element.css('display')).not.toBe('none');
+  });
+
+});
+
+describe('pagination bypass configuration from attributes', function () {
+  var $rootScope, element;
+  beforeEach(module('ui.bootstrap.pagination'));
+  beforeEach(module('template/pagination/pager.html'));
+  beforeEach(inject(function(_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $rootScope.numPages = 5;
+    $rootScope.currentPage = 3;
+    element = $compile('<pager align="true" previous-text="<" next-text=">" show-single="true" num-pages="numPages" current-page="currentPage"></pager>')($rootScope);
+    $rootScope.$digest();
+  }));
+
+  it('contains 2 li elements', function() {
+    expect(element.find('li').length).toBe(2);
+  });
+
+  it('should change paging text from attributes', function () {
+    expect(element.find('li').eq(0).text()).toBe('<');
+    expect(element.find('li').eq(-1).text()).toBe('>');
+  });
+
+  it('should not align previous & next page link', function () {
+    expect(element.find('li').eq(0).hasClass('previous')).toBe(true);
+    expect(element.find('li').eq(-1).hasClass('next')).toBe(true);
+  });
+
+  it('show element even if there is only one page', function() {
+    $rootScope.numPages = 1;
+    $rootScope.$digest();
+    expect(element.css('display')).not.toBe('none');
+  });
+
+});

--- a/src/pagination/test/pagination.spec.js
+++ b/src/pagination/test/pagination.spec.js
@@ -192,7 +192,7 @@ describe('pagination directive with max size option', function () {
 
 });
 
-describe('pagination directive with max size option & grouped mode', function () {
+describe('pagination directive with max size option & no rotate', function () {
   var $rootScope, element;
   beforeEach(module('ui.bootstrap.pagination'));
   beforeEach(module('template/pagination/pagination.html'));
@@ -202,7 +202,7 @@ describe('pagination directive with max size option & grouped mode', function ()
     $rootScope.numPages = 14;
     $rootScope.currentPage = 7;
     $rootScope.maxSize = 5;
-    element = $compile('<pagination num-pages="numPages" current-page="currentPage" max-size="maxSize" grouped-max-mode="true" direction-links="false"></pagination>')($rootScope);
+    element = $compile('<pagination num-pages="numPages" current-page="currentPage" max-size="maxSize" rotate="false" direction-links="false"></pagination>')($rootScope);
     $rootScope.$digest();
   }));
 
@@ -231,7 +231,7 @@ describe('pagination directive with max size option & grouped mode', function ()
     expect(element.find('li').eq(-1).text()).toBe('14');
   });
 
-  it('moves to the previous group when first ellipsis is clicked', function() {
+  it('moves to the previous set when first ellipsis is clicked', function() {
     var prev = element.find('li').eq(0).find('a').eq(0);
     expect(prev.text()).toBe('...');
 
@@ -241,7 +241,7 @@ describe('pagination directive with max size option & grouped mode', function ()
     expect(currentPageItem.hasClass('active')).toBe(true);
   });
 
-  it('moves to the next group when last ellipsis is clicked', function() {
+  it('moves to the next set when last ellipsis is clicked', function() {
     var next = element.find('li').eq(-1).find('a').eq(0);
     expect(next.text()).toBe('...');
 
@@ -249,6 +249,16 @@ describe('pagination directive with max size option & grouped mode', function ()
     expect($rootScope.currentPage).toBe(11);
     var currentPageItem = element.find('li').eq(1);
     expect(currentPageItem.hasClass('active')).toBe(true);
+  });
+
+  it('ignores maxsize when in last set', function() {
+    $rootScope.currentPage = 12;
+    $rootScope.numPages = 13;
+    $rootScope.$digest();
+
+    expect(element.find('ul').length).toBe(1);
+    expect(element.find('li').length).not.toBe($rootScope.maxSize + 2);
+    expect(element.find('li').length).toBe(4);
   });
 });
 
@@ -264,7 +274,6 @@ describe('pagination directive with added first & last links', function () {
     element = $compile('<pagination boundary-links="true" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
     $rootScope.$digest();
   }));
-
 
   it('contains one ul and num-pages + 4 li elements', function() {
     expect(element.find('ul').length).toBe(1);
@@ -284,7 +293,6 @@ describe('pagination directive with added first & last links', function () {
     expect(lastLiEl.text()).toBe('Last');
     expect(lastLiEl.css('display')).not.toBe('none');
   });
-
 
   it('disables the "first" & "previous" link if current-page is 1', function() {
     $rootScope.currentPage = 1;
@@ -410,7 +418,6 @@ describe('pagination directive with just number links', function () {
     expect($rootScope.currentPage).toBe(2);
   });
 
-
   it('executes the onSelectPage expression when the current page changes', function() {
     $rootScope.selectPageHandler = jasmine.createSpy('selectPageHandler');
     element = $compile('<pagination direction-links="false" num-pages="numPages" current-page="currentPage" on-select-page="selectPageHandler(page)"></pagination>')($rootScope);
@@ -438,6 +445,34 @@ describe('pagination directive with just number links', function () {
     expect(element.find('li').length).toBe(2);
     expect($rootScope.currentPage).toBe(2);
     expect($rootScope.selectPageHandler).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('pagination directive that auto-hides for single page', function () {
+  var $rootScope, element;
+  beforeEach(module('ui.bootstrap.pagination'));
+  beforeEach(module('template/pagination/pagination.html'));
+  beforeEach(inject(function(_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $rootScope.numPages = 5;
+    $rootScope.currentPage = 3;
+    element = $compile('<pagination show-single="false" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
+    $rootScope.$digest();
+  }));
+
+
+  it('contains one ul and num-pages + 2 li elements', function() {
+    expect(element.find('ul').length).toBe(1);
+    expect(element.find('ul').css('display')).not.toBe('none');
+  });
+
+  it('has no element when there is only one page', function() {
+    $rootScope.numPages = 1;
+    $rootScope.$digest();
+
+    expect(element.find('ul').length).toBe(1);
+    expect(element.find('ul').css('display')).toBe('none');
   });
 });
 
@@ -494,7 +529,6 @@ describe('pagination directive with first, last & number links', function () {
     $rootScope.$digest();
   }));
 
-
   it('contains one ul and num-pages + 2 li elements', function() {
     expect(element.find('ul').length).toBe(1);
     expect(element.find('li').length).toBe(7);
@@ -503,7 +537,6 @@ describe('pagination directive with first, last & number links', function () {
     expect(element.find('li').eq(-2).text()).toBe(''+$rootScope.numPages);
     expect(element.find('li').eq(-1).text()).toBe('Last');
   });
-
 
   it('disables the "first" & activates "1" link if current-page is 1', function() {
     $rootScope.currentPage = 1;
@@ -521,7 +554,6 @@ describe('pagination directive with first, last & number links', function () {
     expect(element.find('li').eq(-1).hasClass('disabled')).toBe(true);
   });
 
-
   it('changes currentPage if the "first" link is clicked', function() {
     var first = element.find('li').eq(0).find('a').eq(0);
     first.click();
@@ -535,7 +567,6 @@ describe('pagination directive with first, last & number links', function () {
     $rootScope.$digest();
     expect($rootScope.currentPage).toBe($rootScope.numPages);
   });
-
 });
 
 describe('pagination bypass configuration from attributes', function () {

--- a/template/pagination/pager.html
+++ b/template/pagination/pager.html
@@ -1,0 +1,5 @@
+<ul class="pager" ng-show="show()">
+  <li ng-class="{disabled: noPrevious(), previous: options.align}"><a ng-click="selectPage(currentPage - 1)">{{options.previousText}}</a></li>
+  <li ng-class="{disabled: noNext(), next: options.align}"><a ng-click="selectPage(currentPage + 1)">{{options.nextText}}</a></li>
+</ul>
+

--- a/template/pagination/pagination.html
+++ b/template/pagination/pagination.html
@@ -1,4 +1,4 @@
-<div class="pagination"><ul>
+<div class="pagination"><ul ng-show="show()">
   <li ng-repeat="page in pages" ng-class="{active: page.active, disabled: page.disabled}"><a ng-click="selectPage(page.number)">{{page.text}}</a></li>
   </ul>
 </div>


### PR DESCRIPTION
- rotate: true/false (default: true) If true & max-size is set, current page is keeped in the middle of the visible pages.
- Ellipsis are added to move to previous & next page set when rotate is false.
