### PR TITLE
Fix for issue #235: support custom $interpolate.startSymbol

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -213,6 +213,40 @@ describe('tooltip', function() {
 
 });
 
+describe('tooltipWithDifferentSymbols', function() {
+    var elm, 
+        elmBody,
+        scope, 
+        elmScope;
+
+    // load the tooltip code
+    beforeEach(module('ui.bootstrap.tooltip'));
+
+    // load the template
+    beforeEach(module('template/tooltip/tooltip-popup.html'));
+
+    // configure interpolate provider to use [[ ]] instead of {{ }}
+    beforeEach(module( function($interpolateProvider) {
+        $interpolateProvider.startSymbol('[[');
+        $interpolateProvider.startSymbol(']]');
+      }));
+
+    it( 'should show the correct tooltip text', inject( function ( $compile, $rootScope ) {
+
+      elmBody = angular.element(
+        '<div><input type="text" tooltip="My tooltip" tooltip-trigger="focus" tooltip-placement="right" /></div>'
+      );
+      $compile(elmBody)($rootScope);
+      $rootScope.$apply();
+      elmInput = elmBody.find('input');
+      elmInput.trigger('focus');
+
+      expect( elmInput.next().find('div').next().html() ).toBe('My tooltip');
+
+    }));
+
+});
+
 describe( 'tooltipHtmlUnsafe', function() {
   var elm, elmBody, scope;
 

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -55,7 +55,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position' ] )
    * Returns the actual instance of the $tooltip service.
    * TODO support multiple triggers
    */
-  this.$get = [ '$window', '$compile', '$timeout', '$parse', '$document', '$position', function ( $window, $compile, $timeout, $parse, $document, $position ) {
+  this.$get = [ '$window', '$compile', '$timeout', '$parse', '$document', '$position', '$interpolate', function ( $window, $compile, $timeout, $parse, $document, $position, $interpolate ) {
     return function $tooltip ( type, prefix, defaultTriggerShow ) {
       var options = angular.extend( {}, defaultOptions, globalOptions );
 
@@ -92,11 +92,13 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position' ] )
       var directiveName = snake_case( type );
       var triggers = setTriggers( undefined );
 
+      var startSym = $interpolate.startSymbol();
+      var endSym = $interpolate.endSymbol();
       var template = 
         '<'+ directiveName +'-popup '+
-          'title="{{tt_title}}" '+
-          'content="{{tt_content}}" '+
-          'placement="{{tt_placement}}" '+
+          'title="'+startSym+'tt_title'+endSym+'" '+
+          'content="'+startSym+'tt_content'+endSym+'" '+
+          'placement="'+startSym+'tt_placement'+endSym+'" '+
           'animation="tt_animation()" '+
           'is-open="tt_isOpen"'+
           '>'+


### PR DESCRIPTION
Fixed hardcoded tooltip template to use custom delimiters. The unit test needs its own 'describe' section to configure `$interpolateProvider` accordingly for the test. This helps fixing issue #235.
