### PR TITLE
Optimalization & fix

### DIFF
--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -27,7 +27,7 @@ angular.module('ui.bootstrap.dropdownToggle', []).directive('dropdownToggle',
         if (!parent) {
           parent = element.parent();
           parent.bind('click', function (e) {
-            closeMenu(e)
+            closeMenu(e);
           });
         }
         event.preventDefault();


### PR DESCRIPTION
-  `$window` and `attrs` not used
-  reduced number of `DOM` calls to `element.parent()`
-  no need to `parent().bind('click',close)` when the menu wasn't open
-  prevent bubbling & propagation of event on menu click (stacked `ng-click`)
