### PR TITLE
chore(build): Add grunt-contrib-watch task for grunt v0.4

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,7 @@ var markdown = require('node-markdown').Markdown;
 
 module.exports = function(grunt) {
 
+  grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-uglify');
@@ -22,7 +23,7 @@ module.exports = function(grunt) {
     },
     watch: {
       files: ['<%= jshint.files %>', 'template/**/*.html'],
-      tasks: 'before-test test-run'
+      tasks: ['before-test', 'test-run']
     },
     concat: {
       dist: {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "grunt": "0.4.0",
     "grunt-contrib-jshint": "~0.2.0",
     "grunt-contrib-concat": "~0.1.3",
-    "grunt-contrib-uglify": "~0.1.1"
+    "grunt-contrib-uglify": "~0.1.1",
+    "grunt-contrib-watch": "~0.3.1"
   }
 }


### PR DESCRIPTION
The watch task is now in grunt 0.4.x format and grunt-contrib-watch is added.

I see it fails in Jenkins.  We should probably ask Igor to update the build script to just spit an error into the console about bad dependencies and skip them, instead of erroring the build.
