### PR TITLE
some times seems the activeBackdrops.value will be -1, so change the code to fix it. or, it will without the backdrop after the second time call the dialog

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -217,8 +217,9 @@ dialogModule.provider("$dialog", function(){
 
       if(this.options.backdrop) { 
         activeBackdrops.value--;
-        if (activeBackdrops.value === 0) {
+        if (activeBackdrops.value <= 0) {
           this.backdropEl.remove(); 
+          activeBackdrops.value = 0;
         }
       }
       this._open = false;


### PR DESCRIPTION
some times seems the activeBackdrops.value will be -1, so change the code to fix it.
or, it will without the backdrop after the second time call the dialog
