### PR TITLE
Expand $transition API a bit

### DIFF
--- a/src/transition/test/transition.spec.js
+++ b/src/transition/test/transition.spec.js
@@ -37,6 +37,31 @@ describe('$transition', function() {
     expect(element.addClass).toHaveBeenCalledWith('triggerClass');
   });
 
+  it('remove the css class if passed a string starting with `-`', function() {
+    var element = angular.element('<div class="foo"></div>');
+    spyOn(element, 'removeClass');
+    $transition(element, '-foo');
+    $timeout.flush();
+
+    expect(element.removeClass).toHaveBeenCalledWith('foo');
+  });
+
+  it('toggle (removeClass) the css class if passed a string starting with `^`', function() {
+    var element = angular.element('<div class="foo"></div>');
+    spyOn(element, 'removeClass');
+    $transition(element, '^foo');
+    $timeout.flush();
+    expect(element.removeClass).toHaveBeenCalledWith('foo');
+  });
+
+  it('toggle (addClass) the css class if passed a string starting with `^`', function() {
+    var element = angular.element('<div></div>');
+    spyOn(element, 'addClass');
+    $transition(element, '^foo');
+    $timeout.flush();
+    expect(element.addClass).toHaveBeenCalledWith('foo');
+  });
+
   it('changes the css if passed array of strings', function() {
     var element = angular.element('<div></div>');
     spyOn(element, 'addClass');
@@ -67,7 +92,6 @@ describe('$transition', function() {
     expect(element.addClass).toHaveBeenCalledWith(triggerStyle[1]);
   });
 
-
   it('calls the function if passed', function() {
     var element = angular.element('<div></div>');
     var triggerFunction = jasmine.createSpy('triggerFunction');
@@ -86,7 +110,6 @@ describe('$transition', function() {
     expect(triggerFunction).toHaveBeenCalledWith(element);
     expect(element.addClass).toHaveBeenCalledWith('triggerClass');
   });
-
 
   // Versions of Internet Explorer before version 10 do not have CSS transitions
   if ( !ie  || ie > 9 ) {

--- a/src/transition/transition.js
+++ b/src/transition/transition.js
@@ -31,7 +31,18 @@ angular.module('ui.bootstrap.transition', [])
     $timeout(function() {
       var handleTrigger = function(trigger) {
         if ( angular.isString(trigger) ) {
-          element.addClass(trigger);
+          // Additional CSS class semantics
+          if ( trigger.indexOf('-') === 0 ) {
+            element.removeClass(trigger.substr(1));
+          } else if ( trigger.indexOf('^') === 0 ) {
+            var cls = trigger.substr(1);
+            element[element.hasClass(cls) ? 'removeClass' : 'addClass'](cls);
+          } else {
+            if(trigger.indexOf('+') === 0) {
+              trigger = trigger.substr(1);
+            }
+            element.addClass(trigger);
+          }
         } else if ( angular.isFunction(trigger) ) {
           trigger(element);
         } else if ( angular.isObject(trigger) ) {


### PR DESCRIPTION
I was doing some work on #911 and it seemed like these changes would have been
useful for it.

It turns out that they aren't really needed, but I thought it wouldn't hurt to
see if anyone thought they were useful/worth keeping.

There are a couple of tests added for the new functionality, which includes:
- Pass array of triggers (EG for adding CSS classes as well as style CSS or
  functions)
- Support variety of CSS class semantic actions (prepend +,- or ^ to add, remove
  or toggle classes -- but add by default)

Anyways, just throwing these up there in case someone thinks they're useful, but if
not, as I've said I don't think they're really needed to fix #911 anyways. Cheers
