### PR TITLE
Fix #630: Collapse crops content that would overflow.

### DIFF
--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -7,10 +7,10 @@ angular.module('ui.bootstrap.collapse',['ui.bootstrap.transition'])
   // Unfortunately if you do this while the CSS transitions are specified (i.e. in the CSS class
   // "collapse") then you trigger a change to height 0 in between.
   // The fix is to remove the "collapse" CSS class while changing the height back to auto - phew!
-  var fixUpHeight = function(scope, element, height) {
+  var fixUpHeightAndOverflow = function(scope, element, height, overflow) {
     // We remove the collapse CSS class to prevent a transition when we change to height: auto
     element.removeClass('collapse');
-    element.css({ height: height });
+    element.css({ height: height, overflow: overflow });
     // It appears that  reading offsetWidth makes the browser realise that we have changed the
     // height already :-/
     var x = element[0].offsetWidth;
@@ -31,9 +31,9 @@ angular.module('ui.bootstrap.collapse',['ui.bootstrap.transition'])
         if (element[0].scrollHeight !== 0) {
           if (!isCollapsed) {
             if (initialAnimSkip) {
-              fixUpHeight(scope, element, element[0].scrollHeight + 'px');
+              fixUpHeightAndOverflow(scope, element, element[0].scrollHeight + 'px', 'hidden');
             } else {
-              fixUpHeight(scope, element, 'auto');
+              fixUpHeightAndOverflow(scope, element, 'auto', 'visible');
             }
           }
         }
@@ -65,7 +65,7 @@ angular.module('ui.bootstrap.collapse',['ui.bootstrap.transition'])
         if (initialAnimSkip) {
           initialAnimSkip = false;
           if ( !isCollapsed ) {
-            fixUpHeight(scope, element, 'auto');
+            fixUpHeightAndOverflow(scope, element, 'auto', 'visible');
           }
         } else {
           doTransition({ height : element[0].scrollHeight + 'px' })
@@ -73,7 +73,7 @@ angular.module('ui.bootstrap.collapse',['ui.bootstrap.transition'])
             // This check ensures that we don't accidentally update the height if the user has closed
             // the group while the animation was still running
             if ( !isCollapsed ) {
-              fixUpHeight(scope, element, 'auto');
+              fixUpHeightAndOverflow(scope, element, 'auto', 'visible');
             }
           });
         }
@@ -84,12 +84,13 @@ angular.module('ui.bootstrap.collapse',['ui.bootstrap.transition'])
         isCollapsed = true;
         if (initialAnimSkip) {
           initialAnimSkip = false;
-          fixUpHeight(scope, element, 0);
+          fixUpHeightAndOverflow(scope, element, 0, 'hidden');
         } else {
-          fixUpHeight(scope, element, element[0].scrollHeight + 'px');
+          fixUpHeightAndOverflow(scope, element, element[0].scrollHeight + 'px', 'hidden');
           doTransition({'height':'0'});
         }
       };
     }
   };
 }]);
+


### PR DESCRIPTION
- Added overflow visible to the elements style when the expand transition is complete.
- overflow hidden is restored to the element before the collapse transition starts.
