### PR TITLE
fix(collapse): rewrite collapse plugin to work with BS3 classes

### DIFF
--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -2,94 +2,87 @@ angular.module('ui.bootstrap.collapse',['ui.bootstrap.transition'])
 
 // The collapsible directive indicates a block of html that will expand and collapse
 .directive('collapse', ['$transition', function($transition) {
-  // CSS transitions don't work with height: auto, so we have to manually change the height to a
-  // specific value and then once the animation completes, we can reset the height to auto.
-  // Unfortunately if you do this while the CSS transitions are specified (i.e. in the CSS class
-  // "collapse") then you trigger a change to height 0 in between.
-  // The fix is to remove the "collapse" CSS class while changing the height back to auto - phew!
-  var fixUpHeight = function(scope, element, height) {
-    // We remove the collapse CSS class to prevent a transition when we change to height: auto
-    element.removeClass('collapse');
+
+  var setHeight = function(element, height) {
     element.css({ height: height });
     // It appears that  reading offsetWidth makes the browser realise that we have changed the
     // height already :-/
     var x = element[0].offsetWidth;
-    element.addClass('collapse');
+    return element;
   };
+
+  var currentTransition;
+  var doTransition = function(element, change) {
+    if ( currentTransition ) {
+      currentTransition.cancel();
+    }
+    currentTransition = $transition(element, change);
+    currentTransition.then(
+      function() { currentTransition = undefined; },
+      function() { currentTransition = undefined; }
+    );
+    return currentTransition;
+  };
+
 
   return {
     link: function(scope, element, attrs) {
 
-      var isCollapsed;
-      var initialAnimSkip = true;
-      scope.$watch(function (){ return element[0].scrollHeight; }, function (value) {
-        //The listener is called when scollHeight changes
-        //It actually does on 2 scenarios: 
-        // 1. Parent is set to display none
-        // 2. angular bindings inside are resolved
-        //When we have a change of scrollHeight we are setting again the correct height if the group is opened
-        if (element[0].scrollHeight !== 0) {
-          if (!isCollapsed) {
-            if (initialAnimSkip) {
-              fixUpHeight(scope, element, element[0].scrollHeight + 'px');
-            } else {
-              fixUpHeight(scope, element, 'auto');
-            }
-          }
-        }
-      });
-      
-      scope.$watch(attrs.collapse, function(value) {
-        if (value) {
-          collapse();
-        } else {
-          expand();
-        }
-      });
-      
+      var initialAnimSkipped = false, isCollapsed;
 
-      var currentTransition;
-      var doTransition = function(change) {
-        if ( currentTransition ) {
-          currentTransition.cancel();
-        }
-        currentTransition = $transition(element,change);
-        currentTransition.then(
-          function() { currentTransition = undefined; },
-          function() { currentTransition = undefined; }
-        );
-        return currentTransition;
-      };
+      function expand(skipAnim) {
+        setHeight(element, 0)
+          .removeClass('collapse')
+          .addClass('collapsing');
 
-      var expand = function() {
-        if (initialAnimSkip) {
-          initialAnimSkip = false;
-          if ( !isCollapsed ) {
-            fixUpHeight(scope, element, 'auto');
-          }
+        var elHeight = element[0].scrollHeight;
+
+        if (skipAnim) {
+          initialAnimSkipped = true;
+          setHeight(element, elHeight);
         } else {
-          doTransition({ height : element[0].scrollHeight + 'px' })
-          .then(function() {
-            // This check ensures that we don't accidentally update the height if the user has closed
-            // the group while the animation was still running
-            if ( !isCollapsed ) {
-              fixUpHeight(scope, element, 'auto');
-            }
-          });
+          doTransition(element, {height: elHeight})
+            .then(function() {
+              element.removeClass('collapsing');
+              setHeight(element, 'auto').addClass('in');
+              isCollapsed = false;
+            });
         }
-        isCollapsed = false;
-      };
-      
-      var collapse = function() {
+      }
+
+      function collapse(skipAnim) {
         isCollapsed = true;
-        if (initialAnimSkip) {
-          initialAnimSkip = false;
-          fixUpHeight(scope, element, 0);
+        var elHeight = element[0].scrollHeight;
+
+        if (skipAnim) {
+          initialAnimSkipped = true;
+          element
+            .removeClass('in')
+            .addClass('collapse');
         } else {
-          fixUpHeight(scope, element, element[0].scrollHeight + 'px');
-          doTransition({'height':'0'});
+          setHeight(element, elHeight)
+            .removeClass('in')
+            .addClass('collapsing');
+
+          doTransition(element, { height: 0 })
+            .then(function() {
+              setHeight(element, 0)
+                .removeClass('collapsing')
+                .addClass('collapse')
+                .css({height: ''});
+            });
         }
-      };
+      }
+
+      scope.$watch(attrs.collapse, function(value) {
+        var animate = initialAnimSkipped ? false : true;
+        if (value) {
+          collapse(animate);
+        } else {
+          expand(animate);
+        }
+      });
+
     }
   };
 }]);


### PR DESCRIPTION
Hi!

I managed to get the collapse/accordion functionality working properly a while back, but haven't been able to get the tests passing.

I believe the reason is that BS3 uses a class based approach, whereas the current tests rely on inline styling. So of course I looked to see about loading the bootstrap sheet for Karma tests, but it is not supported for the version ui-bootstrap uses. From what I can tell Karma added support for CSS in 0.9.5, but upgrading to the latest version involved redoing the karma.conf file, which seemed like a whole other can of worms to me :smiley: 

So, feel free to use this as a basis for the collapse rewrite. It could probably use some refactoring. Otherwise if you have some pointers, I'd be happy to assist.

Brief synopsis of what the new classes are doing:

 `.collapse` represents `display: none`,

 `.in` represents `display: block; height: auto`, and `.collapsing` takes care of removing `height: auto` for transitions.
