### PR TITLE
define ng-model on the datepicker element, not the parent div

### DIFF
--- a/src/datepicker/docs/demo.html
+++ b/src/datepicker/docs/demo.html
@@ -1,8 +1,8 @@
 <div ng-controller="DatepickerDemoCtrl">
     <pre>Selected date is: <em>{{dt | date:'fullDate' }}</em></pre>
 
-    <div class="well well-small pull-left" ng-model="dt">
-        <datepicker min="minDate" show-weeks="showWeeks"></datepicker>
+    <div class="well well-small pull-left">
+        <datepicker ng-model='dt' min="minDate" show-weeks="showWeeks"></datepicker>
     </div>
 
     <div class="form-horizontal">


### PR DESCRIPTION
- ng-model should be defined on the `<datepicker>` element to avoid this error:

Error: Non-assignable model expression: undefined (directive: datepicker)
