### PR TITLE
chore(build): various fixes to the changelog task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,7 +134,8 @@ module.exports = function(grunt) {
     changelog: {
       options: {
         dest: 'CHANGELOG.md',
-        templateFile: 'misc/changelog.tpl.md'
+        templateFile: 'misc/changelog.tpl.md',
+        github: 'angular-ui/bootstrap'
       }
     },
     shell: {

--- a/misc/changelog.tpl.md
+++ b/misc/changelog.tpl.md
@@ -1,23 +1,16 @@
-
-# <%= version%> (<%= today%>) 
-
-<% if (_(changelog.feat).size() > 0) { %> ## Features
-<% _(changelog.feat).forEach(function(changes, scope) { %>
-- **<%= scope%>:**
-  <% changes.forEach(function(change) { %> - <%= change.msg%> (<%= helpers.commitLink(change.sha1) %>)
-  <% }); %>
-<% }); %> <% } %>
-
-<% if (_(changelog.fix).size() > 0) { %> ## Fixes
-<% _(changelog.fix).forEach(function(changes, scope) { %>
-- **<%= scope%>:**
-  <% changes.forEach(function(change) { %> - <%= change.msg%> (<%= helpers.commitLink(change.sha1) %>)
-  <% }); %>
-<% }); %> <% } %>
-
-<% if (_(changelog.breaking).size() > 0) { %> ## Breaking Changes
-<% _(changelog.breaking).forEach(function(changes, scope) { %>
-- **<%= scope%>:**
-  <% changes.forEach(function(change) { %> <%= change.msg%>
-  <% }); %>
-<% }); %> <% } %>
+# <%= version%> (<%= today%>)
+<% if (_(changelog.feat).size() > 0) { %>
+## Features
+<% _(changelog.feat).keys().sort().forEach(function(scope) { %>
+- **<%= scope%>:** <% changelog.feat[scope].forEach(function(change) { %>
+  - <%= change.msg%> (<%= helpers.commitLink(change.sha1) %>)  <% }); %><% }); %> <% } %>
+<% if (_(changelog.fix).size() > 0) { %>
+## Bug Fixes
+<% _(changelog.fix).keys().sort().forEach(function(scope) { %>
+- **<%= scope%>:** <% changelog.fix[scope].forEach(function(change) { %>
+  - <%= change.msg%> (<%= helpers.commitLink(change.sha1) %>)  <% }); %><% }); %> <% } %>
+<% if (_(changelog.breaking).size() > 0) { %>
+## Breaking Changes
+<% _(changelog.breaking).keys().sort().forEach(function(scope) { %>
+- **<%= scope%>:** <% changelog.breaking[scope].forEach(function(change) { %>
+<%= change.msg%><% }); %><% }); %> <% } %>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",
-    "node-markdown": "0.1.1",
+    "grunt-ngdocs": "~0.1.1",
+    "grunt-conventional-changelog": "~0.1.1",
     "grunt-contrib-concat": "~0.1.3",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-uglify": "~0.2.0",
@@ -13,8 +14,8 @@
     "grunt-contrib-jshint": "~0.4.0",
     "grunt-html2js": "~0.1.3",
     "grunt-karma": "~0.4.4",
+    "node-markdown": "0.1.1",
     "semver": "~1.1.4",
-    "shelljs": "~0.1.4",
-    "grunt-ngdocs": "git://github.com/m7r/grunt-ngdocs"
+    "shelljs": "~0.1.4"
   }
 }


### PR DESCRIPTION
@ajoslin I've tested the changelog task locally and bumped into several issues for which I would like to push fixes:
- dependencies
  - there was a depndency missing on a changelog task
  - ngdoc was pointing to a git endpoint instead of a released version
- template
  - various fixes (mostly new lines) so it looks like the current / AngularJS one
  - sorting by a directive name in each section (feature, fix etc.)
- sha1 links are broken
  - missing config option
  - there is a bug in the changelog task, submitted PR: https://github.com/btford/grunt-conventional-changelog/pull/12
