### PR TITLE
style(datepicker): redesigned for bootstrap 3

### DIFF
--- a/src/datepicker/docs/demo.html
+++ b/src/datepicker/docs/demo.html
@@ -1,19 +1,23 @@
 <div ng-controller="DatepickerDemoCtrl">
     <pre>Selected date is: <em>{{dt | date:'fullDate' }}</em></pre>
 
-    <div class="well well-small pull-left" ng-model="dt">
+    <div ng-model="dt" style="width: 280px">
         <datepicker min="minDate" show-weeks="showWeeks"></datepicker>
     </div>
 
-    <div class="form-horizontal">
-        <input type="text" datepicker-popup="dd-MMMM-yyyy" ng-model="dt" is-open="opened" min="minDate" max="'2015-06-22'" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" />
-        <button class="btn" ng-click="open()"><i class="icon-calendar"></i></button>
+    <hr>
+
+    <div class="input-group">
+        <input class="form-control" type="text" datepicker-popup="dd-MMMM-yyyy" ng-model="dt" is-open="opened" min="minDate" max="'2015-06-22'" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" />
+        <span class="input-group-btn">
+            <button class="btn btn-info" ng-click="open()"> <span class="glyphicon glyphicon-calendar"></span> </button>
+        </span>
     </div>
 
     <hr />
-    <button class="btn btn-small btn-inverse" ng-click="today()">Today</button>
-    <button class="btn btn-small btn-inverse" ng-click="dt = '2009-08-24'">2009-08-24</button>
-    <button class="btn btn-small btn-success" ng-click="toggleWeeks()" tooltip="For inline datepicker">Toggle Weeks</button>
-    <button class="btn btn-small btn-danger" ng-click="clear()">Clear</button>
-    <button class="btn btn-small" ng-click="toggleMin()" tooltip="After today restriction">Min date</button>
+    <button class="btn btn-sm btn-info" ng-click="today()">Today</button>
+    <button class="btn btn-sm btn-info" ng-click="dt = '2009-08-24'">2009-08-24</button>
+    <button class="btn btn-sm btn-success" ng-click="toggleWeeks()" tooltip="For inline datepicker">Toggle Weeks</button>
+    <button class="btn btn-sm btn-danger" ng-click="clear()">Clear</button>
+    <button class="btn btn-sm btn-default" ng-click="toggleMin()" tooltip="After today restriction">Min date</button>
 </div>

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -103,7 +103,7 @@ describe('datepicker directive', function () {
     for (var i = 0, n = options.length; i < n; i ++) {
       var optionsRow = options[i];
       for (var j = 0; j < optionsRow.length; j ++) {
-        expect(optionsRow[j].find('button').hasClass('btn-info')).toBe( i === row && j === col );
+        expect(optionsRow[j].find('button').hasClass('btn-primary')).toBe( i === row && j === col );
       }
     }
   }
@@ -164,7 +164,7 @@ describe('datepicker directive', function () {
     var options = getAllOptionsEl();
     for (var i = 0; i < 5; i ++) {
       for (var j = 0; j < 7; j ++) {
-        expect(options[i][j].find('button').find('span').hasClass('muted')).toBe( ((i === 0 && j < 3) || (i === 4 && j > 4)) );
+        expect(options[i][j].find('button').find('span').hasClass('text-muted')).toBe( ((i === 0 && j < 3) || (i === 4 && j > 4)) );
       }
     }
   });

--- a/template/datepicker/datepicker.html
+++ b/template/datepicker/datepicker.html
@@ -1,20 +1,29 @@
-<table>
-  <thead>
-    <tr class="text-center">
-      <th><button type="button" class="btn pull-left" ng-click="move(-1)"><i class="icon-chevron-left"></i></button></th>
-      <th colspan="{{rows[0].length - 2 + showWeekNumbers}}"><button type="button" class="btn btn-block" ng-click="toggleMode()"><strong>{{title}}</strong></button></th>
-      <th><button type="button" class="btn pull-right" ng-click="move(1)"><i class="icon-chevron-right"></i></button></th>
+<table style="table-layout:fixed;" class="table-condensed">
+  <!-- secondary: last month, disabled: disabled -->
+  <thead class="text-center">
+    <tr>
+      <th style="overflow: hidden; width: 26px">
+        <button type="button" class="btn btn-xs btn-link" ng-click="move(-1)"> 
+          <span class="glyphicon glyphicon-chevron-left"> </span> 
+        </button>
+      </th>
+      <th colspan="{{rows[0].length - 2 + showWeekNumbers}}"><button type="button" class="btn btn-md btn-link btn-block" ng-click="toggleMode()"><strong>{{title}}</strong></button></th></th>
+      <th style="overflow: hidden; width: 26px">
+        <button type="button" class="btn btn-xs btn-link" ng-click="move(1)"> 
+          <span class="glyphicon glyphicon-chevron-right"> </span> 
+        </button>
+      </th>
     </tr>
-    <tr class="text-center" ng-show="labels.length > 0">
-      <th ng-show="showWeekNumbers">#</th>
-      <th ng-repeat="label in labels">{{label}}</th>
+    <tr ng-show="labels.length > 0">
+      <th class="text-center" ng-show="showWeekNumbers"><h6>#</h6></th>
+      <th class="text-center" ng-repeat="label in labels"><h6>{{label}}</h6></th>
     </tr>
   </thead>
   <tbody>
     <tr ng-repeat="row in rows">
-      <td ng-show="showWeekNumbers" class="text-center"><em>{{ getWeekNumber(row) }}</em></td>
-      <td ng-repeat="dt in row" class="text-center">
-        <button type="button" style="width:100%;" class="btn" ng-class="{'btn-info': dt.selected}" ng-click="select(dt.date)" ng-disabled="dt.disabled"><span ng-class="{muted: dt.secondary}">{{dt.label}}</span></button>
+      <td ng-show="showWeekNumbers" class="text-center" style="overflow: hidden; width: 26px"><button type="button" class="btn btn-xs btn-link" disabled><strong><em>{{ getWeekNumber(row) }}</em></strong></button></td>
+      <td ng-repeat="dt in row" class="text-center" style="overflow: hidden; width: 26px">
+        <button type="button" style="width: 100%; border: 0px" class="btn btn-xs" ng-class="{'btn-primary': dt.selected, 'btn-default': !dt.selected}" ng-click="select(dt.date)" ng-disabled="dt.disabled"><span ng-class="{'text-muted': dt.secondary && !dt.selected}">{{dt.label}}</span></button>
       </td>
     </tr>
   </tbody>

--- a/template/datepicker/popup.html
+++ b/template/datepicker/popup.html
@@ -3,10 +3,10 @@
 	<li class="divider"></li>
 	<li style="padding: 9px;">
 		<span class="btn-group">
-			<button class="btn btn-small btn-inverse" ng-click="today()">Today</button>
-			<button class="btn btn-small btn-info" ng-click="showWeeks = ! showWeeks" ng-class="{active: showWeeks}">Weeks</button>
-			<button class="btn btn-small btn-danger" ng-click="clear()">Clear</button>
+			<button class="btn btn-xs btn-default" ng-click="today()">Today</button>
+			<button class="btn btn-xs btn-info" ng-click="showWeeks = ! showWeeks" ng-class="{active: showWeeks}">Weeks</button>
+			<button class="btn btn-xs btn-danger" ng-click="clear()">Clear</button>
 		</span>
-		<button class="btn btn-small btn-success pull-right" ng-click="isOpen = false">Close</button>
+		<button class="btn btn-xs btn-success pull-right" ng-click="isOpen = false">Close</button>
 	</li>
 </ul>


### PR DESCRIPTION
This redesigns the datepicker to conform to new Bootstrap 3.

As a side note, this is a complete redesign from the original styling of the datepicker. 
- It is now a fixed-width control (240px without weeks, 280px with). This is a fairly natural way to design tabular data where each cell needs to be exactly equal in width. 
- The popup no longer has the buttons at the base of the control. I removed them since this appears to be the primary use case (just a plain ol' calendar... ala http://eternicode.github.io/bootstrap-datepicker/). Since that is handled entirely through templates it's fairly easy to fix if certain controls are needed in the popover. 

That's about it, if anyone dislikes how the new control looks let me know and I can play with it.
