### PR TITLE
Fixing reference to Dialog's backdrop element so it closes properly

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -68,7 +68,10 @@ dialogModule.provider("$dialog", function(){
       var self = this, options = this.options = angular.extend({}, defaults, globalOptions, opts);
       this._open = false;
 
-      this.backdropEl = createElement(options.backdropClass);
+      if (activeBackdrops.value===0) {
+          activeBackdrops.backdropEl= createElement(options.backdropClass);
+      }
+      this.backdropEl = activeBackdrops.backdropEl;
       if(options.backdropFade){
         this.backdropEl.addClass(options.transitionClass);
         this.backdropEl.removeClass(options.triggerClass);
@@ -224,6 +227,7 @@ dialogModule.provider("$dialog", function(){
         activeBackdrops.value--;
         if (activeBackdrops.value === 0) {
           this.backdropEl.remove(); 
+          activeBackdrops.backdropEl = {};
         }
       }
       this._open = false;


### PR DESCRIPTION
Relates to #379

There should only be one backdrop element, so the service now will hold a reference to this backdrop element so that it can be properly removed.
