### PR TITLE
Track repeater by index on rating template

### DIFF
--- a/template/rating/rating.html
+++ b/template/rating/rating.html
@@ -1,3 +1,3 @@
 <span ng-mouseleave="reset()">
-	<i ng-repeat="r in range" ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" ng-class="$index < val && (r.stateOn || 'icon-star') || (r.stateOff || 'icon-star-empty')"></i>
+	<i ng-repeat="r in range track by $index" ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" ng-class="$index < val && (r.stateOn || 'icon-star') || (r.stateOff || 'icon-star-empty')"></i>
 </span>


### PR DESCRIPTION
AngularJS 1.2 throws this error on the rating directive:

Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: r in range, Duplicate key: object:008
http://errors.angularjs.org/1.2.0-rc.2/ngRepeat/dupes?p0=r%20in%20range&p1=object%3A008

Following the pointers specified in the doc (as in track by var) works.
I'm not sure about backwards compatibility as i'm new to AngularJS.
