### PR TITLE
Add tooltips to body to avoid css adjacency issues

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -12,7 +12,7 @@ angular.module( 'ui.bootstrap.tooltip', [] )
     templateUrl: 'template/tooltip/tooltip-popup.html'
   };
 })
-.directive( 'tooltip', [ '$compile', '$timeout', '$parse', '$window', function ( $compile, $timeout, $parse, $window) {
+.directive( 'tooltip', [ '$compile', '$timeout', '$parse', '$window', '$document', function ( $compile, $timeout, $parse, $window, $document) {
   
   var template = 
     '<tooltip-popup '+
@@ -79,7 +79,7 @@ angular.module( 'ui.bootstrap.tooltip', [] )
         
         // Now we add it to the DOM because need some info about it. But it's not 
         // visible yet anyway.
-        element.after( tooltip );
+        $document.find( 'body' ).append( tooltip );
         
         // Get the position of the directive element.
         position = getPosition();


### PR DESCRIPTION
Currently, tooltip markup is added `after` the element on which the
directive is defined. As a result, any adjacency selectors based on
the element having a controlled set of siblings will be affected.

This change will add the tooltip element as a child of the body instead.
