### PR TITLE
Collapse scrollfix

### DIFF
--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -68,17 +68,15 @@ angular.module('ui.bootstrap.collapse',['ui.bootstrap.transition'])
             fixUpHeight(scope, element, 'auto');
           }
         } else {
-					// Whilst the element is expanding, we should hide any scrollbars that might appear. 
-					// If the element height is less than the max-height, scrollbars appear then disappear 
-					// during element expansion
-					element.css({ 'overflow-y': 'hidden' });
+					// add the collapse active class during animation
+					element.addClass('collapse-active');
           doTransition({ height : element[0].scrollHeight + 'px' })
           .then(function() {
             // This check ensures that we don't accidentally update the height if the user has closed
             // the group while the animation was still running
             if ( !isCollapsed ) {
-							// unset the overflow-y attribute to allow inherited behaviour
-							element.css({ 'overflow-y': '' });
+							// remove the collapse active class after animation
+							element.removeClass('collapse-active');
               fixUpHeight(scope, element, 'auto');
             }
           });
@@ -93,9 +91,13 @@ angular.module('ui.bootstrap.collapse',['ui.bootstrap.transition'])
           fixUpHeight(scope, element, 0);
         } else {
           fixUpHeight(scope, element, element[0].scrollHeight + 'px');
-					// hide any scrollbar whilst collapsing
-					element.css({ 'overflow-y': 'hidden' });
-          doTransition({'height':'0'});
+					// add the collapse active class during animation
+					element.addClass('collapse-active');
+          doTransition({'height':'0'})
+					.then(function() {
+						// remove the collapse active class after animation
+						element.removeClass('collapse-active');
+					});
         }
       };
     }


### PR DESCRIPTION
When a collapsable element has the css properties 'max-height' and 'overflow: auto' set, a scrollbar appears during the collapse animation then disappears, this happens at least in webkit based browsers. This pull request manually sets the 'overflow-y' css attribute to hidden during the animation then unsets it after the animation has completed. 
