### PR TITLE
feat(tooltip): Added custom trigger support

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -402,6 +402,34 @@ describe( '$tooltipProvider', function() {
       }));
     });
 
+    describe( 'triggers with a custom mapped value', function() {
+      beforeEach(module('ui.bootstrap.tooltip', function($tooltipProvider){
+        $tooltipProvider.setTriggers({ 'customOpenTrigger': 'customCloseTrigger' });
+        $tooltipProvider.options({trigger: 'customOpenTrigger'});
+      }));
+
+      // load the template
+      beforeEach(module('template/tooltip/tooltip-popup.html'));
+
+      it( 'should use the show trigger and the mapped value for the hide trigger', inject( function ( $rootScope, $compile ) {
+        elmBody = angular.element(
+          '<div><input tooltip="tooltip text" /></div>'
+        );
+        
+        scope = $rootScope;
+        $compile(elmBody)(scope);
+        scope.$digest();
+        elm = elmBody.find('input');
+        elmScope = elm.scope();
+
+        expect( elmScope.tt_isOpen ).toBeFalsy();
+        elm.trigger('customOpenTrigger');
+        expect( elmScope.tt_isOpen ).toBeTruthy();
+        elm.trigger('customCloseTrigger');
+        expect( elmScope.tt_isOpen ).toBeFalsy();
+      }));
+    });
+
     describe( 'triggers without a mapped value', function() {
       beforeEach(module('ui.bootstrap.tooltip', function($tooltipProvider){
         $tooltipProvider.options({trigger: 'fakeTrigger'});

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -41,6 +41,15 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position' ] )
 	};
 
   /**
+   * This allows you to extend the set of trigger mappings available. E.g.:
+   *
+   *   $tooltipProvider.setTriggers( 'openTrigger': 'closeTrigger' );
+   */
+  this.setTriggers = function setTriggers ( triggers ) {
+    angular.extend( triggerMap, triggers );
+  };
+
+  /**
    * This is a helper function for translating camel-case to snake-case.
    */
   function snake_case(name){


### PR DESCRIPTION
The $tooltipProvider now allows extending the default set of open and
close trigger mappings.

Closes #382.
