### PR TITLE
Prevent collapsed style overflow: hidden from obscuring the typeahead co...

### DIFF
--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -14,7 +14,9 @@ angular.module('ui.bootstrap.collapse',['ui.bootstrap.transition'])
     // It appears that  reading offsetWidth makes the browser realise that we have changed the
     // height already :-/
     var x = element[0].offsetWidth;
-    if (isCollapsed) element.addClass('collapse');
+    if (isCollapsed) { 
+      element.addClass('collapse');
+    }
   };
 
   return {


### PR DESCRIPTION
...ntrol's suggestion popup.  I ran into the issue after having a typeahead control as a child of a div that could be collapsed. 
