### PR TITLE
feat(carousel): add option to prevent pause

### DIFF
--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -5,7 +5,8 @@
 *      A pure AngularJS carousel.
 *      
 *      For no interval set the interval to non-number, or milliseconds of desired interval
-*      Template: <carousel interval="none"><slide>{{anything}}</slide></carousel>
+*      To prevent pause upon mouseover set the nopause attribute to a truthy value
+*      Template: <carousel interval="none" nopause="someValue"><slide>{{anything}}</slide></carousel>
 *      To change the carousel's active slide set the active attribute to true
 *      Template: <carousel interval="none"><slide active="someModel">{{anything}}</slide></carousel>
 */
@@ -130,9 +131,11 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
     }
   };
   $scope.pause = function() {
-    isPlaying = false;
-    if (currentTimeout) {
-      $timeout.cancel(currentTimeout);
+    if (!$scope.noPause) {
+      isPlaying = false;
+      if (currentTimeout) {
+        $timeout.cancel(currentTimeout);
+      }
     }
   };
 
@@ -173,7 +176,8 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
     templateUrl: 'template/carousel/carousel.html',
     scope: {
       interval: '=',
-      noTransition: '='
+      noTransition: '=',
+      noPause: '='
     }
   };
 }])

--- a/src/carousel/test/carousel.spec.js
+++ b/src/carousel/test/carousel.spec.js
@@ -20,7 +20,7 @@ describe('carousel', function() {
         {active:false,content:'three'}
       ];
       elm = $compile(
-        '<carousel interval="interval" no-transition="true">' +
+        '<carousel interval="interval" no-transition="true" no-pause="nopause">' +
           '<slide ng-repeat="slide in slides" active="slide.active">' +
             '{{slide.content}}' +
           '</slide>' +
@@ -28,6 +28,7 @@ describe('carousel', function() {
       )(scope);
       carouselScope = elm.scope();
       scope.interval = 5000;
+      scope.nopause = undefined;
       scope.$apply();
     });
     afterEach(function() {
@@ -178,6 +179,17 @@ describe('carousel', function() {
       $timeout.flush();
       testSlideActive(2);
     });
+    
+    it('should not pause on mouseover if noPause', function() {
+      scope.$apply('nopause = true');
+      testSlideActive(0);
+      elm.trigger('mouseenter');
+      $timeout.flush();
+      testSlideActive(1);
+      elm.trigger('mouseleave');
+      $timeout.flush();
+      testSlideActive(2);
+    });    
 
     it('should remove slide from dom and change active slide', function() {
       scope.$apply('slides[1].active = true');


### PR DESCRIPTION
Sometimes we want the carousel to spin even if the mouse hovers over it. Added an optional attribute, doesn't break current templates.
