### PR TITLE
fix(pagination): bind *-text attributes

### DIFF
--- a/src/pagination/docs/demo.html
+++ b/src/pagination/docs/demo.html
@@ -2,7 +2,7 @@
     <h4>Default</h4>
 
     <pagination num-pages="noOfPages" current-page="currentPage"></pagination>
-    <pagination boundary-links="true" num-pages="noOfPages" current-page="currentPage" class="pagination-small" previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></pagination>
+    <pagination boundary-links="true" num-pages="noOfPages" current-page="currentPage" class="pagination-small" previous-text="'&lsaquo;'" next-text="'&rsaquo;'" first-text="'&laquo;'" last-text="'&raquo;'"></pagination>
     <pagination direction-links="false" boundary-links="true" num-pages="noOfPages" current-page="currentPage"></pagination>
     <pagination direction-links="false" num-pages="noOfPages" current-page="currentPage"></pagination>
 

--- a/src/pagination/docs/readme.md
+++ b/src/pagination/docs/readme.md
@@ -1,6 +1,51 @@
 
-A lightweight pagination directive that is focused on ... providing pagination!
+A lightweight pagination directive that is focused on ... providing pagination & will take care of visualising a pagination bar and enable / disable buttons correctly!
 
-It will take care of visualising a pagination bar. Additionally it will make sure that the state (enabled / disabled) of the Previous / Next and First / Last buttons (if exist) is maintained correctly.
+### Settings ###
 
-It also provides optional attribute max-size to limit the size of pagination bar & rotate attribute whether to keep current page in the middle of the visible ones.
+Settings can be provided as attributes in the `<pagination>` or globally configured through the `paginationConfig`.
+
+ * `num-pages` <i class="icon-eye-open"></i>
+ 	:
+ 	Number of total pages.
+
+ * `current-page` <i class="icon-eye-open"></i>
+ 	:
+ 	Current page number.
+
+ * `max-size` <i class="icon-eye-open"></i>
+ 	_(Defaults: null)_ :
+ 	Limit number for pagination size.
+
+ * `rotate`
+ 	_(Defaults: true)_ :
+ 	Whether to keep current page in the middle of the visible ones.
+
+ * `on-select-page (page)`
+ 	_(Default: null)_ :
+ 	An optional expression called when a page is selected having the page number as argument.
+
+ * `direction-links`
+ 	_(Default: true)_ :
+ 	Whether to display Previous / Next buttons.
+
+ * `previous-text`
+ 	_(Default: 'Previous')_ :
+ 	Text for Previous button.
+
+ * `next-text`
+ 	_(Default: 'Next')_ :
+ 	Text for Next button.
+
+ * `boundary-links`
+ 	_(Default: false)_ :
+ 	Whether to display First / Last buttons.
+
+ * `first-text`
+ 	_(Default: 'First')_ :
+ 	Text for First button.
+
+ * `last-text`
+ 	_(Default: 'Last')_ :
+ 	Text for Last button.
+

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -26,10 +26,10 @@ angular.module('ui.bootstrap.pagination', [])
       // Setup configuration parameters
       var boundaryLinks = angular.isDefined(attrs.boundaryLinks) ? scope.$eval(attrs.boundaryLinks) : paginationConfig.boundaryLinks;
       var directionLinks = angular.isDefined(attrs.directionLinks) ? scope.$eval(attrs.directionLinks) : paginationConfig.directionLinks;
-      var firstText = angular.isDefined(attrs.firstText) ? attrs.firstText : paginationConfig.firstText;
-      var previousText = angular.isDefined(attrs.previousText) ? attrs.previousText : paginationConfig.previousText;
-      var nextText = angular.isDefined(attrs.nextText) ? attrs.nextText : paginationConfig.nextText;
-      var lastText = angular.isDefined(attrs.lastText) ? attrs.lastText : paginationConfig.lastText;
+      var firstText = angular.isDefined(attrs.firstText) ? scope.$parent.$eval(attrs.firstText) : paginationConfig.firstText;
+      var previousText = angular.isDefined(attrs.previousText) ? scope.$parent.$eval(attrs.previousText) : paginationConfig.previousText;
+      var nextText = angular.isDefined(attrs.nextText) ? scope.$parent.$eval(attrs.nextText) : paginationConfig.nextText;
+      var lastText = angular.isDefined(attrs.lastText) ? scope.$parent.$eval(attrs.lastText) : paginationConfig.lastText;
       var rotate = angular.isDefined(attrs.rotate) ? scope.$eval(attrs.rotate) : paginationConfig.rotate;
 
       // Create page object used in template

--- a/src/pagination/test/pagination.spec.js
+++ b/src/pagination/test/pagination.spec.js
@@ -353,7 +353,7 @@ describe('pagination directive with added first & last links', function () {
   });
 
   it('changes "first" & "last" text from attributes', function() {
-    element = $compile('<pagination boundary-links="true" first-text="<<<" last-text=">>>" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
+    element = $compile('<pagination boundary-links="true" first-text="\'<<<\'" last-text="\'>>>\'" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
     $rootScope.$digest();
 
     expect(element.find('li').eq(0).text()).toBe('<<<');
@@ -361,7 +361,27 @@ describe('pagination directive with added first & last links', function () {
   });
 
   it('changes "previous" & "next" text from attributes', function() {
-    element = $compile('<pagination boundary-links="true" previous-text="<<" next-text=">>" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
+    element = $compile('<pagination boundary-links="true" previous-text="\'<<\'" next-text="\'>>\'" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
+    $rootScope.$digest();
+
+    expect(element.find('li').eq(1).text()).toBe('<<');
+    expect(element.find('li').eq(-2).text()).toBe('>>');
+  });
+
+  it('changes "first" & "last" text from attribute variables', function() {
+    $rootScope.myfirstText = '<<<';
+    $rootScope.mylastText = '>>>';
+    element = $compile('<pagination boundary-links="true" first-text="myfirstText" last-text="mylastText" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
+    $rootScope.$digest();
+
+    expect(element.find('li').eq(0).text()).toBe('<<<');
+    expect(element.find('li').eq(-1).text()).toBe('>>>');
+  });
+
+  it('changes "previous" & "next" text from attribute variables', function() {
+    $rootScope.previousText = '<<';
+    $rootScope.nextText = '>>';
+    element = $compile('<pagination boundary-links="true" previous-text="previousText" next-text="nextText" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
     $rootScope.$digest();
 
     expect(element.find('li').eq(1).text()).toBe('<<');
@@ -566,7 +586,7 @@ describe('pagination bypass configuration from attributes', function () {
     $rootScope = _$rootScope_;
     $rootScope.numPages = 5;
     $rootScope.currentPage = 3;
-    element = $compile('<pagination boundary-links="true" first-text="<<" previous-text="<" next-text=">" last-text=">>" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
+    element = $compile('<pagination boundary-links="true" first-text="\'<<\'" previous-text="\'<\'" next-text="\'>\'" last-text="\'>>\'" num-pages="numPages" current-page="currentPage"></pagination>')($rootScope);
     $rootScope.$digest();
   }));
 


### PR DESCRIPTION
After a discussion in #107, there seems to be a problem when someone is trying to use a scope variables for the *-text attributes.

This a breaking change, since the values for the existing attributes needs to be surrounded with quotes.
