### PR TITLE
chore(grunt): update to latest grunt to fix grunt bug when running on node 0.10.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -149,7 +149,9 @@ module.exports = function(grunt) {
       srcFiles = ['src/*/*.js'];
       tplFiles = ['template/*/*.html.js'];
 
-      grunt.file.expand({filter: 'isDirectory'}, 'src/*').forEach(function(dir) {
+      var folders = grunt.file.expand({filter: 'isDirectory', cwd: '.'}, 'src/*');
+
+      folders.forEach(function(dir) {
         findModule(dir.split('/')[1]);
       });
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "node-markdown": "0.1.1",
-    "grunt": "0.4.0",
+    "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.2.0",
     "grunt-contrib-concat": "~0.1.3",
     "grunt-contrib-uglify": "~0.1.1"


### PR DESCRIPTION
Changes to the path API in nodeJS causes the build to fail with grunt 0.4.0.  This patch fixes it in two ways:
- Update to grunt 0.4.1 - this version fixes the bug
- Add cwd option to build - this also fixes the issue but from our side and works with grunt 0.4.0
