### PR TITLE
feat(modal) Passed entire modal obj to backdrop scope

### DIFF
--- a/template/modal/backdrop.html
+++ b/template/modal/backdrop.html
@@ -1,1 +1,1 @@
-<div class="modal-backdrop fade" ng-class="{in: animate}" ng-style="{'z-index': 1040 + index*10}"></div>
+<div class="modal-backdrop fade {{modal.backdropClass}}" ng-class="{in: animate}" ng-style="{'z-index': 1040 + index*10}"></div>


### PR DESCRIPTION
This is the start of a set of simplification patches I think that could be applied to the modal module.

In addition, the inner-modal scope should be applied to the entire window elm (wrapper). I'm curious if/why it wouldn't be.
