### PR TITLE
fix(tooltip): make sure tooltip scope is evicted from cache.

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -238,6 +238,46 @@ describe('tooltip', function() {
     }));
   });
 
+  describe('cleanup', function () {
+    var elmBody, elm, elmScope, tooltipScope;
+
+    function inCache() {
+      var match = false;
+
+      angular.forEach(angular.element.cache, function (item) {
+        if (item.data && item.data.$scope === tooltipScope) {
+          match = true;
+        }
+      });
+
+      return match;
+    }
+
+    beforeEach(inject(function ( $compile, $rootScope ) {
+      elmBody = angular.element('<div><input tooltip="Hello!" tooltip-trigger="fooTrigger" /></div>');
+
+      $compile(elmBody)($rootScope);
+      $rootScope.$apply();
+
+      elm = elmBody.find('input');
+      elmScope = elm.scope();
+      tooltipScope = elmScope.$$childTail;
+    }));
+
+    it( 'should not contain a cached reference', function() {
+      expect( inCache() ).toBeTruthy();
+      elmScope.$destroy();
+      expect( inCache() ).toBeFalsy();
+    });
+
+    it( 'should not contain a cached reference when visible', inject( function( $timeout ) {
+      expect( inCache() ).toBeTruthy();
+      elm.trigger('fooTrigger');
+      elmScope.$destroy();
+      $timeout.flush();
+      expect( inCache() ).toBeFalsy();
+    }));
+  });
 });
 
 describe('tooltipWithDifferentSymbols', function() {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -303,12 +303,13 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position' ] )
             }
           });
           }
-          
-          // if this trigger element is destroyed while the tooltip is open, we
-          // need to close the tooltip.
-          scope.$on('$destroy', function closeTooltipOnDestroy () {
+
+          // Make sure tooltip is destroyed and removed.
+          scope.$on('$destroy', function onDestroyTooltip() {
             if ( scope.tt_isOpen ) {
               hide();
+            } else {
+              tooltip.remove();
             }
           });
         }


### PR DESCRIPTION
This fix makes sure the tooltip.$scope is cleared from angular.element.cache when $destroy is called, preventing a memory leak.

See: https://github.com/angular-ui/bootstrap/issues/484
