### PR TITLE
style(pagination): fixed for bootstrap3 support

### DIFF
--- a/src/pagination/docs/demo.html
+++ b/src/pagination/docs/demo.html
@@ -5,9 +5,9 @@
     <pagination boundary-links="true" num-pages="noOfPages" current-page="currentPage" class="pagination-small" previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></pagination>
     <pagination direction-links="false" boundary-links="true" num-pages="noOfPages" current-page="currentPage"></pagination>
     <pagination direction-links="false" num-pages="noOfPages" current-page="currentPage"></pagination>
-
-    <button class="btn" ng-click="setPage(3)">Set current page to: 3</button>
-    The selected page no: {{currentPage}}
+    <div><button class="btn btn-info" ng-click="setPage(3)">Set current page to: 3</button></div>
+    <hr />
+    <pre>The selected page no: {{currentPage}}</pre>
 
     <hr />
     <h4>Pager</h4>

--- a/src/pagination/test/pagination.spec.js
+++ b/src/pagination/test/pagination.spec.js
@@ -11,8 +11,8 @@ describe('pagination directive with default configuration', function () {
     $rootScope.$digest();
   }));
 
-  it('has a "pagination" css class', function() {
-    expect(element.hasClass('pagination')).toBe(true);
+  it('has a "pagination" css class on the ul element', function() {
+    expect(element.find('ul').eq(0).hasClass('pagination')).toBe(true);
   });
 
   it('contains one ul and num-pages + 2 li elements', function() {
@@ -414,8 +414,8 @@ describe('pagination directive with just number links', function () {
     $rootScope.$digest();
   }));
 
-  it('has a "pagination" css class', function() {
-    expect(element.hasClass('pagination')).toBe(true);
+  it('has a "pagination" css class on the ul element', function() {
+    expect(element.find('ul').eq(0).hasClass('pagination')).toBe(true);
   });
 
   it('contains one ul and num-pages li elements', function() {

--- a/template/pagination/pagination.html
+++ b/template/pagination/pagination.html
@@ -1,4 +1,4 @@
-<div class="pagination"><ul>
+<div><ul class="pagination">
   <li ng-repeat="page in pages" ng-class="{active: page.active, disabled: page.disabled}"><a ng-click="selectPage(page.number)">{{page.text}}</a></li>
   </ul>
 </div>


### PR DESCRIPTION
Tiny fix here. BS3 requires the pagination class to be on the UL instead of a parent element now. Updated demo, template and tests to conform to that.
