### PR TITLE
fix(collapse): Flag initial animation complete when collapsing

### DIFF
--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -38,6 +38,7 @@ angular.module('ui.bootstrap.collapse', ['ui.bootstrap.transition'])
 
         function collapse() {
           if (initialAnimSkip) {
+            initialAnimSkip = false;
             element.removeClass('collapsing');
             element.addClass('collapse');
             element.css({height: 0});


### PR DESCRIPTION
I know this is branch is a WIP, but I noticed that the `intialAnimSkip` wasn't being set when collapsing.

If a element starting out collapsed, the expand animation would jump since the `initialAnimSkip` was still `true`.
