### PR TITLE
fix(typeahead): Keep pop-up open on clicking input field

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -378,6 +378,23 @@ describe('typeahead tests', function () {
       expect($scope.email).toEqual('bar@host.com');
       expect(inputEl.val()).toEqual('bar@host.com');
     });
+
+    it('does not close matches popup on click in input', function () {
+      var element = prepareInputEl("<div><input ng-model='result' typeahead='item for item in source | filter:$viewValue'></div>");
+      var inputEl = findInput(element);
+
+      // Note that this bug can only be found when element is in the document
+      $document.find('body').append(element);
+      // Extra teardown for this spec
+      this.after(function () { element.remove(); });
+
+      changeInputValueTo(element, 'b');
+
+      inputEl.click();
+      $scope.$digest();
+
+      expect(element).toBeOpenWithActive(2, 0);
+    });
   });
 
   describe('input formatting', function () {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -243,9 +243,18 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position'])
         }
       });
 
-      $document.bind('click', function(){
-        resetMatches();
-        scope.$digest();
+      // Keep reference to click handler to unbind it.
+      var dismissClickHandler = function (evt) {
+        if (element[0] !== evt.target) {
+          resetMatches();
+          scope.$digest();
+        }
+      };
+
+      $document.bind('click', dismissClickHandler);
+
+      originalScope.$on('$destroy', function(){
+        $document.unbind('click', dismissClickHandler);
       });
 
       element.after($compile(popUpEl)(scope));


### PR DESCRIPTION
This follows the behavior of typeahead in Bootstrap 2.3.2, where you can click and modify the text in the input field while keeping the pop-up open.

Also, keep reference to event listener to unbind when scope is destroyed (memory leak).
