### PR TITLE
feat(dialog): reintroduce dialogOpenClass Option

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -20,6 +20,7 @@ dialogModule.provider("$dialog", function(){
     backdropClass: 'modal-backdrop',
     transitionClass: 'fade',
     triggerClass: 'in',
+    dialogOpenClass: 'modal-open',
     resolve:{},
     backdropFade: false,
     dialogFade:false,
@@ -137,7 +138,7 @@ dialogModule.provider("$dialog", function(){
           if(self.options.dialogFade){ self.modalEl.addClass(self.options.triggerClass); }
           if(self.options.backdropFade){ self.backdropEl.addClass(self.options.triggerClass); }
         });
-
+        body.addClass(defaults.dialogOpenClass);
         self._bindEvents();
       });
 
@@ -195,7 +196,7 @@ dialogModule.provider("$dialog", function(){
     Dialog.prototype._onCloseComplete = function(result) {
       this._removeElementsFromDom();
       this._unbindEvents();
-
+      body.removeClass(defaults.dialogOpenClass);
       this.deferred.resolve(result);
     };
 


### PR DESCRIPTION
Reintroduced dialogOpenClass option - class which is added to the body when the dialog is open.  This keeps the source code up to date with documentation and allows users to style the body while the dialog is open.
