### PR TITLE
Add slash before templateUrl's

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -61,7 +61,7 @@ angular.module('ui.bootstrap.modal', [])
     return {
       restrict: 'EA',
       replace: true,
-      templateUrl: 'template/modal/backdrop.html',
+      templateUrl: '/template/modal/backdrop.html',
       link: function (scope, element, attrs) {
 
         //trigger CSS transitions
@@ -89,7 +89,7 @@ angular.module('ui.bootstrap.modal', [])
       },
       replace: true,
       transclude: true,
-      templateUrl: 'template/modal/window.html',
+      templateUrl: '/template/modal/window.html',
       link: function (scope, element, attrs) {
         scope.windowClass = attrs.windowClass || '';
 


### PR DESCRIPTION
On example.com/open/modal/ the direcrives backdrop and window is looking for
example.com/open/template/modal/backdrop.html
change 

```
templateUrl: 'template/modal/backdrop.html',
```

to

```
templateUrl: '/template/modal/backdrop.html',
```

the / fixes the url problem
