### PR TITLE
feat(dialog): rewrite $dialog

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -1,47 +1,287 @@
-angular.module('ui.bootstrap.modal', ['ui.bootstrap.dialog'])
-.directive('modal', ['$parse', '$dialog', function($parse, $dialog) {
-  return {
-    restrict: 'EA',
-    terminal: true,
-    link: function(scope, elm, attrs) {
-      var opts = angular.extend({}, scope.$eval(attrs.uiOptions || attrs.bsOptions || attrs.options));
-      var shownExpr = attrs.modal || attrs.show;
-      var setClosed;
+angular.module('ui.bootstrap.modal', [])
 
-      // Create a dialog with the template as the contents of the directive
-      // Add the current scope as the resolve in order to make the directive scope as a dialog controller scope
-      opts = angular.extend(opts, {
-        template: elm.html(), 
-        resolve: { $scope: function() { return scope; } }
-      });
-      var dialog = $dialog.dialog(opts);
+/**
+ * A helper, internal data structure that acts as a map but also allows getting / removing
+ * elements in the LIFO order
+ */
+  .factory('$$stackedMap', function () {
+    return {
+      createNew: function () {
+        var stack = [];
 
-      elm.remove();
-
-      if (attrs.close) {
-        setClosed = function() {
-          $parse(attrs.close)(scope);
-        };
-      } else {
-        setClosed = function() {         
-          if (angular.isFunction($parse(shownExpr).assign)) {
-            $parse(shownExpr).assign(scope, false); 
+        return {
+          add: function (key, value) {
+            stack.push({
+              key: key,
+              value: value
+            });
+          },
+          get: function (key) {
+            for (var i = 0; i < stack.length; i++) {
+              if (key == stack[i].key) {
+                return stack[i];
+              }
+            }
+          },
+          top: function () {
+            return stack[stack.length - 1];
+          },
+          remove: function (key) {
+            var idx = -1;
+            for (var i = 0; i < stack.length; i++) {
+              if (key == stack[i].key) {
+                idx = i;
+                break;
+              }
+            }
+            return stack.splice(idx, 1)[0];
+          },
+          removeTop: function () {
+            return stack.splice(stack.length - 1, 1)[0];
+          },
+          length: function () {
+            return stack.length;
           }
         };
       }
+    };
+  })
 
-      scope.$watch(shownExpr, function(isShown, oldShown) {
-        if (isShown) {
-          dialog.open().then(function(){
-            setClosed();
-          });
-        } else {
-          //Make sure it is not opened
-          if (dialog.isOpen()){
-            dialog.close();
+/**
+ * A helper directive for the $modal service. It creates a backdrop element.
+ */
+  .directive('modalBackdrop', ['$modalStack', '$timeout', function ($modalStack, $timeout) {
+    return {
+      restrict: 'EA',
+      scope: {},
+      replace: true,
+      templateUrl: 'template/modal/backdrop.html',
+      link: function (scope, element, attrs) {
+
+        //trigger CSS transitions
+        $timeout(function () {
+          scope.animate = true;
+        }, 0, false);
+
+        scope.close = function (evt) {
+          var modal = $modalStack.getTop();
+          //TODO: this logic is duplicated with the place where modal gets opened
+          if (modal && modal.window.backdrop && modal.window.backdrop != 'static') {
+            evt.preventDefault();
+            evt.stopPropagation();
+            $modalStack.dismiss(modal.instance, 'backdrop click');
+          }
+        };
+      }
+    };
+  }])
+
+  .directive('modalWindow', ['$timeout', function ($timeout) {
+    return {
+      restrict: 'EA',
+      scope: {},
+      replace: true,
+      transclude: true,
+      templateUrl: 'template/modal/window.html',
+      link: function (scope, element, attrs) {
+        //trigger CSS transitions
+        $timeout(function () {
+          scope.animate = true;
+        }, 0, false);
+      }
+    };
+  }])
+
+  .factory('$modalStack', ['$document', '$compile', '$rootScope', '$$stackedMap',
+    function ($document, $compile, $rootScope, $$stackedMap) {
+
+      var body = $document.find('body').eq(0);
+      var openedWindows = $$stackedMap.createNew();
+      var $modalStack = {};
+
+      function removeModalWindow(modalInstance) {
+
+        var modalWindow = openedWindows.get(modalInstance).value;
+
+        //clean up the stack
+        openedWindows.remove(modalInstance);
+
+        //remove DOM element
+        modalWindow.modalDomEl.remove();
+
+        //remove backdrop
+        if (modalWindow.backdropDomEl) {
+          modalWindow.backdropDomEl.remove();
+        }
+
+        //destroy scope
+        modalWindow.modalScope.$destroy();
+      }
+
+      $document.bind('keydown', function (evt) {
+        var modal;
+
+        if (evt.which === 27) {
+          modal = openedWindows.top();
+          if (modal && modal.value.keyboard) {
+            $rootScope.$apply(function () {
+              $modalStack.dismiss(modal.key);
+            });
           }
         }
       });
-    }
-  };
-}]);
+
+      $modalStack.open = function (modalInstance, modal) {
+
+        var backdropDomEl;
+        var modalDomEl = $compile(angular.element('<modal-window>').html(modal.content))(modal.scope);
+        body.append(modalDomEl);
+
+        if (modal.backdrop) {
+          backdropDomEl = $compile(angular.element('<modal-backdrop>'))($rootScope);
+          body.append(backdropDomEl);
+        }
+
+        openedWindows.add(modalInstance, {
+          deferred: modal.deferred,
+          modalScope: modal.scope,
+          modalDomEl: modalDomEl,
+          backdrop: modal.backdrop,
+          backdropDomEl: backdropDomEl,
+          keyboard: modal.keyboard
+        });
+      };
+
+      $modalStack.close = function (modalInstance, result) {
+        var modal = openedWindows.get(modalInstance);
+        if (modal) {
+          modal.value.deferred.resolve(result);
+          removeModalWindow(modalInstance);
+        }
+      };
+
+      $modalStack.dismiss = function (modalInstance, reason) {
+        var modalWindow = openedWindows.get(modalInstance).value;
+        if (modalWindow) {
+          modalWindow.deferred.reject(reason);
+          removeModalWindow(modalInstance);
+        }
+      };
+
+      $modalStack.getTop = function () {
+        var top = openedWindows.top();
+        if (top) {
+          return {
+            instance: top.key,
+            window: top.value
+          };
+        }
+      };
+
+      return $modalStack;
+    }])
+
+  .provider('$modal', function () {
+
+    var defaultOptions = {
+      backdrop: true, //can be also false or 'static'
+      keyboard: true
+    };
+
+    return {
+      options: defaultOptions,
+      $get: ['$injector', '$rootScope', '$q', '$http', '$templateCache', '$controller', '$modalStack',
+        function ($injector, $rootScope, $q, $http, $templateCache, $controller, $modalStack) {
+
+          var $modal = {};
+
+          function getTemplatePromise(options) {
+            return options.template ? $q.when(options.template) :
+              $http.get(options.templateUrl, {cache: $templateCache}).then(function (result) {
+                return result.data;
+              });
+          }
+
+          function getResolvePromises(resolves) {
+            var promisesArr = [];
+            angular.forEach(resolves, function (value, key) {
+              if (angular.isFunction(value) || angular.isArray(value)) {
+                promisesArr.push($q.when($injector.invoke(value)));
+              }
+            });
+            return promisesArr;
+          }
+
+          $modal.open = function (modalOptions) {
+
+            var modalResultDeferred = $q.defer();
+            var modalOpenedDeferred = $q.defer();
+
+            //prepare an instance of a modal to be injected into controllers and returned to a caller
+            var modalInstance = {
+              result: modalResultDeferred.promise,
+              opened: modalOpenedDeferred.promise,
+              close: function (result) {
+                $modalStack.close(this, result);
+              },
+              dismiss: function (reason) {
+                $modalStack.dismiss(this, reason);
+              }
+            };
+
+            //merge and clean up options
+            modalOptions = angular.extend(defaultOptions, modalOptions);
+            modalOptions.resolve = modalOptions.resolve || {};
+
+            //verify options
+            if (!modalOptions.template && !modalOptions.templateUrl) {
+              throw new Error('One of template or templateUrl options is required.');
+            }
+
+            var templateAndResolvePromise =
+              $q.all([getTemplatePromise(modalOptions)].concat(getResolvePromises(modalOptions.resolve)));
+
+
+            templateAndResolvePromise.then(function resolveSuccess(tplAndVars) {
+
+              var modalScope = (modalOptions.scope || $rootScope).$new();
+
+              var ctrlInstance, ctrlLocals = {};
+              var resolveIter = 1;
+
+              //controllers
+              if (modalOptions.controller) {
+                ctrlLocals.$scope = modalScope;
+                ctrlLocals.$modalInstance = modalInstance;
+                angular.forEach(modalOptions.resolve, function (value, key) {
+                  ctrlLocals[key] = tplAndVars[resolveIter++];
+                });
+
+                ctrlInstance = $controller(modalOptions.controller, ctrlLocals);
+              }
+
+              $modalStack.open(modalInstance, {
+                scope: modalScope,
+                deferred: modalResultDeferred,
+                content: tplAndVars[0],
+                backdrop: modalOptions.backdrop,
+                keyboard: modalOptions.keyboard
+              });
+
+            }, function resolveError(reason) {
+              modalResultDeferred.reject(reason);
+            });
+
+            templateAndResolvePromise.then(function () {
+              modalOpenedDeferred.resolve(true);
+            }, function () {
+              modalOpenedDeferred.reject(false);
+            });
+
+            return modalInstance;
+          };
+
+          return $modal;
+        }]
+    };
+  });

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -1,171 +1,409 @@
-describe('Give ui.boostrap.modal', function() {
+describe('$modal', function () {
+  var $rootScope, $document, $compile, $templateCache, $timeout, $q;
+  var $modal, $modalProvider;
 
-	var $document, $compile, $scope, $rootScope, provider;
+  var triggerKeyDown = function (element, keyCode) {
+    var e = $.Event("keydown");
+    e.which = keyCode;
+    element.trigger(e);
+  };
 
-	beforeEach(module('ui.bootstrap.modal'));
+  beforeEach(module('ui.bootstrap.modal'));
+  beforeEach(module('template/modal/backdrop.html'));
+  beforeEach(module('template/modal/window.html'));
+  beforeEach(module(function(_$modalProvider_){
+    $modalProvider = _$modalProvider_;
+  }));
 
-	beforeEach(function(){
-		module(function($dialogProvider){
-			provider = $dialogProvider;
-		});
-		inject(function(_$document_, _$compile_, _$rootScope_){
-			$document = _$document_;
-			$compile = _$compile_;
-			$scope = _$rootScope_.$new();
-			$rootScope = _$rootScope_;
-		});
-	});
+  beforeEach(inject(function (_$rootScope_, _$document_, _$compile_, _$templateCache_, _$timeout_, _$q_, _$modal_) {
+    $rootScope = _$rootScope_;
+    $document = _$document_;
+    $compile = _$compile_;
+    $templateCache = _$templateCache_;
+    $timeout = _$timeout_;
+    $q = _$q_;
+    $modal = _$modal_;
+  }));
 
-	var elm;
+  beforeEach(inject(function ($rootScope) {
+    this.addMatchers({
 
-	var templateGenerator = function(expr, scopeExpressionContent, closeExpr) {
-		var additionalExpression = scopeExpressionContent ? scopeExpressionContent : '';
-		var closingExpr = closeExpr ? ' close="' + closeExpr + '" ': '';
-		return '<div modal="' + expr + '" options="modalOpts"' + closingExpr + '>' +
-					additionalExpression + 'Hello!</div>';
-	};
+      toBeResolvedWith: function(value) {
+        var resolved;
+        this.message = function() {
+          return "Expected '" + angular.mock.dump(this.actual) + "' to be resolved with '" + value + "'.";
+        };
+        this.actual.then(function(result){
+          resolved = result;
+        });
+        $rootScope.$digest();
 
-	it('should have just one backdrop', function() {
-		var numberOfSimultaneousModals = 5;
-		var elems = [];
-		for (var i = 0; i< 5; i++) {
-			elems[i] = $compile(templateGenerator('modalShown' + i))($scope);
-			$scope.$apply('modalShown' + i + ' = true');
-		}	
-		expect($document.find('body > div.modal-backdrop').length).toBe(1);
-		expect($document.find('body > div.modal').length).toBe(numberOfSimultaneousModals);
+        return resolved === value;
+      },
 
-		for (i = 0; i< 5; i++) {
-			$scope.$apply('modalShown' + i + ' = false');
-		}	
-	});
+      toBeRejectedWith: function(value) {
+        var rejected;
+        this.message = function() {
+          return "Expected '" + angular.mock.dump(this.actual) + "' to be rejected with '" + value + "'.";
+        };
+        this.actual.then(angular.noop, function(reason){
+          rejected = reason;
+        });
+        $rootScope.$digest();
 
-	it('should work with expression instead of a variable', function() {			
-		$scope.foo = true;
-		$scope.shown = function() { return $scope.foo; };
-		elm = $compile(templateGenerator('shown()'))($scope);
-		$scope.$apply();
-		expect($document.find('body > div.modal').length).toBe(1);
-		$scope.$apply('foo = false');
-		expect($document.find('body > div.modal').length).toBe(0);
-	});
+        return rejected === value;
+      },
 
-	it('should work with a close expression and escape close', function() {
-		$scope.bar = true;
-		$scope.show = function() { return $scope.bar; };
-		elm = $compile(templateGenerator('show()', ' ', 'bar=false'))($scope);
-		$scope.$apply();
-		expect($document.find('body > div.modal').length).toBe(1);
-		var e = $.Event('keydown');
-		e.which = 27;
-		$document.find('body').trigger(e);
-		expect($document.find('body > div.modal').length).toBe(0);
-		expect($scope.bar).not.toBeTruthy();
-	});
+      toHaveModalOpenWithContent: function(content, selector) {
 
-	it('should work with a close expression and backdrop close', function() {
-		$scope.baz = 1;
-		$scope.hello = function() { return $scope.baz===1; };
-		elm = $compile(templateGenerator('hello()', ' ', 'baz=0'))($scope);
-		$scope.$apply();
-		expect($document.find('body > div.modal').length).toBe(1);
-		$document.find('body > div.modal-backdrop').click();
-		expect($document.find('body > div.modal').length).toBe(0);
-		expect($scope.baz).toBe(0);
-	});
+        var contentToCompare, modalDomEls = this.actual.find('body > div.modal');
 
-	it('should not close on escape if option is false', function() {
-		$scope.modalOpts = {keyboard:false};
-		elm = $compile(templateGenerator('modalShown'))($scope);
-		$scope.modalShown = true;
-		$scope.$apply();
-		var e = $.Event('keydown');
-		e.which = 27;
-		expect($document.find('body > div.modal').length).toBe(1);
-		$document.find('body').trigger(e);
-		expect($document.find('body > div.modal').length).toBe(1);
-		$scope.$apply('modalShown = false');
-	});
+        this.message = function() {
+          return "Expected '" + angular.mock.dump(modalDomEls) + "' to be open with '" + content + "'.";
+        };
 
-	it('should not close on backdrop click if option is false', function() {
-		$scope.modalOpts = {backdropClick:false};
-		elm = $compile(templateGenerator('modalShown'))($scope);
-		$scope.modalShown = true;
-		$scope.$apply();
-		expect($document.find('body > div.modal').length).toBe(1);
-		$document.find('body > div.modal-backdrop').click();
-		expect($document.find('body > div.modal').length).toBe(1);
-		$scope.$apply('modalShown = false');
-	});
+        contentToCompare = selector ? modalDomEls.find(selector) : modalDomEls;
+        return modalDomEls.css('display') === 'block' &&  contentToCompare.html() == content;
+      },
 
-	it('should use global $dialog options', function() {
-		elm = $compile(templateGenerator('modalShown'))($scope);
-		expect($document.find('.test-open-modal').length).toBe(0);
-		$scope.$apply('modalShown = true');
-		expect($document.find('body > div.modal').length).toBe(1);
-		$scope.$apply('modalShown = false');
-	});
+      toHaveModalsOpen: function(noOfModals) {
 
-	describe('dialog generated should have directives scope', function() {
+        var modalDomEls = this.actual.find('body > div.modal');
+        return modalDomEls.length === noOfModals;
+      },
 
-		afterEach(function() {
-			$scope.$apply('modalShown = false');
-		});
+      toHaveBackdrop: function() {
 
-		it('should call scope methods', function() {
-			var clickSpy = jasmine.createSpy('localScopeFunction');
-			$scope.myFunc = clickSpy;
-			elm = $compile(templateGenerator('modalShown', '<button ng-click="myFunc()">Click</button>'))($scope);
-			$scope.$apply('modalShown = true');
-			$document.find('body > div.modal button').click();
-			expect(clickSpy).toHaveBeenCalled();
-		});
+        var backdropDomEls = this.actual.find('body > div.modal-backdrop');
+        this.message = function() {
+          return "Expected '" + angular.mock.dump(backdropDomEls) + "' to be a backdrop element'.";
+        };
 
-		it('should resolve scope vars', function() {
-			$scope.buttonName = 'my button';
-			elm = $compile(templateGenerator('modalShown', '<button>{{buttonName}}</button>'))($scope);
-			$scope.$apply('modalShown = true');
-			expect($document.find('body > div.modal button').text()).toBe('my button');
-		});
+        return backdropDomEls.length === 1;
+      }
+    });
+  }));
 
-	});
+  afterEach(function () {
+    var body = $document.find('body');
+    body.find('div.modal').remove();
+    body.find('div.modal-backdrop').remove();
+  });
 
-	describe('toogle modal dialog on model change', function() {
+  function open(modalOptions) {
+    var modal = $modal.open(modalOptions);
+    $rootScope.$digest();
+    return modal;
+  }
 
-		beforeEach(function(){
-			elm = $compile(templateGenerator('modalShown'))($scope);
-			$scope.$apply('modalShown = true');
-		});
+  function close(modal, result) {
+    modal.close(result);
+    $rootScope.$digest();
+  }
 
-		afterEach(function() {
-			$scope.$apply('modalShown = false');
-		});
+  function dismiss(modal, reason) {
+    modal.dismiss(reason);
+    $rootScope.$digest();
+  }
 
-		it('the backdrop should be displayed if specified (true by default)', function(){
-			expect($document.find('body > div.modal-backdrop').css('display')).toBe('block');
-		});
+  describe('basic scenarios with default options', function () {
 
-		it('the modal should be displayed', function(){
-			expect($document.find('body > div.modal').css('display')).toBe('block');
-		});
+    it('should open and dismiss a modal with a minimal set of options', function () {
 
-		it('the modal should not be displayed', function(){
-			$scope.$apply('modalShown = false');
-			expect($document.find('body > div.modal').length).toBe(0);
-		});
+      var modal = open({template: '<div>Content</div>'});
 
-		it('should update the model if the backdrop is clicked', function() {
-			$document.find('body > div.modal-backdrop').click();
-			$scope.$digest();
-			expect($scope.modalShown).not.toBeTruthy();
-		});
+      expect($document).toHaveModalsOpen(1);
+      expect($document).toHaveModalOpenWithContent('Content', 'div');
+      expect($document).toHaveBackdrop();
 
-		it('should update the model if the esc is pressed', function() {
-			var e = $.Event('keydown');
-			e.which = 27;
-			$document.find('body').trigger(e);
-			$scope.$digest();
-			expect($scope.modalShown).not.toBeTruthy();
-		});
-	});
+      dismiss(modal, 'closing in test');
+
+      expect($document).toHaveModalsOpen(0);
+      expect($document).not.toHaveBackdrop();
+    });
+
+    it('should open a modal from templateUrl', function () {
+
+      $templateCache.put('content.html', '<div>URL Content</div>');
+      var modal = open({templateUrl: 'content.html'});
+
+      expect($document).toHaveModalsOpen(1);
+      expect($document).toHaveModalOpenWithContent('URL Content', 'div');
+      expect($document).toHaveBackdrop();
+
+      dismiss(modal, 'closing in test');
+
+      expect($document).toHaveModalsOpen(0);
+      expect($document).not.toHaveBackdrop();
+    });
+
+    it('should support closing on ESC', function () {
+
+      var modal = open({template: '<div>Content</div>'});
+      expect($document).toHaveModalsOpen(1);
+
+      triggerKeyDown($document, 27);
+      $rootScope.$digest();
+
+      expect($document).toHaveModalsOpen(0);
+    });
+
+    it('should support closing on backdrop click', function () {
+
+      var modal = open({template: '<div>Content</div>'});
+      expect($document).toHaveModalsOpen(1);
+
+      $document.find('body > div.modal-backdrop').click();
+      $rootScope.$digest();
+
+      expect($document).toHaveModalsOpen(0);
+    });
+
+    it('should resolve returned promise on close', function () {
+      var modal = open({template: '<div>Content</div>'});
+      close(modal, 'closed ok');
+
+      expect(modal.result).toBeResolvedWith('closed ok');
+    });
+
+    it('should reject returned promise on dismiss', function () {
+
+      var modal = open({template: '<div>Content</div>'});
+      dismiss(modal, 'esc');
+
+      expect(modal.result).toBeRejectedWith('esc');
+    });
+
+    it('should expose a promise linked to the templateUrl / resolve promises', function () {
+      var modal = open({template: '<div>Content</div>', resolve: {
+          ok: function() {return $q.when('ok');}
+        }}
+      );
+      expect(modal.opened).toBeResolvedWith(true);
+    });
+
+    it('should expose a promise linked to the templateUrl / resolve promises and reject it if needed', function () {
+      var modal = open({template: '<div>Content</div>', resolve: {
+          ok: function() {return $q.reject('ko');}
+        }}
+      );
+      expect(modal.opened).toBeRejectedWith(false);
+    });
+
+  });
+
+  describe('default options can be changed in a provider', function () {
+
+    it('should allow overriding default options in a provider', function () {
+
+      $modalProvider.options.backdrop = false;
+      var modal = open({template: '<div>Content</div>'});
+
+      expect($document).toHaveModalOpenWithContent('Content', 'div');
+      expect($document).not.toHaveBackdrop();
+    });
+  });
+
+  describe('option by option', function () {
+
+    describe('template and templateUrl', function () {
+
+      it('should throw an error if none of template and templateUrl are provided', function () {
+        expect(function(){
+          var modal = open({});
+        }).toThrow(new Error('One of template or templateUrl options is required.'));
+      });
+
+      it('should not fail if a templateUrl contains leading / trailing white spaces', function () {
+
+        $templateCache.put('whitespace.html', '  <div>Whitespaces</div>  ');
+        open({templateUrl: 'whitespace.html'});
+        expect($document).toHaveModalOpenWithContent('Whitespaces', 'div');
+      });
+
+    });
+
+    describe('controllers', function () {
+
+      it('should accept controllers and inject modal instances', function () {
+
+        var TestCtrl = function($scope, $modalInstance) {
+          $scope.fromCtrl = 'Content from ctrl';
+          $scope.isModalInstance = angular.isObject($modalInstance) && angular.isFunction($modalInstance.close);
+        };
+
+        var modal = open({template: '<div>{{fromCtrl}} {{isModalInstance}}</div>', controller: TestCtrl});
+        expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
+      });
+    });
+
+    describe('resolve', function () {
+
+      var ExposeCtrl = function($scope, value) {
+        $scope.value = value;
+      };
+
+      function modalDefinition(template, resolve) {
+        return {
+          template: template,
+          controller: ExposeCtrl,
+          resolve: resolve
+        };
+      }
+
+      it('should resolve simple values', function () {
+        open(modalDefinition('<div>{{value}}</div>', {
+          value: function () {
+            return 'Content from resolve';
+          }
+        }));
+
+        expect($document).toHaveModalOpenWithContent('Content from resolve', 'div');
+      });
+
+      it('should delay showing modal if one of the resolves is a promise', function () {
+
+        open(modalDefinition('<div>{{value}}</div>', {
+          value: function () {
+            return $timeout(function(){ return 'Promise'; }, 100);
+          }
+        }));
+        expect($document).toHaveModalsOpen(0);
+
+        $timeout.flush();
+        expect($document).toHaveModalOpenWithContent('Promise', 'div');
+      });
+
+      it('should not open dialog (and reject returned promise) if one of resolve fails', function () {
+
+        var deferred = $q.defer();
+
+        var modal = open(modalDefinition('<div>{{value}}</div>', {
+          value: function () {
+            return deferred.promise;
+          }
+        }));
+        expect($document).toHaveModalsOpen(0);
+
+        deferred.reject('error in test');
+        $rootScope.$digest();
+
+        expect($document).toHaveModalsOpen(0);
+        expect(modal.result).toBeRejectedWith('error in test');
+      });
+
+      it('should support injection with minification-safe syntax in resolve functions', function () {
+
+        open(modalDefinition('<div>{{value.id}}</div>', {
+          value: ['$locale', function (e) {
+            return e;
+          }]
+        }));
+
+        expect($document).toHaveModalOpenWithContent('en-us', 'div');
+      });
+
+      //TODO: resolves with dependency injection - do we want to support them?
+    });
+
+    describe('scope', function () {
+
+      it('should custom scope if provided', function () {
+        var $scope = $rootScope.$new();
+        $scope.fromScope = 'Content from custom scope';
+        open({
+          template: '<div>{{fromScope}}</div>',
+          scope: $scope
+        });
+        expect($document).toHaveModalOpenWithContent('Content from custom scope', 'div');
+      });
+    });
+
+    describe('keyboard', function () {
+
+      it('should not close modals if keyboard option is set to false', function () {
+        open({
+          template: '<div>No keyboard</div>',
+          keyboard: false
+        });
+
+        expect($document).toHaveModalsOpen(1);
+
+        triggerKeyDown($document, 27);
+        $rootScope.$digest();
+
+        expect($document).toHaveModalsOpen(1);
+      });
+    });
+
+    describe('backdrop', function () {
+
+      it('should not have any backdrop element if backdrop set to false', function () {
+        open({
+          template: '<div>No backdrop</div>',
+          backdrop: false
+        });
+        expect($document).toHaveModalOpenWithContent('No backdrop', 'div');
+        expect($document).not.toHaveBackdrop();
+      });
+
+      it('should not close modal on backdrop click if backdrop is specified as "static"', function () {
+        open({
+          template: '<div>Static backdrop</div>',
+          backdrop: 'static'
+        });
+
+        $document.find('body > div.modal-backdrop').click();
+        $rootScope.$digest();
+
+        expect($document).toHaveModalOpenWithContent('Static backdrop', 'div');
+        expect($document).toHaveBackdrop();
+      });
+    });
+  });
+
+  describe('multiple modals', function () {
+
+    it('it should allow opening of multiple modals', function () {
+
+      var modal1 = open({template: '<div>Modal1</div>'});
+      var modal2 = open({template: '<div>Modal2</div>'});
+      expect($document).toHaveModalsOpen(2);
+
+      dismiss(modal2);
+      expect($document).toHaveModalsOpen(1);
+      expect($document).toHaveModalOpenWithContent('Modal1', 'div');
+
+      dismiss(modal1);
+      expect($document).toHaveModalsOpen(0);
+    });
+
+    it('should not close any modals on ESC if the topmost one does not allow it', function () {
+
+      var modal1 = open({template: '<div>Modal1</div>'});
+      var modal2 = open({template: '<div>Modal2</div>', keyboard: false});
+
+      triggerKeyDown($document, 27);
+      $rootScope.$digest();
+
+      expect($document).toHaveModalsOpen(2);
+    });
+
+    it('should not close any modals on click if a topmost modal does not have backdrop', function () {
+
+      var modal1 = open({template: '<div>Modal1</div>'});
+      var modal2 = open({template: '<div>Modal2</div>', backdrop: false});
+
+      $document.find('body > div.modal-backdrop').click();
+      $rootScope.$digest();
+
+      expect($document).toHaveModalsOpen(2);
+    });
+  });
+
+  //TODO: tests to write:
+  //- go over opened issues and see if anything needs covering
+  //- documentation!!!
+  //$location.path() changes and closing modal
+    //- this probably should be configurable....
 });

--- a/src/modal/test/stackedMap.spec.js
+++ b/src/modal/test/stackedMap.spec.js
@@ -1,0 +1,50 @@
+describe('stacked map', function () {
+
+  var stackedMap;
+
+  beforeEach(module('ui.bootstrap.modal'));
+  beforeEach(inject(function ($$stackedMap) {
+    stackedMap = $$stackedMap.createNew();
+  }));
+
+  it('should add and remove objects by key', function () {
+
+    stackedMap.add('foo', 'foo_value');
+    expect(stackedMap.length()).toEqual(1);
+    expect(stackedMap.get('foo').key).toEqual('foo');
+    expect(stackedMap.get('foo').value).toEqual('foo_value');
+
+    stackedMap.remove('foo');
+    expect(stackedMap.length()).toEqual(0);
+    expect(stackedMap.get('foo')).toBeUndefined();
+  });
+
+  it('should get topmost element', function () {
+
+    stackedMap.add('foo', 'foo_value');
+    stackedMap.add('bar', 'bar_value');
+    expect(stackedMap.length()).toEqual(2);
+
+    expect(stackedMap.top().key).toEqual('bar');
+    expect(stackedMap.length()).toEqual(2);
+  });
+
+  it('should remove topmost element', function () {
+
+    stackedMap.add('foo', 'foo_value');
+    stackedMap.add('bar', 'bar_value');
+
+    expect(stackedMap.removeTop().key).toEqual('bar');
+    expect(stackedMap.removeTop().key).toEqual('foo');
+  });
+
+  it('should preserve semantic of an empty stackedMap', function () {
+
+    expect(stackedMap.length()).toEqual(0);
+    expect(stackedMap.top()).toBeUndefined();
+  });
+
+  it('should ignore removal of non-existing elements', function () {
+    expect(stackedMap.remove('non-existing')).toBeUndefined();
+  });
+});

--- a/template/modal/backdrop.html
+++ b/template/modal/backdrop.html
@@ -1,0 +1,1 @@
+<div class="modal-backdrop fade" ng-class="{in: animate}" ng-click="close($event)"></div>

--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,0 +1,1 @@
+<div class="modal fade" ng-class="{in: animate}" ng-transclude></div>


### PR DESCRIPTION
I think that at this point it is cleat to everyone that the current `$dialog` service got in a state where it is hardy maintainable. There are tons of issues opened for it and some of the design decisions make it impossible to move forward with the current code. 

I'm in the process of re-writing the current service and the modal directive, will try to push the first version for review over the weekend (if everything goes as planned). 

Going to close all the existing issues for `$dialog` and 'modal' as a duplicate of this  one.

As a reminder, early draft of the design is available here: 
https://gist.github.com/ajoslin/5477996

@ajoslin I'm not sure if keeping is as gist is the best thing at the moment as I can't easily modify it. Not sure how to progress - I can fork of course but how do we merge all the versions? Anyway I will be working on the forked gist for now.
