### PR TITLE
Fixed problem with offsetWidth being set in carousel

### DIFF
--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -35,7 +35,7 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
       if (self.currentSlide && angular.isString(direction) && !$scope.noTransition && nextSlide.$element) {
         //We shouldn't do class manip in here, but it's the same weird thing bootstrap does. need to fix sometime
         nextSlide.$element.addClass(direction);
-        nextSlide.$element[0].offsetWidth; //force reflow
+        var reflow = nextSlide.$element[0].offsetWidth; //force reflow
 
         //Set all other slides to stop doing their stuff for the new transition
         angular.forEach(slides, function(slide) {


### PR DESCRIPTION
The HTMLElement ($element) offsetWidth property is read only.
The carousel forces the reflow by assigning to this property, which causes exceptions in Firefox and Safari browsers on OSX (I'm unable to test it anywhere else). But - reading the property does the trick, so I think it's enough to read it (unless I don't know about something).
