### PR TITLE
Update tooltip.js

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -254,16 +254,16 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position' ] )
           });
 
           attrs.$observe( prefix+'Trigger', function ( val ) {
-            element.unbind( triggers.show );
-            element.unbind( triggers.hide );
+            element.off(triggers.show, showTooltipBind);
+            element.off(triggers.hide, hideTooltipBind);
 
             triggers = setTriggers( val );
 
             if ( triggers.show === triggers.hide ) {
-              element.bind( triggers.show, toggleTooltipBind );
+              element.on(triggers.show, toggleTooltipBind);
             } else {
-              element.bind( triggers.show, showTooltipBind );
-              element.bind( triggers.hide, hideTooltipBind );
+              element.on(triggers.show, showTooltipBind);
+              element.on(triggers.hide, hideTooltipBind);
             }
           });
         }


### PR DESCRIPTION
I'm still pretty new to js. Is there some reason bind/unbind was used instead of on/off? Maybe on/off introduces an undesirable jQuery dependency? On/off prevents wiping out any other handlers for the given event. Anyhow, this ultimately solved my problem and I thought I'd share it.
