### PR TITLE
fix duplicate Key in Repeater issue

### DIFF
--- a/template/rating/rating.html
+++ b/template/rating/rating.html
@@ -1,3 +1,3 @@
 <span ng-mouseleave="reset()">
-	<i ng-repeat="r in range" ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" ng-class="$index < val && (r.stateOn || 'icon-star') || (r.stateOff || 'icon-star-empty')"></i>
+	<i ng-repeat="r in range  track by $index" ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" ng-class="$index < val && (r.stateOn || 'icon-star') || (r.stateOff || 'icon-star-empty')"></i>
 </span>


### PR DESCRIPTION
Chrome devtools console report the "Duplicate Key in Repeater" error when I use the rate plugin. 
Detail: http://docs.angularjs.org/error/ngRepeat:dupes?p0=r%20in%20range&p1=object:008
