### PR TITLE
Properly removes listener for $locationChangeSuccess when dialog is clos...

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -194,7 +194,9 @@ dialogModule.provider("$dialog", function(){
       if(this.options.keyboard){ body.unbind('keydown', this.handledEscapeKey); }
       if(this.options.backdrop && this.options.backdropClick){ this.backdropEl.unbind('click', this.handleBackDropClick); }
 
-      if(this.unregisterLocationListener) this.unregisterLocationListener();
+      if(this.unregisterLocationListener) {
+        this.unregisterLocationListener();
+      }
     };
 
     Dialog.prototype._onCloseComplete = function(result) {


### PR DESCRIPTION
Properly removes listener for $locationChangeSuccess when dialog is closed.  This prevents unnecessary dialog close events being triggered every time a location change happens when the dialog is already closed.

Fixes #376 and compliments PR#383 and PR#381 and PR#436
