### PR TITLE
element.focus() will throw an error for DatePicker w/out jQuery present

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -391,7 +391,7 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
           updatePosition();
           $document.bind('click', documentClickBind);
           element.unbind('focus', elementFocusBind);
-          element.focus();
+          element[0].focus();
         } else {
           $document.unbind('click', documentClickBind);
           element.bind('focus', elementFocusBind);


### PR DESCRIPTION
I've been using the DatePicker and found a bug in the following area (works when jQuery is present but I'm trying to eliminate jQuery for this particular app). It's currently line 394 that has the problem in the source.

```
  scope.$watch('isOpen', function(value) {
    if (value) {
      updatePosition();
      $document.bind('click', documentClickBind);
      element.unbind('focus', elementFocusBind);
```

 -->     element.focus(); //should be element[0].focus() at a minimum w/ out jQuery present
        } else {
          $document.unbind('click', documentClickBind);
          element.bind('focus', elementFocusBind);
        }

```
    if ( setIsOpen ) {
      setIsOpen(originalScope, value);
    }
  });
```

The element.focus() will throw an error since the object needs to be unwrapped first. Should be:  element[0].focus() at a minimum to unwrap the jqlite object since it doesn't expose focus().
