### PR TITLE
feat(tooltipProvider): added appendToBody option for $tooltip

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -123,4 +123,43 @@ describe('tooltip', function() {
   }));
 });
 
-    
+describe('$tooltipProvider', function() {
+  var elm, 
+      elmBody,
+      scope, 
+      elmScope,
+      body;
+
+  // load the tooltip code
+  beforeEach(module('ui.bootstrap.tooltip'));
+
+  // load the template
+  beforeEach(module('template/tooltip/tooltip-popup.html'));
+
+  it( 'should not be open initially', function() {
+    module( function ( $tooltipProvider ) {
+      $tooltipProvider.options({ appendToBody: true });
+    });
+
+    inject( function( $rootScope, $compile, $document ) {
+      $body = $document.find( 'body' );
+      elmBody = angular.element( 
+        '<div><span tooltip="tooltip text">Selector Text</span></div>' 
+      );
+
+      scope = $rootScope;
+      $compile(elmBody)(scope);
+      scope.$digest();
+      elm = elmBody.find('span');
+      elmScope = elm.scope();
+
+      var bodyLength = $body.children().length;
+      elm.trigger( 'mouseenter' );
+      
+      expect( elmScope.tt_isOpen ).toBe( true );
+      expect( elmBody.children().length ).toBe( 1 );
+      expect( $body.children().length ).toEqual( bodyLength + 1 );
+    });
+  });
+});
+

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -20,7 +20,7 @@ angular.module( 'ui.bootstrap.tooltip', [] )
   var globalOptions = {};
   
   /**
-   * The `options({})` allows global configuration of all dialogs in the
+   * `options({})` allows global configuration of all tooltips in the
    * application.
    *
    *   var app = angular.module( 'App', ['ui.bootstrap.tooltip'], function( $tooltipProvider ) {
@@ -36,7 +36,7 @@ angular.module( 'ui.bootstrap.tooltip', [] )
    * Returns the actual instance of the $tooltip service.
    * TODO support multiple triggers
    */
-  this.$get = [ '$window', '$compile', '$timeout', '$parse', function ( $window, $compile, $timeout, $parse ) {
+  this.$get = [ '$window', '$compile', '$timeout', '$parse', '$document', function ( $window, $compile, $timeout, $parse, $document ) {
     return function $tooltip ( type, defaultTriggerShow, defaultTriggerHide ) {
       var options = angular.extend( {}, defaultOptions, globalOptions );
 
@@ -65,8 +65,9 @@ angular.module( 'ui.bootstrap.tooltip', [] )
         restrict: 'EA',
         scope: true,
         link: function link ( scope, element, attrs ) {
-          var tooltip = $compile( template )( scope ), 
-              transitionTimeout;
+          var tooltip = $compile( template )( scope );
+          var transitionTimeout;
+          var $body;
 
           attrs.$observe( type, function ( val ) {
             scope.tt_content = val;
@@ -111,7 +112,12 @@ angular.module( 'ui.bootstrap.tooltip', [] )
             
             // Now we add it to the DOM because need some info about it. But it's not 
             // visible yet anyway.
-            element.after( tooltip );
+            if ( options.appendToBody ) {
+                $body = $body || $document.find( 'body' );
+                $body.append( tooltip );
+            } else {
+              element.after( tooltip );
+            }
             
             // Get the position of the directive element.
             position = getPosition( element );


### PR DESCRIPTION
Okay, in re #139 I decided to just create a completely independent option called `appendToBody` for now. When `true`, the tooltips will be appended to the body. I do not think this is the best long-term solution, but until someone comes up with something brilliant for containers, this will do.

I intentionally did not update the docs. I think before we unleash the `$tooltipProvider` on the public, we should add a few more options to it, some proper defaults, and a few more detailed tests.

I also did not update the demo as that is not feasible in this case (needs a `config` block). But all the tests pass and I created a [working Plunker](http://plnkr.co/edit/OAtk4gUhqGx8R6ZeYH6T?p=preview).

This doesn't close #139 as that's still an issue, but it provides a good stopgap. 

What do y'all think?
