### PR TITLE
refactor(typeahead): Add typeahead controller (WIP)

### DIFF
--- a/src/typeahead/test/typeahead-popup.spec.js
+++ b/src/typeahead/test/typeahead-popup.spec.js
@@ -48,14 +48,13 @@ describe('typeaheadPopup - result rendering', function () {
 
     scope.matches = ['foo', 'bar', 'baz'];
     scope.active = 1;
-    $rootScope.select = angular.noop;
-    spyOn($rootScope, 'select');
+    $rootScope.typeaheadCtrl = jasmine.createSpyObj('typeaheadCtrl', ['_selectActive']);
 
     var el = $compile('<div><typeahead-popup matches="matches" active="active" select="select(activeIdx)"></typeahead-popup></div>')(scope);
     $rootScope.$digest();
 
     var liElems = el.find('li');
     liElems.eq(2).find('a').trigger('click');
-    expect($rootScope.select).toHaveBeenCalledWith(2);
+    expect($rootScope.typeaheadCtrl._selectActive).toHaveBeenCalledWith(2);
   });
 });

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -29,14 +29,118 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
   };
 }])
 
+  .controller('typeaheadController', [
+             '$scope', '$compile', '$q', '$attrs', '$parse', '$element', '$position', 'typeaheadParser',
+    function ($scope ,  $compile ,  $q ,  $attrs ,  $parse ,  $element ,  $position ,  typeaheadParser) {
+
+      var ctrl = this;
+
+      //binding to a variable that indicates if matches are being retrieved asynchronously
+      var isLoadingSetter = $parse($attrs.typeaheadLoading).assign || angular.noop;
+
+      var appendToBody =  $attrs.typeaheadAppendToBody ? $scope.$eval($attrs.typeaheadAppendToBody) : false;
+
+      //INTERNAL VARIABLES
+
+      //expressions used by typeahead
+      var parserResult = typeaheadParser.parse($attrs.typeahead);
+
+      //create a child scope for the typeahead directive so we are not polluting original scope
+      //with typeahead-specific data (matches, query etc.)
+      var taScope = this.taScope = $scope.$new();
+      taScope.typeaheadCtrl = this;
+
+      ctrl.setQuery = function (query) {
+        ctrl.query = query;
+        if (!query && query !== '') {
+          resetMatches();
+          return;
+        }
+        ctrl.getMatches(query);
+      };
+
+      ctrl.getMatches = function(inputValue) {
+
+        var locals = {$viewValue: inputValue};
+        isLoadingSetter($scope, true);
+        $q.when(parserResult.source($scope, locals)).then(function(matches) {
+
+          //it might happen that several async queries were in progress if a user were typing fast
+          //but we are interested only in responses that correspond to the current view value
+          if (inputValue === ctrl.query) {
+            if (matches.length > 0) {
+
+              taScope.activeIdx = 0;
+              taScope.matches.length = 0;
+
+              //transform labels
+              for(var i=0; i<matches.length; i++) {
+                locals[parserResult.itemName] = matches[i];
+                taScope.matches.push({
+                  label: parserResult.viewMapper($scope, locals),
+                  model: matches[i]
+                });
+              }
+
+              taScope.query = inputValue;
+              //position pop-up with matches - we need to re-calculate its position each time we are opening a window
+              //with matches as a pop-up might be absolute-positioned and position of an input might have changed on a page
+              //due to other elements being rendered
+              taScope.position = appendToBody ? $position.offset($element) : $position.position($element);
+              taScope.position = $position.position($element);
+              taScope.position.top = taScope.position.top + $element.prop('offsetHeight');
+
+            } else {
+              resetMatches();
+            }
+            isLoadingSetter($scope, false);
+          }
+        }, function(){
+          resetMatches();
+          isLoadingSetter($scope, false);
+        });
+      };
+
+      resetMatches();
+
+      //pop-up element used to display matches
+      var popUpEl = angular.element('<div typeahead-popup></div>');
+      popUpEl.attr({
+        typeaheadCtrl: 'typeaheadCtrl',
+        matches: 'matches',
+        active: 'activeIdx',
+        select: 'select(activeIdx)',
+        query: 'query',
+        position: 'position'
+      });
+      //custom item template
+      if (angular.isDefined($attrs.typeaheadTemplateUrl)) {
+        popUpEl.attr('template-url', $attrs.typeaheadTemplateUrl);
+      }
+
+      function resetMatches() {
+        taScope.matches = [];
+        taScope.activeIdx = -1;
+        isLoadingSetter($scope, false);
+      }
+
+      ctrl.popUpEl = $compile(popUpEl)(taScope);
+    }
+  ])
+
   .directive('typeahead', ['$compile', '$parse', '$q', '$timeout', '$document', '$position', 'typeaheadParser',
     function ($compile, $parse, $q, $timeout, $document, $position, typeaheadParser) {
 
   var HOT_KEYS = [9, 13, 27, 38, 40];
 
   return {
-    require:'ngModel',
-    link:function (originalScope, element, attrs, modelCtrl) {
+    require: ['typeahead', 'ngModel'],
+    controller: 'typeaheadController',
+    link:function (originalScope, element, attrs, controllers) {
+
+      var typeaheadCtrl = controllers[0],
+          modelCtrl = controllers[1],
+          scope = typeaheadCtrl.taScope;
 
       //SUPPORTED ATTRIBUTES (OPTIONS)
 
@@ -45,9 +149,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       //minimal wait time after last character typed before typehead kicks-in
       var waitTime = originalScope.$eval(attrs.typeaheadWaitMs) || 0;
-
-      //binding to a variable that indicates if matches are being retrieved asynchronously
-      var isLoadingSetter = $parse(attrs.typeaheadLoading).assign || angular.noop;
 
       //a callback executed when a match is selected
       var onSelectCallback = $parse(attrs.typeaheadOnSelect);
@@ -64,77 +165,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //expressions used by typeahead
       var parserResult = typeaheadParser.parse(attrs.typeahead);
 
-      var hasFocus;
-
-      //pop-up element used to display matches
-      var popUpEl = angular.element('<div typeahead-popup></div>');
-      popUpEl.attr({
-        matches: 'matches',
-        active: 'activeIdx',
-        select: 'select(activeIdx)',
-        query: 'query',
-        position: 'position'
-      });
-      //custom item template
-      if (angular.isDefined(attrs.typeaheadTemplateUrl)) {
-        popUpEl.attr('template-url', attrs.typeaheadTemplateUrl);
-      }
-
-      //create a child scope for the typeahead directive so we are not polluting original scope
-      //with typeahead-specific data (matches, query etc.)
-      var scope = originalScope.$new();
-      originalScope.$on('$destroy', function(){
-        scope.$destroy();
-      });
-
-      var resetMatches = function() {
-        scope.matches = [];
-        scope.activeIdx = -1;
-      };
-
-      var getMatchesAsync = function(inputValue) {
-
-        var locals = {$viewValue: inputValue};
-        isLoadingSetter(originalScope, true);
-        $q.when(parserResult.source(originalScope, locals)).then(function(matches) {
-
-          //it might happen that several async queries were in progress if a user were typing fast
-          //but we are interested only in responses that correspond to the current view value
-          if (inputValue === modelCtrl.$viewValue && hasFocus) {
-            if (matches.length > 0) {
-
-              scope.activeIdx = 0;
-              scope.matches.length = 0;
-
-              //transform labels
-              for(var i=0; i<matches.length; i++) {
-                locals[parserResult.itemName] = matches[i];
-                scope.matches.push({
-                  label: parserResult.viewMapper(scope, locals),
-                  model: matches[i]
-                });
-              }
-
-              scope.query = inputValue;
-              //position pop-up with matches - we need to re-calculate its position each time we are opening a window
-              //with matches as a pop-up might be absolute-positioned and position of an input might have changed on a page
-              //due to other elements being rendered
-              scope.position = appendToBody ? $position.offset(element) : $position.position(element);
-              scope.position.top = scope.position.top + element.prop('offsetHeight');
-
-            } else {
-              resetMatches();
-            }
-            isLoadingSetter(originalScope, false);
-          }
-        }, function(){
-          resetMatches();
-          isLoadingSetter(originalScope, false);
-        });
-      };
-
-      resetMatches();
-
       //we need to propagate user's query so we can higlight matches
       scope.query = undefined;
 
@@ -145,21 +175,18 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //$parsers kick-in on all the changes coming from the view as well as manually triggered by $setViewValue
       modelCtrl.$parsers.unshift(function (inputValue) {
 
-        hasFocus = true;
-
         if (inputValue && inputValue.length >= minSearch) {
           if (waitTime > 0) {
             if (timeoutPromise) {
               $timeout.cancel(timeoutPromise);//cancel previous timeout
             }
             timeoutPromise = $timeout(function () {
-              getMatchesAsync(inputValue);
+              typeaheadCtrl.setQuery(inputValue);
             }, waitTime);
           } else {
-            getMatchesAsync(inputValue);
+            typeaheadCtrl.setQuery(inputValue);
           }
         } else {
-          isLoadingSetter(originalScope, false);
           resetMatches();
         }
 
@@ -242,8 +269,8 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         }
       });
 
-      element.bind('blur', function (evt) {
-        hasFocus = false;
+      element.bind('blur', function () {
+        resetMatches();
       });
 
       // Keep reference to click handler to unbind it.
@@ -260,11 +287,14 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         $document.unbind('click', dismissClickHandler);
       });
 
-      var $popup = $compile(popUpEl)(scope);
       if ( appendToBody ) {
-        $document.find('body').append($popup);
+        $document.find('body').append(typeaheadCtrl.popUpEl);
       } else {
-        element.after($popup);
+        element.after(typeaheadCtrl.popUpEl);
+      }
+
+      function resetMatches() {
+        typeaheadCtrl.setQuery(null);
       }
     }
   };

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -42,6 +42,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       //INTERNAL VARIABLES
 
+      //model setter executed upon match selection
+      var $setModelValue = $parse($attrs.ngModel).assign;
+
       //expressions used by typeahead
       var parserResult = typeaheadParser.parse($attrs.typeahead);
 
@@ -49,6 +52,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //with typeahead-specific data (matches, query etc.)
       var taScope = this.taScope = $scope.$new();
       taScope.typeaheadCtrl = this;
+
+      // Called with model, itemDetails (model, {item, model, label})
+      ctrl.selectListeners = [];
 
       ctrl.setQuery = function (query) {
         ctrl.query = query;
@@ -100,6 +106,18 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         });
       };
 
+      ctrl.select = function (match) {
+        $setModelValue($scope, match.model);
+        resetMatches();
+
+        for (var i = 0; i < ctrl.selectListeners.length; i++) {
+          ctrl.selectListeners[i](match.model, match);
+        }
+
+        //return focus to the input element if a mach was selected via a mouse click event
+        $element[0].focus();
+      };
+
       resetMatches();
 
       //pop-up element used to display matches
@@ -108,7 +126,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         typeaheadCtrl: 'typeaheadCtrl',
         matches: 'matches',
         active: 'activeIdx',
-        select: 'select(activeIdx)',
+        select: 'typeaheadCtrl.select(matches[activeIdx])',
         query: 'query',
         position: 'position'
       });
@@ -149,17 +167,11 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //minimal wait time after last character typed before typehead kicks-in
       var waitTime = originalScope.$eval(attrs.typeaheadWaitMs) || 0;
 
-      //a callback executed when a match is selected
-      var onSelectCallback = $parse(attrs.typeaheadOnSelect);
-
       var inputFormatter = attrs.typeaheadInputFormatter ? $parse(attrs.typeaheadInputFormatter) : undefined;
 
       var appendToBody =  attrs.typeaheadAppendToBody ? originalScope.$eval(attrs.typeaheadAppendToBody) : false;
 
       //INTERNAL VARIABLES
-
-      //model setter executed upon match selection
-      var $setModelValue = $parse(attrs.ngModel).assign;
 
       //expressions used by typeahead
       var parserResult = typeaheadParser.parse(attrs.typeahead);
@@ -215,28 +227,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         }
       });
 
-      scope.select = function (activeIdx) {
-        //called from within the $digest() cycle
-        var selectedMatch = scope.matches[activeIdx],
-          item  = selectedMatch.item,
-          model = selectedMatch.model,
-          label = selectedMatch.label;
-
-        $setModelValue(originalScope, model);
-        modelCtrl.$setValidity('editable', true);
-
-        onSelectCallback(originalScope, {
-          $item: item,
-          $model: model,
-          $label: label
-        });
-
-        resetMatches();
-
-        //return focus to the input element if a mach was selected via a mouse click event
-        element[0].focus();
-      };
-
       //bind keyboard events: arrows up(38) / down(40), enter(13) and tab(9), esc(27)
       element.bind('keydown', function (evt) {
 
@@ -257,7 +247,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
         } else if (evt.which === 13 || evt.which === 9) {
           scope.$apply(function () {
-            scope.select(scope.activeIdx);
+            typeaheadCtrl.select(scope.matches[scope.activeIdx]);
           });
 
         } else if (evt.which === 27) {
@@ -352,12 +342,40 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
     };
   }])
 
+  .directive('typeaheadOnSelect', [
+             '$parse',
+    function ($parse) {
+      return {
+        restrict: 'A',
+        require: 'typeahead',
+        link: function (scope, element, attrs, typeaheadCtrl) {
+
+          //a callback executed when a match is selected
+          var onSelectCallback = $parse(attrs.typeaheadOnSelect);
+
+          typeaheadCtrl.selectListeners.push(function (model, match) {
+            onSelectCallback(scope, {
+              $item: match.item,
+              $model: match.model,
+              $label: match.label
+            });
+          });
+
+        }
+      };
+    }
+  ])
+
+
   .directive('typeaheadEditable', [
     function () {
       return {
         restrict: 'A',
-        require: 'ngModel',
-        link: function (scope, element, attrs, ngModelCtrl) {
+        require: ['ngModel', 'typeahead'],
+        link: function (scope, element, attrs, controllers) {
+
+          var ngModelCtrl = controllers[0],
+              typeaheadCtrl = controllers[1];
 
           //should it restrict model values to the ones selected from the popup only?
           var isEditable = scope.$eval(attrs.typeaheadEditable) !== false;
@@ -376,6 +394,10 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
                 return undefined;
               }
             }
+          });
+
+          typeaheadCtrl.selectListeners.push(function () {
+            ngModelCtrl.$setValidity('editable', true);
           });
         }
       };

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -199,9 +199,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       //SUPPORTED ATTRIBUTES (OPTIONS)
 
-      //minimal no of characters that needs to be entered before typeahead kicks-in
-      var minSearch = originalScope.$eval(attrs.typeaheadMinLength) || 1;
-
       //minimal wait time after last character typed before typehead kicks-in
       var waitTime = originalScope.$eval(attrs.typeaheadWaitMs) || 0;
 
@@ -221,7 +218,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //$parsers kick-in on all the changes coming from the view as well as manually triggered by $setViewValue
       modelCtrl.$parsers.unshift(function (inputValue) {
 
-        if (inputValue && inputValue.length >= minSearch) {
+        if (inputValue) {
           if (waitTime > 0) {
             if (timeoutPromise) {
               $timeout.cancel(timeoutPromise);//cancel previous timeout
@@ -376,6 +373,27 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       }
     };
   }])
+
+  .directive('typeaheadMinLength', [
+    function () {
+      return {
+        restrict: 'A',
+        require: 'typeahead',
+        link: function (scope, element, attrs, typeaheadCtrl) {
+
+          //minimal no of characters that needs to be entered before typeahead kicks-in
+          var minSearch = scope.$eval(attrs.typeaheadMinLength) || 1;
+
+          typeaheadCtrl.queryParsers.push(function (value) {
+            if (value.length >= minSearch) {
+              return value;
+            }
+          });
+
+        }
+      };
+    }
+  ])
 
   .directive('typeaheadOnSelect', [
              '$parse',

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -78,7 +78,8 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
                 locals[parserResult.itemName] = matches[i];
                 taScope.matches.push({
                   label: parserResult.viewMapper($scope, locals),
-                  model: matches[i]
+                  model: parserResult.modelMapper($scope, locals),
+                  item: matches[i]
                 });
               }
 
@@ -216,18 +217,18 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       scope.select = function (activeIdx) {
         //called from within the $digest() cycle
-        var locals = {};
-        var model, item;
+        var selectedMatch = scope.matches[activeIdx],
+          item  = selectedMatch.item,
+          model = selectedMatch.model,
+          label = selectedMatch.label;
 
-        locals[parserResult.itemName] = item = scope.matches[activeIdx].model;
-        model = parserResult.modelMapper(originalScope, locals);
         $setModelValue(originalScope, model);
         modelCtrl.$setValidity('editable', true);
 
         onSelectCallback(originalScope, {
           $item: item,
           $model: model,
-          $label: parserResult.viewMapper(originalScope, locals)
+          $label: label
         });
 
         resetMatches();

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -46,7 +46,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       var $setModelValue = $parse($attrs.ngModel).assign;
 
       //expressions used by typeahead
-      var parserResult = typeaheadParser.parse($attrs.typeahead);
+      ctrl.parserResult = typeaheadParser.parse($attrs.typeahead);
 
       //create a child scope for the typeahead directive so we are not polluting original scope
       //with typeahead-specific data (matches, query etc.)
@@ -91,7 +91,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
         var locals = {$viewValue: inputValue};
         isLoadingSetter($scope, true);
-        $q.when(parserResult.source($scope, locals)).then(function(matches) {
+        $q.when(ctrl.parserResult.source($scope, locals)).then(function(matches) {
 
           //it might happen that several async queries were in progress if a user were typing fast
           //but we are interested only in responses that correspond to the current view value
@@ -103,10 +103,10 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
               //transform labels
               for(var i=0; i<matches.length; i++) {
-                locals[parserResult.itemName] = matches[i];
+                locals[ctrl.parserResult.itemName] = matches[i];
                 ctrl.matches.push({
-                  label: parserResult.viewMapper($scope, locals),
-                  model: parserResult.modelMapper($scope, locals),
+                  label: ctrl.parserResult.viewMapper($scope, locals),
+                  model: ctrl.parserResult.modelMapper($scope, locals),
                   item: matches[i]
                 });
               }
@@ -205,9 +205,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       //INTERNAL VARIABLES
 
-      //expressions used by typeahead
-      var parserResult = typeaheadParser.parse(attrs.typeahead);
-
       //plug into modelCtrl pipeline to open a typeahead on view changes
       modelCtrl._$setViewValue = modelCtrl.$setViewValue;
       modelCtrl.$setViewValue = function (inputValue) {
@@ -235,10 +232,10 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
           //it might happen that we don't have enough info to properly render input value
           //we need to check for this situation and simply return model value if we can't apply custom formatting
-          locals[parserResult.itemName] = modelValue;
-          candidateViewValue = parserResult.viewMapper(originalScope, locals);
-          locals[parserResult.itemName] = undefined;
-          emptyViewValue = parserResult.viewMapper(originalScope, locals);
+          locals[typeaheadCtrl.parserResult.itemName] = modelValue;
+          candidateViewValue = typeaheadCtrl.parserResult.viewMapper(originalScope, locals);
+          locals[typeaheadCtrl.parserResult.itemName] = undefined;
+          emptyViewValue = typeaheadCtrl.parserResult.viewMapper(originalScope, locals);
 
           return candidateViewValue!== emptyViewValue ? candidateViewValue : modelValue;
         }

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -120,6 +120,21 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         $element[0].focus();
       };
 
+      ctrl._selectActive = function (activeIdx) {
+        if (typeof activeIdx != 'undefined') {
+          ctrl.activeIdx = activeIdx;
+        }
+        ctrl.select(ctrl.matches[ctrl.activeIdx]);
+      };
+
+      ctrl._nextMatch = function () {
+        ctrl.activeIdx = (ctrl.activeIdx + 1) % ctrl.matches.length;
+      };
+
+      ctrl._prevMatch = function () {
+        ctrl.activeIdx = (ctrl.activeIdx ? ctrl.activeIdx : ctrl.matches.length) - 1;
+      };
+
       resetMatches();
 
       //pop-up element used to display matches
@@ -128,7 +143,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         typeaheadCtrl: 'typeaheadCtrl',
         matches: 'typeaheadCtrl.matches',
         active: 'typeaheadCtrl.activeIdx',
-        select: 'typeaheadCtrl.select(typeaheadCtrl.matches[activeIdx])',
+        select: 'typeaheadCtrl._selectActive(activeIdx)',
         query: 'typeaheadCtrl.query',
         position: 'typeaheadCtrl.position'
       });
@@ -238,16 +253,16 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         evt.preventDefault();
 
         if (evt.which === 40) {
-          typeaheadCtrl.activeIdx = (typeaheadCtrl.activeIdx + 1) % typeaheadCtrl.matches.length;
+          typeaheadCtrl._nextMatch();
           scope.$digest();
 
         } else if (evt.which === 38) {
-          typeaheadCtrl.activeIdx = (typeaheadCtrl.activeIdx ? typeaheadCtrl.activeIdx : typeaheadCtrl.matches.length) - 1;
+          typeaheadCtrl._prevMatch();
           scope.$digest();
 
         } else if (evt.which === 13 || evt.which === 9) {
           scope.$apply(function () {
-            typeaheadCtrl.select(typeaheadCtrl.matches[typeaheadCtrl.activeIdx]);
+            typeaheadCtrl._selectActive();
           });
 
         } else if (evt.which === 27) {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -89,15 +89,13 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
               taScope.position = appendToBody ? $position.offset($element) : $position.position($element);
               taScope.position = $position.position($element);
               taScope.position.top = taScope.position.top + $element.prop('offsetHeight');
-
+              isLoadingSetter($scope, false);
             } else {
               resetMatches();
             }
-            isLoadingSetter($scope, false);
           }
         }, function(){
           resetMatches();
-          isLoadingSetter($scope, false);
         });
       };
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -46,9 +46,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //minimal wait time after last character typed before typehead kicks-in
       var waitTime = originalScope.$eval(attrs.typeaheadWaitMs) || 0;
 
-      //should it restrict model values to the ones selected from the popup only?
-      var isEditable = originalScope.$eval(attrs.typeaheadEditable) !== false;
-
       //binding to a variable that indicates if matches are being retrieved asynchronously
       var isLoadingSetter = $parse(attrs.typeaheadLoading).assign || angular.noop;
 
@@ -166,18 +163,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
           resetMatches();
         }
 
-        if (isEditable) {
-          return inputValue;
-        } else {
-          if (!inputValue) {
-            // Reset in case user had typed something previously.
-            modelCtrl.$setValidity('editable', true);
-            return inputValue;
-          } else {
-            modelCtrl.$setValidity('editable', false);
-            return undefined;
-          }
-        }
+        return inputValue;
       });
 
       modelCtrl.$formatters.push(function (modelValue) {
@@ -336,6 +322,36 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       }
     };
   }])
+
+  .directive('typeaheadEditable', [
+    function () {
+      return {
+        restrict: 'A',
+        require: 'ngModel',
+        link: function (scope, element, attrs, ngModelCtrl) {
+
+          //should it restrict model values to the ones selected from the popup only?
+          var isEditable = scope.$eval(attrs.typeaheadEditable) !== false;
+
+          // push instead of unshift as this has to come after the parser added by typeahead
+          ngModelCtrl.$parsers.push(function (inputValue) {
+            if (isEditable) {
+              return inputValue;
+            } else {
+              if (!inputValue) {
+                // Reset in case user had typed something previously.
+                ngModelCtrl.$setValidity('editable', true);
+                return inputValue;
+              } else {
+                ngModelCtrl.$setValidity('editable', false);
+                return undefined;
+              }
+            }
+          });
+        }
+      };
+    }
+  ])
 
   .filter('typeaheadHighlight', function() {
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -55,6 +55,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       // promises.
       ctrl.queryParsers = [];
 
+      // FIXME: Remove when switching to isolate scope
+      ctrl.mouseIsOver = false;
+
       // Check this value to see if it's the latest query
       var lastQuery = null;
 
@@ -180,7 +183,8 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         active: 'typeaheadCtrl.activeIdx',
         select: 'typeaheadCtrl._selectActive(activeIdx)',
         query: 'typeaheadCtrl.query',
-        position: 'typeaheadCtrl.position'
+        position: 'typeaheadCtrl.position',
+        mouseisover: 'typeaheadCtrl.mouseIsOver'
       });
       //custom item template
       if (angular.isDefined($attrs.typeaheadTemplateUrl)) {
@@ -270,7 +274,10 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       });
 
       element.bind('blur', function () {
-        resetMatches();
+        if (!typeaheadCtrl.mouseIsOver) {
+          resetMatches();
+          scope.$digest();
+        }
       });
 
       // Keep reference to click handler to unbind it.
@@ -309,6 +316,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         query:'=',
         active:'=',
         position:'=',
+        mouseIsOver:'=mouseisover',
         select:'&'
       },
       replace:true,

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -53,6 +53,19 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       var taScope = this.taScope = $scope.$new();
       taScope.typeaheadCtrl = this;
 
+      ctrl.inputFormatter = function (scope, locals) {
+        var candidateViewValue, emptyViewValue;
+
+        //it might happen that we don't have enough info to properly render input value
+        //we need to check for this situation and simply return model value if we can't apply custom formatting
+        locals[ctrl.parserResult.itemName] = locals.$model;
+        candidateViewValue = ctrl.parserResult.viewMapper(scope, locals);
+        locals[ctrl.parserResult.itemName] = undefined;
+        emptyViewValue = ctrl.parserResult.viewMapper(scope, locals);
+
+        return candidateViewValue !== emptyViewValue ? candidateViewValue : locals.$model;
+      };
+
       // Called with model, itemDetails (model, {item, model, label})
       ctrl.selectListeners = [];
 
@@ -199,8 +212,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       //SUPPORTED ATTRIBUTES (OPTIONS)
 
-      var inputFormatter = attrs.typeaheadInputFormatter ? $parse(attrs.typeaheadInputFormatter) : undefined;
-
       var appendToBody =  attrs.typeaheadAppendToBody ? originalScope.$eval(attrs.typeaheadAppendToBody) : false;
 
       //INTERNAL VARIABLES
@@ -220,25 +231,11 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       modelCtrl.$formatters.push(function (modelValue) {
 
-        var candidateViewValue, emptyViewValue;
-        var locals = {};
+        var locals = {
+          $model: modelValue
+        };
 
-        if (inputFormatter) {
-
-          locals['$model'] = modelValue;
-          return inputFormatter(originalScope, locals);
-
-        } else {
-
-          //it might happen that we don't have enough info to properly render input value
-          //we need to check for this situation and simply return model value if we can't apply custom formatting
-          locals[typeaheadCtrl.parserResult.itemName] = modelValue;
-          candidateViewValue = typeaheadCtrl.parserResult.viewMapper(originalScope, locals);
-          locals[typeaheadCtrl.parserResult.itemName] = undefined;
-          emptyViewValue = typeaheadCtrl.parserResult.viewMapper(originalScope, locals);
-
-          return candidateViewValue!== emptyViewValue ? candidateViewValue : modelValue;
-        }
+        return typeaheadCtrl.inputFormatter(originalScope, locals);
       });
 
       //bind keyboard events: arrows up(38) / down(40), enter(13) and tab(9), esc(27)
@@ -465,6 +462,21 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
           typeaheadCtrl.selectListeners.push(function () {
             ngModelCtrl.$setValidity('editable', true);
           });
+        }
+      };
+    }
+  ])
+
+  .directive('typeaheadInputFormatter', [
+             '$parse',
+    function ($parse) {
+      return {
+        restrict: 'A',
+        require: 'typeahead',
+        link: function (scope, element, attrs, typeaheadCtrl) {
+          if (attrs.typeaheadInputFormatter) {
+            typeaheadCtrl.inputFormatter = $parse(attrs.typeaheadInputFormatter);
+          }
         }
       };
     }

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -183,8 +183,8 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
     }
   ])
 
-  .directive('typeahead', ['$compile', '$parse', '$q', '$timeout', '$document', 'typeaheadParser',
-    function ($compile, $parse, $q, $timeout, $document, typeaheadParser) {
+  .directive('typeahead', ['$compile', '$parse', '$document', 'typeaheadParser',
+    function ($compile, $parse, $document, typeaheadParser) {
 
   var HOT_KEYS = [9, 13, 27, 38, 40];
 
@@ -199,9 +199,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       //SUPPORTED ATTRIBUTES (OPTIONS)
 
-      //minimal wait time after last character typed before typehead kicks-in
-      var waitTime = originalScope.$eval(attrs.typeaheadWaitMs) || 0;
-
       var inputFormatter = attrs.typeaheadInputFormatter ? $parse(attrs.typeaheadInputFormatter) : undefined;
 
       var appendToBody =  attrs.typeaheadAppendToBody ? originalScope.$eval(attrs.typeaheadAppendToBody) : false;
@@ -211,24 +208,12 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //expressions used by typeahead
       var parserResult = typeaheadParser.parse(attrs.typeahead);
 
-      //Declare the timeout promise var outside the function scope so that stacked calls can be cancelled later 
-      var timeoutPromise;
-
       //plug into $parsers pipeline to open a typeahead on view changes initiated from DOM
       //$parsers kick-in on all the changes coming from the view as well as manually triggered by $setViewValue
       modelCtrl.$parsers.unshift(function (inputValue) {
 
         if (inputValue) {
-          if (waitTime > 0) {
-            if (timeoutPromise) {
-              $timeout.cancel(timeoutPromise);//cancel previous timeout
-            }
-            timeoutPromise = $timeout(function () {
-              typeaheadCtrl.setQuery(inputValue);
-            }, waitTime);
-          } else {
-            typeaheadCtrl.setQuery(inputValue);
-          }
+          typeaheadCtrl.setQuery(inputValue);
         } else {
           resetMatches();
         }
@@ -389,6 +374,37 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
               return value;
             }
           });
+
+        }
+      };
+    }
+  ])
+
+  .directive('typeaheadWaitMs', [
+             '$timeout',
+    function ($timeout) {
+      return {
+        restrict: 'A',
+        require: 'typeahead',
+        link: function (scope, element, attrs, typeaheadCtrl) {
+
+          //minimal wait time after last character typed before typehead kicks-in
+          var waitTime = scope.$eval(attrs.typeaheadWaitMs) || 0;
+
+          if (waitTime > 0) {
+            //Declare the timeout promise var outside the function scope so that stacked calls can be cancelled later
+            var timeoutPromise;
+
+            typeaheadCtrl.queryParsers.push(function (value) {
+              if (timeoutPromise) {
+                $timeout.cancel(timeoutPromise);//cancel previous timeout
+              }
+              timeoutPromise = $timeout(function () {
+                return value;
+              }, waitTime);
+              return timeoutPromise;
+            });
+          }
 
         }
       };

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -29,7 +29,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
   };
 }])
 
-  .controller('typeaheadController', [
+  .controller('TypeaheadController', [
              '$scope', '$compile', '$q', '$attrs', '$parse', '$element', '$position', 'typeaheadParser',
     function ($scope ,  $compile ,  $q ,  $attrs ,  $parse ,  $element ,  $position ,  typeaheadParser) {
 
@@ -203,7 +203,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
   return {
     require: ['typeahead', 'ngModel'],
-    controller: 'typeaheadController',
+    controller: 'TypeaheadController',
     link:function (originalScope, element, attrs, controllers) {
 
       var typeaheadCtrl = controllers[0],

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -36,7 +36,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       var ctrl = this;
 
       //binding to a variable that indicates if matches are being retrieved asynchronously
-      var isLoadingSetter = $parse($attrs.typeaheadLoading).assign || angular.noop;
+      ctrl.setIsLoading = angular.noop;
 
       var appendToBody =  $attrs.typeaheadAppendToBody ? $scope.$eval($attrs.typeaheadAppendToBody) : false;
 
@@ -103,7 +103,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         lastMatchInputValue = inputValue;
 
         var locals = {$viewValue: inputValue};
-        isLoadingSetter($scope, true);
+        ctrl.setIsLoading($scope, true);
         $q.when(ctrl.parserResult.source($scope, locals)).then(function(matches) {
 
           //it might happen that several async queries were in progress if a user were typing fast
@@ -130,7 +130,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
               //due to other elements being rendered
               ctrl.position = appendToBody ? $position.offset($element) : $position.position($element);
               ctrl.position.top = ctrl.position.top + $element.prop('offsetHeight');
-              isLoadingSetter($scope, false);
+              ctrl.setIsLoading($scope, false);
             } else {
               resetMatches();
             }
@@ -189,7 +189,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         lastMatchInputValue = null;
         ctrl.matches = [];
         ctrl.activeIdx = -1;
-        isLoadingSetter($scope, false);
+        ctrl.setIsLoading($scope, false);
       }
 
       ctrl.popUpEl = $compile(popUpEl)(taScope);
@@ -477,6 +477,19 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
           if (attrs.typeaheadInputFormatter) {
             typeaheadCtrl.inputFormatter = $parse(attrs.typeaheadInputFormatter);
           }
+        }
+      };
+    }
+  ])
+
+  .directive('typeaheadLoading', [
+             '$parse',
+    function ($parse) {
+      return {
+        restrict: 'A',
+        require: 'typeahead',
+        link: function (scope, element, attrs, typeaheadCtrl) {
+          typeaheadCtrl.setIsLoading = $parse(attrs.typeaheadLoading).assign || angular.noop;
         }
       };
     }

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -208,9 +208,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //expressions used by typeahead
       var parserResult = typeaheadParser.parse(attrs.typeahead);
 
-      //plug into $parsers pipeline to open a typeahead on view changes initiated from DOM
-      //$parsers kick-in on all the changes coming from the view as well as manually triggered by $setViewValue
-      modelCtrl.$parsers.unshift(function (inputValue) {
+      //plug into modelCtrl pipeline to open a typeahead on view changes
+      modelCtrl._$setViewValue = modelCtrl.$setViewValue;
+      modelCtrl.$setViewValue = function (inputValue) {
 
         if (inputValue) {
           typeaheadCtrl.setQuery(inputValue);
@@ -218,8 +218,8 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
           resetMatches();
         }
 
-        return inputValue;
-      });
+        return modelCtrl._$setViewValue(inputValue);
+      };
 
       modelCtrl.$formatters.push(function (modelValue) {
 

--- a/template/typeahead/typeahead-popup.html
+++ b/template/typeahead/typeahead-popup.html
@@ -1,4 +1,6 @@
-<ul class="dropdown-menu" ng-style="{display: isOpen()&&'block' || 'none', top: position.top+'px', left: position.left+'px'}">
+<ul class="dropdown-menu"
+    ng-style="{display: isOpen()&&'block' || 'none', top: position.top+'px', left: position.left+'px'}"
+    ng-mouseenter="mouseIsOver = true" ng-mouseleave="mouseIsOver = false">
     <li ng-repeat="match in matches" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index)">
         <div typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>
     </li>


### PR DESCRIPTION
Tasks left:

- [x] Clean up duplicated code
- [ ] Add tests
- [ ] See if there are any other additions needed
- [ ] Finalize public API

Current known issues:

- Breaks defaults. Default min length is no longer there.

---

Allows other directives to extend functionality of controller.

Since typeahead-popup is a sibling that is right after the typeahead
input element, the controller can't be shared through the directive's
'require' option. As such, it's shared through the new child scope.


#### Example Typeahead Extension Directive

Here's an example that extends the typeahead directive to open on focus (#764):
http://plnkr.co/edit/UAWfTE
(Note that the example is based on my build which is on my demo branch https://github.com/chrisirhc/bootstrap-1/tree/demo/typeahead-extension , as typeahead needs fixes #886, #887 to get that functionality)

The directive is just:

    .directive('typeaheadOpenOnFocus', function () {
      return {
        require: ['typeahead', 'ngModel'],
        link: function (scope, element, attr, ctrls) {
          element.bind('focus', function () {
            ctrls[0].getMatchesAsync(ctrls[1].$viewValue);
            scope.$apply();
          });
        }
      };
    })

This follows ideas of `ngModel` and its `ngModelController` in AngularJS. The `typeaheadController` provides an API (just another object) that can be overridden, added, or called by other directives.