### PR TITLE
chore(dialog): Use double quotes around HTML attribute for consistency

### DIFF
--- a/template/dialog/message.html
+++ b/template/dialog/message.html
@@ -5,5 +5,5 @@
 	<p>{{ message }}</p>
 </div>
 <div class="modal-footer">
-	<button ng-repeat="btn in buttons" ng-click="close(btn.result)" class=btn ng-class="btn.cssClass">{{ btn.label }}</button>
+	<button ng-repeat="btn in buttons" ng-click="close(btn.result)" class="btn" ng-class="btn.cssClass">{{ btn.label }}</button>
 </div>


### PR DESCRIPTION
Noticed this due to my editor's syntax highlighting and got a bit OCD.
