### PR TITLE
fix(popover): don't unbind event handlers created by other directives

### DIFF
--- a/src/popover/test/popoverSpec.js
+++ b/src/popover/test/popoverSpec.js
@@ -44,6 +44,28 @@ describe('popover', function() {
     elm.trigger( 'click' );
     expect( elmScope.tt_isOpen ).toBe( false );
   }));
+
+  it('should not unbind event handlers created by other directives - issue 456', inject( function( $compile ) {
+
+    scope.click = function() {
+      scope.clicked = !scope.clicked;
+    };
+
+    elmBody = angular.element(
+      '<div><input popover="Hello!" ng-click="click()" popover-trigger="mouseenter"/></div>'
+    );
+    $compile(elmBody)(scope);
+    scope.$digest();
+
+    elm = elmBody.find('input');
+
+    elm.trigger( 'mouseenter' );
+    elm.trigger( 'mouseleave' );
+    expect(scope.clicked).toBeFalsy();
+
+    elm.click();
+    expect(scope.clicked).toBeTruthy();
+  }));
 });
 
     

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -276,8 +276,8 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position' ] )
           });
 
           attrs.$observe( prefix+'Trigger', function ( val ) {
-            element.unbind( triggers.show );
-            element.unbind( triggers.hide );
+            element.unbind( triggers.show, showTooltipBind );
+            element.unbind( triggers.hide, hideTooltipBind );
 
             triggers = setTriggers( val );
 


### PR DESCRIPTION
Closes #456 

@joshdmiller I'm not sure this is a proper fix... I'm a bit puzzled since the issue happens only for popovers and not for tooltips... So there is something I don't quite get here. Would be great if you could review.
