### PR TITLE
(fix) error with rating inside another ng-repeat directive - dupe

### DIFF
--- a/template/rating/rating.html
+++ b/template/rating/rating.html
@@ -1,3 +1,3 @@
 <span ng-mouseleave="reset()">
-	<i ng-repeat="r in range" ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" ng-class="$index < val && (r.stateOn || 'icon-star') || (r.stateOff || 'icon-star-empty')"></i>
+	<i ng-repeat="r in range track by $index" ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" ng-class="$index < val && (r.stateOn || 'icon-star') || (r.stateOff || 'icon-star-empty')"></i>
 </span>


### PR DESCRIPTION
Angular throws a dupe error in ng-repeat directive for rating when inside another ng-repeat directive, changed template to ng-repeat="r in range track by $index" as suggested by angular.

Error: [ngRepeat:dupes] http://errors.angularjs.org/undefined/ngRepeat/dupes?p0=r%20in%20range&p1=object%3A00R

Fixed by adding track by $index to the ng-repeat directive
