### PR TITLE
fix(tabs): hasAttribute method not available in IE7

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -285,8 +285,8 @@ function($parse, $http, $templateCache, $compile) {
   };
   function isTabHeading(node) {
     return node.tagName &&  (
-      node.hasAttribute('tab-heading') ||
-      node.hasAttribute('data-tab-heading') ||
+      node.getAttribute('tab-heading') !== null ||
+      node.getAttribute('data-tab-heading') !== null ||
       node.tagName.toLowerCase() === 'tab-heading' ||
       node.tagName.toLowerCase() === 'data-tab-heading'
     );


### PR DESCRIPTION
IE7 doesn't allow to call the method hasAttribute on any element, and just for this reason the tabset isn't working, so I think is worthy to do this little change and make it work.
