### PR TITLE
fix(dialog): dialog now appears correctly

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -196,8 +196,8 @@ dialogModule.provider("$dialog", function(){
     };
 
     Dialog.prototype._addElementsToDom = function(){
+      this.modalEl.css({display: 'block'});
       body.append(this.modalEl);
-
       if(this.options.backdrop) { 
         if (activeBackdrops.value === 0) {
           body.append(this.backdropEl); 


### PR DESCRIPTION
The CSS for modals in bootstrap 3 has

``` css
display:hidden
```

by default - this patch makes sure that `display:block` is applied.

Is this a good approach? 

Also, what would the appropriate test be? Because there is no way to include the default bootstrap css in a karma test, the original test fail to detect the bug... (even though it does test for display:block)
