### PR TITLE
fix(tabs): evaluate `vertical` on parent scope

### DIFF
--- a/src/tabs/docs/readme.md
+++ b/src/tabs/docs/readme.md
@@ -12,6 +12,10 @@ AngularJS version of the tabs directive.
  	_(Defaults: 'tabs')_ :
  	Navigation type. Possible values are 'tabs' and 'pills'.
 
+ * `direction`
+ 	_(Defaults: null)_ :
+ 	What direction the tabs should be rendered. Available: 'right', 'left', 'below'.
+
 #### `<tab>` ####
 
  * `heading` or `<tab-heading>`

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -85,7 +85,7 @@ function TabsetCtrl($scope, $element) {
     templateUrl: 'template/tabs/tabset.html',
     compile: function(elm, attrs, transclude) {
       return function(scope, element, attrs, tabsetCtrl) {
-        scope.vertical = angular.isDefined(attrs.vertical) ? scope.$eval(attrs.vertical) : false;
+        scope.vertical = angular.isDefined(attrs.vertical) ? scope.$parent.$eval(attrs.vertical) : false;
         scope.type = angular.isDefined(attrs.type) ? scope.$parent.$eval(attrs.type) : 'tabs';
         scope.direction = angular.isDefined(attrs.direction) ? scope.$parent.$eval(attrs.direction) : 'top';
         scope.tabsAbove = (scope.direction != 'below');

--- a/src/tabs/test/tabsSpec.js
+++ b/src/tabs/test/tabsSpec.js
@@ -468,8 +468,8 @@ describe('tabs', function() {
   describe('vertical', function() {
     beforeEach(inject(function($compile, $rootScope) {
       scope = $rootScope.$new();
-
-      elm = $compile('<tabset vertical="true"></tabset>')(scope);
+      scope.vertical = true;
+      elm = $compile('<tabset vertical="vertical"></tabset>')(scope);
       scope.$apply();
     }));
 


### PR DESCRIPTION
Closes #849.
