### PR TITLE
fix(dialog): update to Bootstrap3

### DIFF
--- a/src/dialog/test/dialog.spec.js
+++ b/src/dialog/test/dialog.spec.js
@@ -111,8 +111,8 @@ describe('Given ui.bootstrap.dialog', function(){
 			});
 		});
 
-		describe('dialogClass:foo, backdropClass:bar', function(){
-			useDialogWithGlobalOption({dialogClass: 'foo', backdropClass: 'bar'});
+		describe('modalClass:foo, backdropClass:bar', function(){
+			useDialogWithGlobalOption({modalClass: 'foo', backdropClass: 'bar'});
 
 			it('backdrop class should be changed', function(){
 				expect($document.find('body > div.bar').length).toBe(1);
@@ -238,7 +238,7 @@ describe('Given ui.bootstrap.dialog', function(){
 		beforeEach(function(){
 			createDialog({template:'foo'});
 			openDialog();
-			$document.find('body > div.modal-backdrop').click();
+			$document.find('body > div.modal').click();
 		});
 
 		dialogShouldBeClosed();
@@ -285,7 +285,7 @@ describe('Given ui.bootstrap.dialog', function(){
 		});
 
 		it('should use the specified template', function(){
-			expect($document.find('body > div.modal > div.modal-header').length).toBe(1);
+			expect($document.find('body > div.modal > div.modal-dialog > div.modal-content > div.modal-header').length).toBe(1);
 		});
 	});
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -69,7 +69,7 @@ describe('Give ui.boostrap.modal', function() {
 		elm = $compile(templateGenerator('hello()', ' ', 'baz=0'))($scope);
 		$scope.$apply();
 		expect($document.find('body > div.modal').length).toBe(1);
-		$document.find('body > div.modal-backdrop').click();
+		$document.find('body > div.modal').click();
 		expect($document.find('body > div.modal').length).toBe(0);
 		expect($scope.baz).toBe(0);
 	});
@@ -155,7 +155,7 @@ describe('Give ui.boostrap.modal', function() {
 		});
 
 		it('should update the model if the backdrop is clicked', function() {
-			$document.find('body > div.modal-backdrop').click();
+			$document.find('body > div.modal').click();
 			$scope.$digest();
 			expect($scope.modalShown).not.toBeTruthy();
 		});


### PR DESCRIPTION
In Bootstrap3 dialogs are composed of three nested divs: ".modal",
".modal-dialog" and ".modal-content". Also, ".model" now covers
".model-backdrop" and therefore the click has to be detected on the
former. Moreover, the triggerClass is now set even if elements aren't
fading.

Finally I also substituted tabs with spaces.
