### PR TITLE
feat(editable): added editable directive

### DIFF
--- a/src/editable/docs/demo.html
+++ b/src/editable/docs/demo.html
@@ -1,0 +1,46 @@
+<div ng-controller="EditableDemoCtrl">
+	<div class="row-fluid">
+		<div class="span4 alert">
+	    	Required: 
+	    </div>
+	    <div class="span8 alert alert-info">
+<a href="" ng-model="$parent.color" type="text" editable required>{{ $parent.color }}</a>
+	    </div>
+	</div>
+	<div class="row-fluid">
+		<div class="span4 alert">
+	    	Empty Value: 
+	    </div>
+	    <div class="span8 alert alert-info">
+<a href="" ng-model="$parent.empty" type="text" editable>{{ $parent.empty }}
+<span ng-show="$parent.empty == ''"><em>Empty</em></span></a>
+	    </div>
+	</div>
+	<div class="row-fluid">
+		<div class="span4 alert">
+	    	Progmatic:
+	    </div>
+	    <div class="span5 alert alert-info">
+<a href="" ng-model="$parent.progmaticColor" type="text" editable-active="state" editable required>{{ $parent.progmaticColor }}</a>
+	    </div>
+	    <div class="span3">
+	    	<button class="btn btn-mini" ng-click="state = !state">Active: {{ state }}</button>
+	    </div>
+	</div>
+	<div class="row-fluid">
+		<div class="span4 alert">
+	    	Select Array:
+	    </div>
+	    <div class="span8 alert alert-info">
+<a href="" ng-model="$parent.color" source="colorArray" type="select" source-options="value for value in source()" editable>{{ $parent.color }}</a>
+	    </div>
+	</div>
+	<div class="row-fluid">
+		<div class="span4 alert">
+	    	Radio Object:
+	    </div>
+	    <div class="span8 alert alert-info">
+<a href="" ng-model="$parent.color" source="colorObjectDefaults" type="radio" editable>{{ $parent.color }}</a>
+	    </div>
+	</div>
+</div>

--- a/src/editable/docs/demo.js
+++ b/src/editable/docs/demo.js
@@ -1,0 +1,17 @@
+var EditableDemoCtrl = function ($scope) {
+    $scope.empty = '';
+    $scope.state = false;
+    $scope.progmaticColor = 'Red';
+    $scope.color = 'Red';
+    $scope.colorArray = ['Red', 'Green', 'Blue'];
+    $scope.colorObjectDefaults = [{
+        key: 'Red',
+        label: 'Rojo'
+    }, {
+        key: 'Green',
+        label: 'Verde'
+    }, {
+        key: 'Blue',
+        label: 'Azul'
+    }];
+};

--- a/src/editable/docs/readme.md
+++ b/src/editable/docs/readme.md
@@ -1,0 +1,70 @@
+A configurable component that turns any text into an editable form input. It supports AngularJS validation by default, and custom controls via templates.
+
+### Notes on Use ###
+The current template design for Bootstrap 2.3 requires that each form element span the width of its parent container. 
+As such, using Editable in inline text, the input box will take 100% of it's parent containers div (usually results in 
+an entire line being dedicated to the input box).
+
+Editable is an isolate scope directive, and as such the `ngModel` attribute must bind to the $parent of the editable. So when 
+assigning the ngModel to the editable you must use the form `ng-model="$parent.variable"` and when using the variable for display 
+**inside** the editable container, you must use {{ $parent.variable }}. See the examples for more information.
+
+
+### Attributes ###
+
+All attributes must be set in the editable element, and can not be overwritten by the editable-options object.
+
+ * `ng-model` <i class="icon-eye-open"></i>
+ 	:
+ 	The model value to be edited.
+
+ * `active` <i class="icon-eye-open"></i>
+ 	:
+ 	An assignable value which stores the current state of a single editable object.
+
+ * `type`
+    : 
+    Accepts any HTML type attribute (number, email) as well as the text, select and radio types.
+
+ * `trigger`
+ 	_(Defaults: 'click')_ :
+ 	An event type to trigger edit mode used in conjunction with angular.element.bind(). 
+
+ * `source`
+ 	:
+ 	An object or array that represents the data for a select or radio type.
+
+ * `source-options`
+ 	:
+ 	An ng-options expression that is passed to a select element (or any element with the editableOptions directive). It must
+ 	*always* refer to `source()` as the "in" value.
+
+ * `editable-options`
+ 	:
+ 	An object with the properties listed below.
+
+
+### Settings ###
+
+Settings are non-attribute options that can be 
+
+ * `checked-label`
+ 	_(Defaults: 'label')_ :
+ 	The property name of the source object to use as a label for radio/checkboxes.
+
+ * `checked-value`
+ 	_(Defaults: 'key')_ :
+ 	The property name of the source object to send back as the return value.
+
+ * `template-urls`
+    :
+ 	An object of template URLs used in conjunction with the `type` attribute listed above.
+
+ * `validators` 
+ 	:
+ 	An object of validators in the form `validators[name]: errorMessage`. The default validators object contains values for all default AngularJS form validators.
+
+ * `requiredConstants` 
+ 	:
+ 	An array of strings, each string representing a configuration constant for a complex control. The timepicker for example would be
+    `requiredConstants: ['timepicker']`, which would attempt to inject the timepickerConfig object into the scope as scope.timepicker. Requiring a constant that doesn't exist will result in an javascript error.

--- a/src/editable/editable.js
+++ b/src/editable/editable.js
@@ -1,0 +1,355 @@
+angular.module('ui.bootstrap.editable', [])
+    .constant('editableConfig', {
+        validators: {
+            required: 'This field is required.',
+            min: 'A minimum value of {{ value }} is required.',
+            max: 'A maximum value of {{ value }} is allowed.',
+            ngMinlength: 'A minimum length of {{ value }} is required.',
+            ngMaxlength: 'A maximum length of {{ value }} is allowed.',
+            email: 'A valid email address is required.',
+            url: 'A valid URL is required.',
+            number: 'A valid number is required.',
+            defaultError: 'This is not a valid value.'
+        },
+        templateUrls: {
+            defaultTemplate: 'template/editable/editable.html',
+            radio: 'template/editable/radio.html',
+            select: 'template/editable/select.html'
+        },
+        requiredConstants: [],
+        checkedLabel: 'label',
+        checkedValue: 'key'
+    })
+    .controller('EditableController', ['$scope', '$element', '$attrs', '$interpolate', '$injector', 'editableConfig', function ($scope, $element, $attrs, $interpolate, $injector, editableConfig) {
+        $scope.opts = {};
+
+        // injects constants into the current scope
+        // we introduce these first so they can get overwritten
+        // by editableOptions
+        if (angular.isDefined($scope.editableOptions())) {
+            if ($scope.editableOptions().requiredConstants) {
+                angular.forEach($scope.editableOptions().requiredConstants, function(serviceName, key) {
+                    $scope.opts[serviceName] = $injector.get(serviceName + 'Config');
+                });
+            }
+        }
+
+        // write anything that's calculated in the model
+        $scope.opts = angular.extend($scope.opts, $scope.editableOptions());
+
+        // next we write the editableConfig constant
+        $scope.opts = angular.extend($scope.opts, editableConfig);
+
+        // we need the attributes for editable-validators/options as well
+        $scope.attrs = $attrs;
+
+        // ensure the compiledForm and form are removed
+        $scope.$on('$destroy', function() {
+            if (angular.isDefined($scope.compiledForm)) {
+                $scope.cleanUp();
+            }
+
+            if (angular.isDefined($scope.form)) {
+                $scope.form.remove();
+            }
+        });
+
+    }])
+    .directive('editable', ['$compile', '$http', '$templateCache', '$parse', function ($compile, $http, $templateCache, $parse) {
+        return {
+            require: 'ngModel',
+            controller: 'EditableController',
+            scope: {
+                'source': '&',
+                'editableOptions': '&',
+                'sourceOptions': '@',
+                'type': '@',
+                'trigger': '@'
+            },
+            link: function postLink(scope, element, attrs, ctrl) {
+                var template,
+                    templateUrl,
+                    errors,
+                    getActive,
+                    setActive;
+
+                // wait for the trigger to be available and load the template
+                attrs.$observe('trigger', function(value) {
+                    if (!angular.isDefined(value)) {
+                        scope.trigger = 'click';
+                    }
+
+                    getTemplate();
+                });
+
+                // active state, taken from the tabs directive
+                if (attrs.editableActive) {
+                    getActive = $parse(attrs.editableActive);
+                    setActive = getActive.assign;
+
+                    scope.$parent.$watch(getActive, function updateActive(value) {
+                        scope.active = !! value;
+                    });
+
+                    scope.active = getActive(scope.$parent);
+                } else {
+                    setActive = getActive = angular.noop;
+                }
+
+                // watch the active state for progmatic control
+                scope.$watch('active', function(active) {
+                    setActive(scope.$parent, active);
+                    if (active) {
+                        showForm();
+                    } else {
+                        // on first run this won't do anything
+                        scope.submitForm();
+                    }
+                });
+
+                // changes from inside isolate scope -> outside isolate scope
+                scope.$watch('model', function(val) {
+                    // when the element is intially created, it's undefined
+                    if (angular.isDefined(val)) {
+                        ctrl.$setViewValue(val);
+                    } else {
+                        // get the original value
+                        scope.originalValue = ctrl.$modelValue;
+                    }
+                });
+
+                // changes from outside isolate scope -> isolate scope
+                scope.$watch(attrs.ngModel, function(val) {
+                    scope.model = ctrl.$viewValue;
+                });
+
+                // submits the form if it's valid, shows error otherwise
+                scope.submitForm = function() {
+                    if ((angular.isDefined(scope.editable_form) && scope.editable_form.$valid) || !scope.isValidated && ctrl.$valid) {
+                        scope.cleanUp();
+                        scope.active = false;
+                    }
+                };
+
+                // cancels the form and sets the viewValue back to the originalValue
+                scope.cancelForm = function() {
+                    scope.model = scope.originalValue;
+                    scope.cleanUp();
+                };
+
+                // remove the compiled form and show the element
+                scope.cleanUp = function() {
+                    if (angular.isDefined(scope.compiledForm)) {
+                        scope.compiledForm.remove();
+                    }
+                    showElement();
+                    scope.compiledForm = scope.form.clone();
+                };
+
+                // recompiles and shows the form
+                var showForm = function() {
+                    scope.cleanUp();
+
+                    // clone/compile the form
+                    compileForm();
+
+                    // hide the element
+                    hideElement();
+                };
+
+                var getTemplate = function() {
+                    // get the template
+                    if (angular.isDefined(scope.opts.templateUrls[scope.type])) {
+                        templateUrl = scope.opts.templateUrls[scope.type];
+                    } else {
+                        templateUrl = scope.opts.templateUrls.defaultTemplate;
+                    }
+
+                    $http.get(templateUrl, {cache: $templateCache})
+                        .success(function(result) {
+                            template = result;
+                            buildForm();
+
+                            // only bind the element after the form has been built
+                            element.bind(scope.trigger, function(e) {
+                                e.preventDefault();
+
+                                scope.active = true;
+                                scope.$apply();
+                            });
+
+                        });
+                };
+
+                // clone and compile the form
+                var compileForm = function() {
+                    $compile(scope.compiledForm)(scope);
+                    element.after(scope.compiledForm);
+                };
+
+                // hides the element
+                var hideElement = function() {
+                    element.css('display', 'none');
+                };
+
+                // shows the element
+                var showElement = function() {
+                    element.css('display', '');
+                };
+
+                // form must have an editable-input somewhere
+                var buildForm = function() {
+                    scope.form = angular.element(template);
+
+                    // this is a "fix" to get the jasmine tests to pass
+                    // jQuery doesn't allow for dynamic type changing of input attributes if
+                    // the browser doesn't support it (<= IE 8).
+                    // this shouldn't cause any issues since it will only run when the default
+                    // template is called, but jasmine really shouldn't be firing a type error
+                    if (templateUrl == scope.opts.templateUrls.defaultTemplate) {
+                        scope.form.find('input').get(0).type = scope.type;
+                    }
+                };
+            }
+        };
+    }])
+    // Handles any input that requires validation (such as text);
+    .directive('editableValidator', ['$interpolate', '$compile', function ($interpolate, $compile) {
+        return {
+            restrict: 'C',
+            link: function postLink(scope, element, attrs) {
+                // setup errors as false
+                scope.errors = false;
+
+                // watch wehther editable_form is valid or not
+                scope.$watch(function() {
+                    if (angular.isDefined(scope.editable_form)) {
+                        return scope.editable_form.$valid;
+                    }
+                // show error on valid is true
+                }, function(valid) {
+                    if (!valid) {
+                        showError();
+                    }
+                });
+
+                // once type is loaded we know the element attributes are read
+                attrs.$observe('type', function() {
+                    // add the input attributes
+                    addInputAttributes();
+
+                    // ensure recompile won't forever loop
+                    element.removeClass("editable-validator");
+
+                    // avoid breaking the model
+                    attrs.$set('ngModel', 'model');
+
+                    // re-compile the element
+                    $compile(element)(scope);
+                });
+
+                // adds the input attributes per scope.opts.validators
+                var addInputAttributes = function() {
+                    scope.isValidated = true;
+                    angular.forEach(scope.attrs, function(value, key) {
+                        if (angular.isDefined(scope.opts.validators[key])) {
+                            element.attr(snakeCase(key), scope.attrs[key]);
+                        }
+                    });
+                };
+
+                // displays the errors
+                // on scope namespace since editable input may need to call it
+                var showError = function() {
+                    // reset the errors
+                    scope.errors = false;
+
+                    var errorString = false;
+
+                    // make sure the form field is defined
+                    // also check if this particular component even has valid validations
+                    if (angular.isDefined(scope.editable_form)) {
+                        // loop through all editable_field errors
+                        angular.forEach(scope.editable_form.$error, function(key, value) {
+
+                            // if error is true
+                            if (key) {
+
+                                // most validation fields don't have ng prefixes. But since ngMinlength and ngMaxlength do
+                                // we have to check.
+                                var camelValue = camelCase('ng-' + value);
+                                var validator = scope.opts.validators[value] || scope.opts.validators[camelValue] || false;
+
+                                // if validator is not false
+                                if(validator !== false) {
+                                    // interpolate the value... this only works for min/max/minlength/maxlength or custom
+                                    // it will return a null for any validator that doesn't have a {{ value }}
+                                    var errorFunction = $interpolate(validator, true);
+
+                                    // if a function is returned
+                                    if (angular.isDefined(errorFunction) && angular.isFunction(errorFunction)) {
+                                        // get the value for {{ value }} and replace it
+                                        var replacementVal = scope.attrs[value] || scope.attrs[camelValue];
+                                        errorString = errorFunction({ value: replacementVal });
+                                    } else {
+                                        // no interpolation required, just set string
+                                        errorString = validator;
+                                    }
+
+                                } else {
+                                    // we don't have a validator for this (how?) push the default error
+                                    errorString = scope.opts.validators.defaultError;
+                                }
+                            }
+                        });
+                    }
+                    scope.errors = !errorString ? '' : errorString;
+                };
+
+                // taken directly from Angular.
+                // converts camelCase to snake-case
+                var snakeCase = function(name, separator) {
+                    separator = separator || '-';
+                        return name.replace(/[A-Z]/g, function(letter, pos) {
+                        return (pos ? separator : '') + letter.toLowerCase();
+                    });
+                };
+
+                // taken directly from Angular.js
+                // converts snake-case to camelCaseGET
+                var camelCase = function(name) {
+                  return name.
+                    replace(/([\:\-\_]+(.))/g, function(_, separator, letter, offset) {
+                      return offset ? letter.toUpperCase() : letter;
+                    }).
+                    replace(/^moz([A-Z])/, 'Moz$1');
+                };
+            }
+        };
+    }])
+    .directive('editableOptions', ['$compile', function ($compile) {
+        return {
+            restrict: 'C',
+            link: function postLink(scope, element, attrs) {
+
+                // once type is loaded we know the element attributes are read
+                attrs.$observe('ng-options', function() {
+                    addOptions();
+
+                    // ensure recompile won't forever loop
+                    element.removeClass("editable-options");
+
+                    // avoid breaking the model
+                    attrs.$set('ngModel', 'model');
+
+                    // re-compile the element
+                    $compile(element)(scope);
+                });
+
+                // pass ng-options to from sourceOptions on to the .wg-editable-options element
+                var addOptions = function() {
+                    element.attr('ng-options', scope.sourceOptions);
+                };
+            }
+        };
+    }]);

--- a/src/editable/test/editable.spec.js
+++ b/src/editable/test/editable.spec.js
@@ -1,0 +1,391 @@
+describe('Given a ui.bootstrap.editable', function () {
+    beforeEach(module('ui.bootstrap.editable', 'template/editable/editable.html', 'template/editable/select.html', 'template/editable/radio.html'));
+
+    beforeEach(inject(function($compile, $rootScope, _$sniffer_) {
+        scope = $rootScope;
+        $sniffer = _$sniffer_;
+        scope.editable = 'test';
+    }));
+
+    afterEach(function() {
+        elementBody.remove();
+    });
+
+    var scope, element, elementBody, $sniffer;
+
+    var findInput = function(triggerEl) {
+        return triggerEl.find('input');
+    };
+
+    var findSelect = function(triggerEl) {
+        return triggerEl.find('select');
+    };
+
+    var findSubmitButton = function(triggerEl) {
+        return triggerEl.find('button').eq(1);
+    };
+
+    var findErrorButton = function(triggerEl) {
+        return triggerEl.find('button').eq(0);
+    };
+
+    var triggerKeyDown = function (element, keyCode) {
+        var inputEl = findInput(element);
+        var e = $.Event("keydown");
+        e.which = keyCode;
+        inputEl.trigger(e);
+    };
+
+    var changeInputValueTo = function (element, value) {
+        var inputEl = findInput(element);
+        inputEl.val(value);
+        inputEl.trigger($sniffer.hasEvent('input') ? 'input' : 'change');
+        scope.$digest();
+    };
+
+    var changeSelectValueTo = function (element, value) {
+        var inputEl = findSelect(element);
+        inputEl.val(value);
+        inputEl.trigger($sniffer.hasEvent('input') ? 'input' : 'change');
+        scope.$digest();
+    };
+
+    describe('with default settings', function() {
+
+        beforeEach(inject(function($compile, $rootScope, $sniffer) {
+            elementBody = angular.element('<div></div>');
+            element = $compile('<a href="" type="text" ng-model="$parent.editable" editable></a>')(scope);
+            angular.element(elementBody).append(element);
+            scope.$apply();
+        }));
+
+        it('the element should be visible by default', function () {
+            expect(element.css('display')).not.toBe('none');
+        });
+
+        describe('when the element is clicked', function() {
+
+            beforeEach(function() {
+                element.click();
+            });
+
+            it ('should change the element css property `display` to "none"', function() {
+                expect(element.css('display')).toBe('none');
+            });
+
+            it ('should have a visible submit button', function() {
+                expect(findSubmitButton(elementBody).css('display')).not.toBe('none');
+            });
+
+            it ('should create 1 `text` input type', function() {
+                expect(findInput(elementBody).length).toBe(1);
+                expect(findInput(elementBody).attr('type')).toBe('text');
+            });
+
+            it ('should update the model when the input value changes', function() {
+                changeInputValueTo(elementBody, 'modified');
+                expect(scope.editable).toBe('modified');
+            });      
+
+            describe('and the submit button is clicked', function() {
+
+                it('should change the element css property back to the original value', function() {
+                    findSubmitButton(elementBody).click();
+                    expect(element.css('display')).not.toBe('none');
+                });
+
+                it('should remove the input and button elements', function() {
+                    findSubmitButton(elementBody).click();
+                    expect(findInput(elementBody).length).toBe(0);
+                    expect(findSubmitButton(elementBody).length).toBe(0);
+                });
+
+                it('should update the model to the new value', function() {
+                    changeInputValueTo(elementBody, 'clickedSubmit');
+                    findSubmitButton(elementBody).click();
+                    expect(scope.editable).toBe('clickedSubmit');
+                });
+
+            }); 
+
+        });
+    });
+
+    describe('with a validation property', function() {
+        describe('of `required`', function() {
+            beforeEach(inject(function($compile, $rootScope, $sniffer) {
+                element = $compile('<a href="" type="text" ng-model="$parent.editable" editable required></a>')(scope);
+                angular.element(elementBody).append(element);
+                angular.element(document.body).append(elementBody);
+                scope.$apply();
+                element.click();
+            }));
+
+            describe('and and invalid value', function() {
+                beforeEach(function() {
+                    changeInputValueTo(elementBody, '');
+                });
+
+                it('should hide the submit button and show the error button when invalid', function() {
+                    expect(findSubmitButton(elementBody).css('display')).toBe('none');
+                    expect(findErrorButton(elementBody).css('display')).not.toBe('none');
+                });
+
+                it('should display errors in the error buttons tooltip', function() {
+                    expect(findErrorButton(elementBody).attr('tooltip')).not.toBe(false);
+                });
+
+                it('should set the validation classes', function() {
+                    expect(findInput(elementBody).hasClass('ng-invalid')).toBe(true);
+                    expect(findInput(elementBody).hasClass('ng-invalid-required')).toBe(true);
+                });
+            });
+        });
+
+        describe ('of `min="3"` and a type of type of `number`', function() {
+            beforeEach(inject(function($compile, $rootScope, $sniffer) {
+                element = $compile('<a href="" type="number" ng-model="$parent.editable" editable min="3"></a>')(scope);
+                angular.element(elementBody).append(element);
+                scope.$apply();
+                element.click();
+            }));
+
+            describe('and and invalid value', function() {
+                beforeEach(function() {
+                    changeInputValueTo(elementBody, '1');
+                });
+
+                it('should hide the submit button and show the error button when invalid', function() {
+                    expect(findSubmitButton(elementBody).css('display')).toBe('none');
+                    expect(findErrorButton(elementBody).css('display')).not.toBe('none');
+                });
+
+                it('should display errors in the error buttons tooltip', function() {
+                    expect(findErrorButton(elementBody).attr('tooltip')).not.toBe(false);
+                });
+
+                it('should set the validation classes', function() {
+                    expect(findInput(elementBody).hasClass('ng-invalid')).toBe(true);
+                    expect(findInput(elementBody).hasClass('ng-invalid-min')).toBe(true);
+                });
+            });
+        });
+
+        describe ('of `min="3"` and a type of type of `number`', function() {
+            beforeEach(inject(function($compile, $rootScope, $sniffer) {
+                element = $compile('<a href="" type="number" ng-model="$parent.editable" editable max="10"></a>')(scope);
+                angular.element(elementBody).append(element);
+                scope.$apply();
+                element.click();
+            }));
+
+            describe('and and invalid value', function() {
+                beforeEach(function() {
+                    changeInputValueTo(elementBody, '100');
+                });
+
+                it('should hide the submit button and show the error button when invalid', function() {
+                    expect(findSubmitButton(elementBody).css('display')).toBe('none');
+                    expect(findErrorButton(elementBody).css('display')).not.toBe('none');
+                });
+
+                it('should display errors in the error buttons tooltip', function() {
+                    expect(findErrorButton(elementBody).attr('tooltip')).not.toBe(false);
+                });
+
+                it('should set the validation classes', function() {
+                    expect(findInput(elementBody).hasClass('ng-invalid')).toBe(true);
+                    expect(findInput(elementBody).hasClass('ng-invalid-max')).toBe(true);
+                });
+            });
+        });
+
+        describe ('of `ng-minlength="3"`', function() {
+            beforeEach(inject(function($compile, $rootScope, $sniffer) {
+                element = $compile('<a href="" type="text" ng-model="$parent.editable" editable ng-minlength="3"></a>')(scope);
+                angular.element(elementBody).append(element);
+                scope.$apply();
+                element.click();
+            }));
+
+            describe('and and invalid value', function() {
+                beforeEach(function() {
+                    changeInputValueTo(elementBody, 'aa');
+                });
+
+                it('should hide the submit button and show the error button when invalid', function() {
+                    expect(findSubmitButton(elementBody).css('display')).toBe('none');
+                    expect(findErrorButton(elementBody).css('display')).not.toBe('none');
+                });
+
+                it('should display errors in the error buttons tooltip', function() {
+                    expect(findErrorButton(elementBody).attr('tooltip')).not.toBe(false);
+                });
+
+                it('should set the validation classes', function() {
+                    expect(findInput(elementBody).hasClass('ng-invalid')).toBe(true);
+                    expect(findInput(elementBody).hasClass('ng-invalid-minlength')).toBe(true);
+                });
+            });
+        });
+
+        describe ('of `ng-maxlength="3"`', function() {
+            beforeEach(inject(function($compile, $rootScope, $sniffer) {
+                element = $compile('<a href="" type="text" ng-model="$parent.editable" editable ng-maxlength="3"></a>')(scope);
+                angular.element(elementBody).append(element);
+                scope.$apply();
+                element.click();
+            }));
+
+            describe('and and invalid value', function() {
+                beforeEach(function() {
+                    changeInputValueTo(elementBody, 'aaaa');
+                });
+
+                it('should hide the submit button and show the error button when invalid', function() {
+                    expect(findSubmitButton(elementBody).css('display')).toBe('none');
+                    expect(findErrorButton(elementBody).css('display')).not.toBe('none');
+                });
+
+                it('should display errors in the error buttons tooltip', function() {
+                    expect(findErrorButton(elementBody).attr('tooltip')).not.toBe(false);
+                });
+
+                it('should set the validation classes', function() {
+                    expect(findInput(elementBody).hasClass('ng-invalid')).toBe(true);
+                    expect(findInput(elementBody).hasClass('ng-invalid-maxlength')).toBe(true);
+                });
+            });
+        });
+    });
+
+    describe('with an HTML5 validation type', function() {
+        describe('of `url`', function() {
+            beforeEach(inject(function($compile, $rootScope) {
+                element = $compile('<a href="" type="url" ng-model="$parent.editable" editable></a>')(scope);
+                angular.element(elementBody).append(element);
+                angular.element(document.body).append(elementBody);
+                scope.$apply();
+                element.click();
+            }));
+
+            describe('and an invalid value', function() {
+                beforeEach(function() {
+                    changeInputValueTo(elementBody, 'test');
+                });
+
+                it('should hide the submit button and show the error button when invalid', function() {
+                    expect(findSubmitButton(elementBody).css('display')).toBe('none');
+                    expect(findErrorButton(elementBody).css('display')).not.toBe('none');
+                });
+
+                it('should display errors in the error buttons tooltip', function() {
+                    expect(findErrorButton(elementBody).attr('tooltip')).not.toBe(false);
+                });
+
+                it('should set the validation classes', function() {
+                    expect(findInput(elementBody).hasClass('ng-invalid')).toBe(true);
+                    expect(findInput(elementBody).hasClass('ng-invalid-url')).toBe(true);
+                });
+            });
+        });
+
+        describe('of `email`', function() {
+            beforeEach(inject(function($compile, $rootScope) {
+                element = $compile('<a href="" type="email" ng-model="$parent.editable" editable></a>')(scope);
+                angular.element(elementBody).append(element);
+                angular.element(document.body).append(elementBody);
+                scope.$apply();
+                element.click();
+            }));
+
+            describe('and an invalid value', function() {
+                beforeEach(function() {
+                    changeInputValueTo(elementBody, 'test');
+                });
+
+                it('should hide the submit button and show the error button when invalid', function() {
+                    expect(findSubmitButton(elementBody).css('display')).toBe('none');
+                    expect(findErrorButton(elementBody).css('display')).not.toBe('none');
+                });
+
+                it('should display errors in the error buttons tooltip', function() {
+                    expect(findErrorButton(elementBody).attr('tooltip')).not.toBe(false);
+                });
+
+                it('should set the validation classes', function() {
+                    expect(findInput(elementBody).hasClass('ng-invalid')).toBe(true);
+                    expect(findInput(elementBody).hasClass('ng-invalid-email')).toBe(true);
+                });
+            });
+        });
+
+        describe('of `number`', function() {
+            beforeEach(inject(function($compile, $rootScope) {
+                element = $compile('<a href="" type="number" ng-model="$parent.editable" editable></a>')(scope);
+                angular.element(elementBody).append(element);
+                angular.element(document.body).append(elementBody);
+                scope.$apply();
+                element.click();
+            }));
+
+            describe('and an invalid value', function() {
+                beforeEach(function() {
+                    changeInputValueTo(elementBody, 'asdf');
+                });
+
+                it('should hide the submit button and show the error button when invalid', function() {
+                    expect(findSubmitButton(elementBody).css('display')).toBe('none');
+                    expect(findErrorButton(elementBody).css('display')).not.toBe('none');
+                });
+
+                it('should display errors in the error buttons tooltip', function() {
+                    expect(findErrorButton(elementBody).attr('tooltip')).not.toBe(false);
+                });
+
+                it('should set the validation classes', function() {
+                    expect(findInput(elementBody).hasClass('ng-invalid')).toBe(true);
+                    expect(findInput(elementBody).hasClass('ng-invalid-number')).toBe(true);
+                });
+            });
+        });
+    });
+
+    describe('with a `select` type', function() {
+        beforeEach(inject(function($compile, $rootScope) {
+            scope.editable = 'Red';
+            scope.selectSource = ['Red', 'Green', 'Blue'];
+            element = $compile('<a href="" type="select" source="selectSource" source-options="value for value in source()" ng-model="$parent.editable" editable></a>')(scope);
+            angular.element(elementBody).append(element);
+            angular.element(document.body).append(elementBody);
+            scope.$apply();
+            element.click();
+        }));
+
+        it('should have 3 option values', function() {
+            expect(findSelect(elementBody).children().length).toBe(3);
+        });
+
+        it('should update the model on selection change', function() {
+            changeSelectValueTo(elementBody, 'Green');
+            expect(scope.editable).toBe('Red');
+        });
+    });
+
+    describe('with a `radio` type', function() {
+        beforeEach(inject(function($compile, $rootScope) {
+            scope.editable = 'Red';
+            scope.selectSource = ['Red', 'Green', 'Blue'];
+            elementBody = angular.element('<div></div>');
+            element = $compile('<a href="" type="radio" source="selectSource" ng-model="$parent.editable" editable></a>')(scope);
+            angular.element(elementBody).append(element);
+            angular.element(document.body).append(elementBody);
+            scope.$apply();
+            element.click();
+        }));
+
+        it('should have 3 input radios', function() {
+            expect(findInput(elementBody).length).toBe(3);
+        });
+    });
+});

--- a/template/editable/editable.html
+++ b/template/editable/editable.html
@@ -1,0 +1,15 @@
+<form class="form-inline" name="editable_form" style="margin-bottom: 0; display: inline-block" ng-submit="submitForm()">
+    <div class="control-group" style="margin-bottom: 0" ng-class="{error: editable_form.$invalid }">
+        <div class="row-fluid">
+            <div class="input-append span12">
+                <input class="editable-validator span10" name="editable_field">
+                <button class="btn btn-danger disabled" tooltip="{{ errors }}" ng-hide="editable_form.$valid">
+                    <i class="icon-remove icon-white"></i>
+                </button>
+                <button class="btn btn-primary" ng-show="editable_form.$valid" ng-click="submitForm()">
+                    <i class="icon-ok icon-white"></i>
+                </button>
+            </div>
+        </div>
+   </div>
+</form>

--- a/template/editable/radio.html
+++ b/template/editable/radio.html
@@ -1,0 +1,10 @@
+<form class="form-inline" name="editable_form" style="margin-bottom: 0; display: inline-block" ng-submit="submitForm()">
+	<div class="control-group" style="margin-bottom: 0" ng-class="{error: editable_form.$invalid }">
+		<label class="radio inline" ng-repeat="values in source()">
+			<input type="radio" ng-model="$parent.model" value="{{ $parent.source()[$index][opts.checkedValue] || $parent.source()[$index] }}"> {{ $parent.source()[$index][opts.checkedLabel] || $parent.source()[$index] }}
+		</label>
+        <button class="btn btn-mini btn-primary" ng-click="submitForm()">
+            <i class="icon-ok icon-white"></i>
+        </button>
+   </div>
+</form>

--- a/template/editable/select.html
+++ b/template/editable/select.html
@@ -1,0 +1,15 @@
+<form class="form-inline" name="editable_form" style="margin-bottom: 0; display: inline-block" ng-submit="submitForm()">
+    <div class="control-group" style="margin-bottom: 0" ng-class="{error: editable_form.$invalid }">
+        <div class="row-fluid">
+            <div class="input-append span12">
+                <select class="editable-options" name="editable_field"></select>
+                <button class="btn btn-danger disabled" tooltip="{{ errors }}" ng-hide="editable_form.$valid">
+                    <i class="icon-remove icon-white"></i>
+                </button>
+                <button class="btn btn-primary" ng-show="editable_form.$valid" ng-click="submitForm()">
+                    <i class="icon-ok icon-white"></i>
+                </button>
+            </div>
+        </div>
+   </div>
+</form>


### PR DESCRIPTION
This directive is an implementation of editable modeled after the inline-editable version of http://vitalets.github.io/bootstrap-editable/. You can build and read the docs for how it is used.

Tests are in place, but if anyone finds a use case that I haven't tested against I am all ears! A couple of notes:
- There's an oddity in there at [#L207](https://github.com/hall5714/angular-ui-bootstrap/blob/aab6c80f3e393c07ebd18821478c9dce5f80a2b0/src/editable/editable.js#L209) of the source. The issue is that IE versions prior to 9 throw an error if an input type is changed. Unfortunately, Jasmine causes the error to be thrown. Frankly, I'm not sure if this will actually work in <IE9 or not, but this prevented jQuery from throwing the error. The error is specific to jQuery so running jQLite wouldn't throw the error anyway.
- Presently inputs attempt to fill the entire parent container in the templates. It may be better to pass in an inputClass.
- There is no popup support for now. This will have to wait until popups can have a template.

Any other questions feel free to ask!
