### PR TITLE
fix(tooltip): bind correct 'hide' event handler

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -467,6 +467,24 @@ describe( '$tooltipProvider', function() {
         elm.trigger('blur');
         expect( elmScope.tt_isOpen ).toBeFalsy();
       }));
+
+      it( 'should override the show and hide triggers if there is an attribute', inject( function ( $rootScope, $compile ) {
+        elmBody = angular.element(
+          '<div><input tooltip="tooltip text" tooltip-trigger="mouseenter"/></div>'
+        );
+
+        scope = $rootScope;
+        $compile(elmBody)(scope);
+        scope.$digest();
+        elm = elmBody.find('input');
+        elmScope = elm.scope();
+
+        expect( elmScope.tt_isOpen ).toBeFalsy();
+        elm.trigger('mouseenter');
+        expect( elmScope.tt_isOpen ).toBeTruthy();
+        elm.trigger('mouseleave');
+        expect( elmScope.tt_isOpen ).toBeFalsy();
+      }));
     });
 
     describe( 'triggers with a custom mapped value', function() {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -86,11 +86,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position' ] )
         var show, hide;
        
         show = trigger || options.trigger || defaultTriggerShow;
-        if ( angular.isDefined ( options.trigger ) ) {
-          hide = triggerMap[options.trigger] || show;
-        } else {
-          hide = triggerMap[show] || show;
-        }
+        hide = triggerMap[show] || show;
 
         return {
           show: show,


### PR DESCRIPTION
If a user defines a tooltip-trigger attribute, this ensures the correct event handlers are used to hide the tooltip.

Fixes a bug where if a user sets both a default trigger using the tooltip provider, and then tries to override with an attribute, the wrong 'hide' event was being used.
