### PR TITLE
Remove reference to msTransition for IE10

### DIFF
--- a/src/transition/transition.js
+++ b/src/transition/transition.js
@@ -61,14 +61,12 @@ angular.module('ui.bootstrap.transition', [])
     'WebkitTransition': 'webkitTransitionEnd',
     'MozTransition': 'transitionend',
     'OTransition': 'oTransitionEnd',
-    'msTransition': 'MSTransitionEnd',
     'transition': 'transitionend'
   };
   var animationEndEventNames = {
     'WebkitTransition': 'webkitAnimationEnd',
     'MozTransition': 'animationend',
     'OTransition': 'oAnimationEnd',
-    'msTransition': 'MSAnimationEnd',
     'transition': 'animationend'
   };
   function findEndEventName(endEventNames) {


### PR DESCRIPTION
This fixes an issue with transitions in IE10. For example dialog with transitions on never removes the elements in that browser.

In IE10 msTransition exists but msTransitionEnd never fires. IE10 does however support standard transitionend. Since IE<10 does not support transitions this line can be removed entirely.

This has already been done in Twitter Bootstrap. Reference here: https://github.com/twitter/bootstrap/pull/4166
