### PR TITLE
fix(datapicker): set popup initial position in append-to-body case

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -414,7 +414,7 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
       }
 
       function updatePosition() {
-        scope.position = $position.position(element);
+        scope.position = appendToBody ? $position.offset(element) : $position.position(element);
         scope.position.top = scope.position.top + element.prop('offsetHeight');
       }
 


### PR DESCRIPTION
Set the initial position offsets of the datepicker popup element in case of appended to 'body'.
(the position would still become incorrect after parent elements resizing)
