### PR TITLE
fix(tooltip): open tooltips will hide on trigger scope.

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -12,7 +12,7 @@ describe('tooltip', function() {
 
   beforeEach(inject(function($rootScope, $compile) {
     elmBody = angular.element( 
-      '<div><span tooltip="tooltip text">Selector Text</span></div>' 
+      '<div><span tooltip="tooltip text" tooltip-animation="false">Selector Text</span></div>' 
     );
 
     scope = $rootScope;
@@ -121,6 +121,15 @@ describe('tooltip', function() {
     elmBody.find('span').trigger('mouseenter');
 
     expect(elmBody.children().length).toBe(1);
+  }));
+
+  it( 'should close the tooltip when its trigger element is destroyed', inject( function() {
+    elm.trigger( 'mouseenter' );
+    expect( elmScope.tt_isOpen ).toBe( true );
+
+    elm.remove();
+    elmScope.$destroy();
+    expect( elmBody.children().length ).toBe( 0 );
   }));
 
   describe('with specified popup delay', function () {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -267,12 +267,18 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position' ] )
             }
           });
 
-          //if a tooltip is attached to <body> we need to remove it on location change
+          // if a tooltip is attached to <body> we need to remove it on location change
           if ( options.appendToBody ) {
             scope.$on('$locationChangeSuccess', hide);
           }
           
-          scope.$on('$destroy', hide);
+          // if this trigger element is destroyed while the tooltip is open, we
+          // need to close the tooltip.
+          scope.$on('$destroy', function closeTooltipOnDestroy () {
+            if ( scope.tt_isOpen ) {
+              hide();
+            }
+          });
         }
       };
     };


### PR DESCRIPTION
This (of course) assumes the user actually destroys the scope of the element she removes.

Incorporates #411. Closes #410.
