### PR TITLE
feat(modal): added bootstrap3 support

### DIFF
--- a/src/modal/docs/demo.html
+++ b/src/modal/docs/demo.html
@@ -17,6 +17,6 @@
         </div>
     </script>
 
-    <button class="btn" ng-click="open()">Open me!</button>
+    <button class="btn btn-default" ng-click="open()">Open me!</button>
     <div ng-show="selected">Selection from a modal: {{ selected }}</div>
 </div>

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -56,7 +56,7 @@ describe('$modal', function () {
 
       toHaveModalOpenWithContent: function(content, selector) {
 
-        var contentToCompare, modalDomEls = this.actual.find('body > div.modal');
+        var contentToCompare, modalDomEls = this.actual.find('body > div.modal > div.modal-dialog > div.modal-content');
 
         this.message = function() {
           return "Expected '" + angular.mock.dump(modalDomEls) + "' to be open with '" + content + "'.";
@@ -153,7 +153,7 @@ describe('$modal', function () {
       var modal = open({template: '<div>Content</div>'});
       expect($document).toHaveModalsOpen(1);
 
-      $document.find('body > div.modal-backdrop').click();
+      $document.find('body > div.modal').click();
       $rootScope.$digest();
 
       expect($document).toHaveModalsOpen(0);

--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,1 +1,3 @@
-<div class="modal fade" ng-class="{in: animate}" ng-transclude></div>
+<div class="modal fade" ng-class="{in: animate}" style="display: block" ng-click="close($event)">
+	<div class="modal-dialog"><div class="modal-content" ng-transclude></div></div>
+</div>


### PR DESCRIPTION
Updated for the new branch.

I added the `modal-open` class when a modal opens and remove it when it closes, but this may open a can of worms. In Bootstrap 3 they decided to add a modals scrollbar to the `modal` itself, rather than `modal-body`. 

This is causing a 15px shift in the rest of the body, because the modal scrollbar is absolutely positioned (whereas the body's is not). This is still being worked on per https://github.com/twbs/bootstrap/issues/9855. The last response to this  suggests to progmatically determine how wide the scrollbar is on that particular browser, than add a `margin-right` to the body to offset the difference between the scrollbars. The only way I'm aware of how to do this is to make a hidden element, add it to the dom and get the difference between the `element.clientWidth` and the `element.offsetWidth`. Totally worth it to have the scrollbars on the `body` rather than `modal-body`, right? :angry:

The other issue we may run into, that I haven't tested, is that stacked modals _may_ have multiple scrollbars. So if we have 2 modals in the stack, 2 scrollbars may show. I haven't really tested this so maybe the absolute positioning of the modals will render that moot (the scrollbar of the top modal may overlay the modal below it... hopefully).
