### PR TITLE
Remove dialogOpenClass from dialog.js to get in line with v2.3

### DIFF
--- a/src/dialog/README.md
+++ b/src/dialog/README.md
@@ -15,7 +15,6 @@ Sets the default global options for your application. Options can be overridden 
 *   `backdropClass`: the css class for the backdrop, defaults to 'modal-backdrop'
 *   `transitionClass`: the css class that applies transitions to the modal and backdrop, defaults to 'fade'
 *   `triggerClass`: the css class that triggers the transitions, defaults to 'in'
-*   `dialogOpenClass`: the css class that is added to body when dialog is opened, defaults to 'modal-open'
 *   `resolve`: members that will be resolved and passed to the controller as locals
 *   `controller`: the controller to associate with the included partial view
 *   `backdropFade`: a boolean value indicating whether the backdrop should fade in and out using a CSS transition, defaults to false

--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -20,7 +20,6 @@ dialogModule.provider("$dialog", function(){
     backdropClass: 'modal-backdrop',
     transitionClass: 'fade',
     triggerClass: 'in',
-    dialogOpenClass: 'modal-open',  
     resolve:{},
     backdropFade: false,
     dialogFade:false,
@@ -48,7 +47,6 @@ dialogModule.provider("$dialog", function(){
   function ($http, $document, $compile, $rootScope, $controller, $templateCache, $q, $transition, $injector) {
 
 		var body = $document.find('body');
-        var html = $document.find('html');
 
 		function createElement(clazz) {
 			var el = angular.element("<div>");
@@ -133,8 +131,6 @@ dialogModule.provider("$dialog", function(){
 
         $compile(self.modalEl)($scope);
         self._addElementsToDom();
-        body.addClass(self.options.dialogOpenClass);
-        html.addClass(self.options.dialogOpenClass);
 
         // trigger tranisitions
         setTimeout(function(){
@@ -153,9 +149,6 @@ dialogModule.provider("$dialog", function(){
     Dialog.prototype.close = function(result){
       var self = this;
       var fadingElements = this._getFadingElements();
-
-      body.removeClass(self.options.dialogOpenClass);
-      html.removeClass(self.options.dialogOpenClass);
 
       if(fadingElements.length > 0){
         for (var i = fadingElements.length - 1; i >= 0; i--) {


### PR DESCRIPTION
I don't have older browsers available to test on my local machine, so I left body in the code in case that covers < IE10, although I'm 95% sure that can be removed.
