### PR TITLE
fix(position): Fallback for IE8's scrollTop/Left for offset

### DIFF
--- a/src/position/position.js
+++ b/src/position/position.js
@@ -71,8 +71,8 @@ angular.module('ui.bootstrap.position', [])
         return {
           width: element.prop('offsetWidth'),
           height: element.prop('offsetHeight'),
-          top: boundingClientRect.top + ($window.pageYOffset || $document[0].body.scrollTop),
-          left: boundingClientRect.left + ($window.pageXOffset || $document[0].body.scrollLeft)
+          top: boundingClientRect.top + ($window.pageYOffset || $document[0].body.scrollTop || $document[0].documentElement.scrollTop),
+          left: boundingClientRect.left + ($window.pageXOffset || $document[0].body.scrollLeft  || $document[0].documentElement.scrollLeft)
         };
       }
     };


### PR DESCRIPTION
With IE8 and below, `$document[0].body.scrollTop()` and its left variant would always return 0, whatever the position of the scrollbar of the page is. This pull request add a third case as a fallback for old IE when calculating the top/left offset with the `$position`.

Normally, this allows directive based on `$position.offset()`to be correctly placed after scrolling. (tested with popovers and tooltip in IE7/IE8 compatibility mode)
