### PR TITLE
Add optional boolean return to refire typeahead onSelectCallback

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -211,11 +211,17 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         $setModelValue(originalScope, model);
         modelCtrl.$setValidity('editable', true);
 
-        onSelectCallback(originalScope, {
+        var refire = onSelectCallback(originalScope, {
           $item: item,
           $model: model,
           $label: parserResult.viewMapper(originalScope, locals)
         });
+
+        if (refire) {
+          $timeout(function(){
+            modelCtrl.$setViewValue(model);
+          });
+        }
 
         resetMatches();
 


### PR DESCRIPTION
Adds a backward compatible, optional return value to the onSelectCallback. If truthy, it will set the input's view value to the selected item which will cause the typeahead to refire.

This is useful for iterative auto-completion matches, such as picking a file from a highly nested directory, similar to bash auto-completion with tab.

Example Template:

```
<input typeahead-on-select="continue_suggesting_if_directory($model)" ... >
```

Example Controller:

```
$scope.continue_suggesting_if_directory = function(value){
  return value.slice(-1) === '/';
};
```
