### PR TITLE
docs(tooltipProvider): Added docs for available methods

### DIFF
--- a/src/popover/docs/readme.md
+++ b/src/popover/docs/readme.md
@@ -18,3 +18,6 @@ will display:
 
 The popover directives require the `$position` service.
 
+The popover directive also supports various default configurations through the
+$tooltipProvider. See the [tooltip](#tooltip) section for more information.
+

--- a/src/tooltip/docs/readme.md
+++ b/src/tooltip/docs/readme.md
@@ -31,3 +31,22 @@ provided hide triggers:
 For any non-supported value, the trigger will be used to both show and hide the
 tooltip.
 
+**$tooltipProvider**
+
+Through the `$tooltipProvider`, you can change the way tooltips and popovers
+behave by default; the attributes above always take precedence. The following
+methods are available:
+
+- `setTriggers( obj )`: Extends the default trigger mappings mentioned above
+  with mappings of your own. E.g. `{ 'openTrigger': 'closeTrigger' }`.
+- `options( obj )`: Provide a set of defaults for certain tooltip and popover
+  attributes. Currently supports 'placement', 'animation', 'popupDelay', and
+  `appendToBody`. Here are the defaults:
+
+  <pre>
+  placement: 'top',
+  animation: true,
+  popupDelay: 0,
+  appendToBody: false
+  </pre>
+


### PR DESCRIPTION
Until now, the $tooltipProvider has been an undocumented feature, but as
there are now several options requested by the community at large, it is
finally included in the documentation.
