### PR TITLE
fix(rating): change icons to new glyphicon naming convention

### DIFF
--- a/src/rating/docs/demo.html
+++ b/src/rating/docs/demo.html
@@ -1,11 +1,11 @@
 <div ng-controller="RatingDemoCtrl">
     <rating value="rate" max="max" readonly="isReadonly" on-hover="hoveringOver(value)" on-leave="overStar = null"></rating>
-    <span class="badge badge-inverse" ng-show="overStar && !isReadonly">{{overStar}} / {{max}}</span>
+    <span class="badge" ng-show="overStar && !isReadonly">{{overStar}} / {{max}}</span>
 
     <hr/>
     <pre>Rate: <b>{{rate}}</b> - Readonly is: <i>{{isReadonly}}</i> - Hovering over: <b>{{overStar || "none"}}</b></pre>
 
     <hr/>
     <button class="btn btn-small btn-danger" ng-click="rate = 0" ng-disabled="isReadonly">Clear</button>
-    <button class="btn btn-small" ng-click="isReadonly = ! isReadonly">Toggle Readonly</button>
+    <button class="btn btn-small btn-primary" ng-click="isReadonly = ! isReadonly">Toggle Readonly</button>
 </div>

--- a/src/rating/test/rating.spec.js
+++ b/src/rating/test/rating.spec.js
@@ -22,7 +22,7 @@ describe('rating directive', function () {
     var stars = getStars();
     var state = [];
     for (var i = 0, n = stars.length; i < n; i++) {
-      state.push( (stars.eq(i).hasClass('icon-star') && ! stars.eq(i).hasClass('icon-star-empty')) );
+      state.push( (stars.eq(i).hasClass('glyphicon glyphicon-star') && ! stars.eq(i).hasClass('glyphicon glyphicon-star-empty')) );
     }
     return state;
   }

--- a/template/rating/rating.html
+++ b/template/rating/rating.html
@@ -1,3 +1,3 @@
 <span ng-mouseleave="reset()">
-	<i ng-repeat="number in range" ng-mouseenter="enter(number)" ng-click="rate(number)" ng-class="{'icon-star': number <= val, 'icon-star-empty': number > val}"></i>
+	<i ng-repeat="number in range" ng-mouseenter="enter(number)" ng-click="rate(number)" ng-class="{'glyphicon glyphicon-star': number <= val, 'glyphicon glyphicon-star-empty': number > val}"></i>
 </span>


### PR DESCRIPTION
There's a bunch of hasClass tests in this one as well. Instead of deleting them, I'm thinking as we approach framework-agnostic design we implement these hasClass methods as model changes (`element.click()` a star and `expect($scope.rating).toBe(x)`). Didn't do this now as it's a little outside the scope of converting to BS3.
