### PR TITLE
Set _open to false on init (Dialog)

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -66,6 +66,7 @@ dialogModule.provider("$dialog", function(){
 		function Dialog(opts) {
 
       var self = this, options = this.options = angular.extend({}, defaults, globalOptions, opts);
+      this._open = false;
 
       this.backdropEl = createElement(options.backdropClass);
       if(options.backdropFade){


### PR DESCRIPTION
calling $dialog.isOpen returns undefined before opening the $dialog for the first time.
Simply set the this._open var to false on init.
