### PR TITLE
Binding selected btn-radio value with model

### DIFF
--- a/src/buttons/buttons.js
+++ b/src/buttons/buttons.js
@@ -15,6 +15,14 @@ angular.module('ui.bootstrap.buttons', [])
     link:function (scope, element, attrs, ngModelCtrl) {
 
       var value = scope.$eval(attrs.btnRadio);
+      
+      //btn-radio values -> model
+      scope.$watch(attrs.btnRadio, function(v){
+        value = v;
+        if (element.hasClass(activeClass)) {
+          ngModelCtrl.$setViewValue(value);
+        }
+      });      
 
       //model -> UI
       scope.$watch(function () {

--- a/src/buttons/test/buttons.spec.js
+++ b/src/buttons/test/buttons.spec.js
@@ -79,6 +79,26 @@ describe('buttons', function () {
       expect(btns.eq(1)).toHaveClass('active');
     });
 
+    //btn-radio values -> model
+    it('should maintain model and btn-radio values', function () {
+      $scope.values = ["value1", "value2"];
+
+      var btns = compileButtons('<button ng-model="model" btn-radio="values[0]">click1</button><button ng-model="model" btn-radio="values[1]">click2</button>', $scope);
+      expect(btns.eq(0)).not.toHaveClass('active');
+      expect(btns.eq(1)).not.toHaveClass('active');
+
+      $scope.model = "value2";
+      $scope.$digest();
+      expect(btns.eq(0)).not.toHaveClass('active');
+      expect(btns.eq(1)).toHaveClass('active');
+
+      $scope.values[1] = "value3";
+      $scope.$digest();
+      expect(btns.eq(0)).not.toHaveClass('active');
+      expect(btns.eq(1)).toHaveClass('active');
+      expect($scope.model).toEqual("value3");
+    });
+    
     //UI->model
     it('should work correctly set active class based on model', function () {
       var btns = compileButtons('<button ng-model="model" btn-radio="1">click1</button><button ng-model="model" btn-radio="2">click2</button>', $scope);


### PR DESCRIPTION
refs #512.
I've rebased with current master and had taken a look into #490.
Yes I think it solves the same problem that #490 does, but I'm no really sure that which approach is better in case of performance and covering all use cases.
Of course I've added tests to buttons specifications but in case that its not clear enough I describe it in more details here.
In my use case I need a page that user can add edit and remove pictures of a product and select one of them as default image. so I did something like this:

``` html
<div ng-repeat="image in product.images">
  <input type="text" ng-model="image.url"/>
  <button btn-radio="image.url" ng-model="product.defaultImage"> Is Default </button>
</div>
```

but it didn't worked cause btn-radio evaluates value just once at the first and its not watching for the changes. so i've added a watch on btnRadio attribute to update the evaluated value.
