### PR TITLE
stop event propagation on tab click

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -2,11 +2,15 @@ angular.module('ui.bootstrap.tabs', [])
 .controller('TabsController', ['$scope', '$element', function($scope, $element) {
   var panes = $scope.panes = [];
 
-  this.select = $scope.select = function selectPane(pane) {
+  this.select = $scope.select = function selectPane(pane, $event) {
     angular.forEach(panes, function(pane) {
       pane.selected = false;
     });
     pane.selected = true;
+    if(arguments.length > 1 && $event) {
+      $event.preventDefault();
+      $event.stopPropagation();
+    }
   };
 
   this.addPane = function addPane(pane) {

--- a/template/tabs/tabs.html
+++ b/template/tabs/tabs.html
@@ -1,7 +1,7 @@
 <div class="tabbable">
   <ul class="nav nav-tabs">
     <li ng-repeat="pane in panes" ng-class="{active:pane.selected}">
-      <a href="" ng-click="select(pane)">{{pane.heading}}</a>
+      <a href="" ng-click="select(pane, $event)">{{pane.heading}}</a>
     </li>
   </ul>
   <div class="tab-content" ng-transclude></div>


### PR DESCRIPTION
I have a complex angularjs application (backed by grails) and
- many routes to different controllers / views, with default route bound to "/"
- `
  <base href="/mycontext" />
  ` in head tag

When someone clicks on a tab, the new tab is selected, but the event is propagated and the link resolved (href=""). In my case the link change is intercepted by routeProvider which loads the main view.
