### PR TITLE
feat(position): Access width and height for hidden fields

### DIFF
--- a/src/position/test/position.spec.js
+++ b/src/position/test/position.spec.js
@@ -1,0 +1,70 @@
+describe('position service', function () {
+
+  var $position, $document, $body, elem;
+  beforeEach(module('ui.bootstrap.position'));
+  beforeEach(inject(function(_$position_, _$document_) {
+    $position = _$position_;
+    $document = _$document_;
+    $body = $document.find('body');
+  }));
+
+  beforeEach(function() {
+    elem = angular.element('<div><p>Miscellaneous content</p></div>');
+    ['height', 'width'].forEach(function(name) {
+      ['', 'min-', 'max-'].forEach(function(prefix) {
+        elem.css(prefix+name, '100px');
+      });
+    });
+    $body.append(elem);
+  });
+  afterEach(function() {
+    elem.remove();
+  });
+
+  describe('$position.width', function() {
+    it('will be a function', function() {
+      expect(typeof $position.width).toEqual('function');
+    });
+
+    it('will return correct dimensions with `display: none`', function() {
+      elem.css('display', 'none');
+      expect($position.width(elem)).toEqual(100);
+      expect(elem[0].offsetWidth).toBe(0);
+    });
+
+    it('will return correct dimensions with `visibility: hidden`', function() {
+      elem.css({'visibility': 'hidden', 'display': 'none'});
+      expect($position.width(elem)).toEqual(100);
+      expect(elem[0].offsetWidth).toBe(0);
+    });
+
+    it('will return correct dimensions with `display: block`', function() {
+      expect($position.width(elem)).toEqual(100);
+      expect(elem[0].offsetWidth).toBe(100);
+    });
+  });
+
+  describe('$position.height', function() {
+    it('will be a function', function() {
+      expect(typeof $position.height).toEqual('function');
+    });
+
+    it('will return correct dimensions with `display: none`', function() {
+      elem.css('display', 'none');
+      expect($position.height(elem)).toEqual(100);
+      expect(elem[0].offsetHeight).toBe(0);
+    });
+
+    it('will return correct dimensions with `visibility: hidden`', function() {
+      elem.css({'visibility': 'hidden', 'display': 'none'});
+      expect($position.height(elem)).toEqual(100);
+      expect(elem[0].offsetHeight).toBe(0);
+    });
+
+    it('will return correct dimensions with `display: block`', function() {
+      expect($position.height(elem)).toEqual(100);
+      expect(elem[0].offsetHeight).toBe(100);
+    });
+  });
+
+});


### PR DESCRIPTION
To avoid being too wordy: collapse.js needs to be able to query the height of invisible (collapsed) elements. Previous hack involved removing `.collapse` and re-adding it after. This is not a very good solution (although it is probably the least verbose).

jQuery provides a swapping mechanism here, which allows the height/width of hidden elements to be shown
https://github.com/jquery/jquery/blob/94ae7133449b2d0f5aab7e1a7f7190be65924145/src/css.js#L349

I propose adding height/width helpers to $position (and perhaps, just wrapping jQuery if jQuery is present), removing them from collapse.js (in #934 / #1001).

Additionally, it might be helpful to provide this behaviour for `$position.offset` as well, but I'm not sure.
- Pros: Lets me shrink down #934 / #1001 and avoid duplicating some code which is already present in $position.
- Cons: Makes library slightly bigger .___. (but very slightly!)
