### PR TITLE
fix(dialog): Don't increase the active backdrops counter when opening a dialog that is already open

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -207,7 +207,8 @@ dialogModule.provider("$dialog", function(){
     Dialog.prototype._addElementsToDom = function(){
       body.append(this.modalEl);
 
-      if(this.options.backdrop) { 
+      //Don't increase the backdrop count if a modal is opened while already open
+      if(this.options.backdrop && this._open === false) {
         if (activeBackdrops.value === 0) {
           body.append(this.backdropEl); 
         }

--- a/src/dialog/test/dialog.spec.js
+++ b/src/dialog/test/dialog.spec.js
@@ -323,4 +323,21 @@ describe('Given ui.bootstrap.dialog', function(){
 
 		dialogShouldBeOpen();
 	});
+
+	describe('when closing a dialog that has been opened while already open', function(){
+
+		beforeEach(function(){
+			createDialog({template:template});
+			openDialog();
+			openDialog();
+			closeDialog();
+		});
+
+		dialogShouldBeClosed();
+
+		it('should not show the backdrop', function(){
+			expect($document.find('body > div.modal-backdrop').length).toBe(0);
+		});
+	});
+
 });


### PR DESCRIPTION
When opening a dialog that is already open (e.g. to change the template), the active.backdrops count should not be increased, because this prevents the backdrop from being removed when you close the twice opened dialog.

I added a test, but I am not sure if this is the right way to test it.
