### PR TITLE
allow resources to be resolved by dialog again

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -239,7 +239,7 @@ dialogModule.provider("$dialog", function(){
 
       angular.forEach(this.options.resolve || [], function(value, key) {
         keys.push(key);
-        values.push(angular.isString(value) ? $injector.get(value) : $injector.invoke(value));
+        values.push(angular.isString(value) ? $injector.get(value) : (angular.isFunction(value)) ? $injector.invoke(value) : value);
       });
 
       keys.push('$template');


### PR DESCRIPTION
This re-enables the ability to pass objects through to the dialog via resolve, as currently only strings (sets the value) or functions (gets invoked) work. Anything that isn't a string is currently treated as a function and invoked.

It was stopped by https://github.com/angular-ui/bootstrap/commit/739f86f21a2919654bcb01f3edc6ddeeb1b35c22#L0L220
but I don't know whether that was by design or oversight?
