### PR TITLE
feat(alert): add `closable` attribute

### DIFF
--- a/src/alert/alert.js
+++ b/src/alert/alert.js
@@ -8,8 +8,8 @@ angular.module("ui.bootstrap.alert", []).directive('alert', function () {
       type: '=',
       close: '&'
     },
-    link: function(scope, iElement, iAttrs) {
-      scope.closeable = "close" in iAttrs;
+    link: function(scope, element, attrs) {
+      scope.closable = "close" in attrs && (angular.isUndefined(attrs.closable) || scope.$parent.$eval(attrs.closable) !== false);
     }
   };
 });

--- a/src/alert/docs/demo.html
+++ b/src/alert/docs/demo.html
@@ -1,4 +1,4 @@
 <div ng-controller="AlertDemoCtrl">
-  <alert ng-repeat="alert in alerts" type="alert.type" close="closeAlert($index)">{{alert.msg}}</alert>
+  <alert ng-repeat="alert in alerts" type="alert.type" close="closeAlert($index)" closable="alert.closable">{{alert.msg}}</alert>
   <button class='btn' ng-click="addAlert()">Add Alert</button>
 </div>

--- a/src/alert/docs/demo.js
+++ b/src/alert/docs/demo.js
@@ -1,6 +1,7 @@
 function AlertDemoCtrl($scope) {
   $scope.alerts = [
-    { type: 'error', msg: 'Oh snap! Change a few things up and try submitting again.' }, 
+    { type: 'error', msg: 'Oh snap! Change a few things up and try submitting again.' },
+    { type: 'info', msg: 'I am sticky!', closable: false },
     { type: 'success', msg: 'Well done! You successfully read this important alert message.' }
   ];
 

--- a/src/alert/docs/readme.md
+++ b/src/alert/docs/readme.md
@@ -2,4 +2,4 @@ Alert is an AngularJS-version of bootstrap's alert.
 
 This directive can be used to generate alerts from the dynamic model data (using the ng-repeat directive);
 
-The presence of the "close" attribute determines if a close button is displayed
+The presence of `close` callback and value of `closable` attribute (if present) determine if a close button is displayed.

--- a/src/alert/test/alert.spec.js
+++ b/src/alert/test/alert.spec.js
@@ -35,6 +35,10 @@ describe("alert", function () {
     return element.find('.close').eq(index);
   }
 
+  function hasCloseButton(index) {
+    return findCloseButton(index).css('display') !== 'none';
+  }
+
   it("should generate alerts using ng-repeat", function () {
     var alerts = createAlerts();
     expect(alerts.length).toEqual(3);
@@ -66,7 +70,7 @@ describe("alert", function () {
   it('should not show close buttons if no close callback specified', function () {
     element = $compile('<alert>No close</alert>')(scope);
     scope.$digest();
-    expect(findCloseButton(0).css('display')).toBe('none');
+    expect(hasCloseButton(0)).toBe(false);
   });
 
   it('it should be possible to add additional classes for alert', function () {
@@ -74,6 +78,60 @@ describe("alert", function () {
     scope.$digest();
     expect(element).toHaveClass('alert-block');
     expect(element).toHaveClass('alert-info');
+  });
+
+  describe('closebale', function () {
+    it('should not show close button if false even if `close` exists', function () {
+      element = $compile('<alert closable="false" close="remove($index)"></alert>')(scope);
+      scope.$digest();
+      expect(hasCloseButton(0)).toBe(false);
+    });
+
+    it('should not show close button if true and `close` does not exist', function () {
+      element = $compile('<alert closable="true"></alert>')(scope);
+      scope.$digest();
+      expect(hasCloseButton(0)).toBe(false);
+    });
+
+    describe('with dynamic alerts', function () {
+      it('should show close button correctly if `close` exists', function () {
+        scope.alerts = [
+            {closable: true},
+            {},
+            {closable: false}
+          ];
+
+        element = angular.element(
+          '<div>' +
+            '<alert ng-repeat="alert in alerts" close="close()" closable="alert.closable">' +
+            '</alert>' +
+          '</div>');
+
+          var alerts = createAlerts();
+          expect(hasCloseButton(0)).toBe(true);
+          expect(hasCloseButton(1)).toBe(true);
+          expect(hasCloseButton(2)).toBe(false);
+      });
+
+      it('should not show close button if `close` does not exist', function () {
+        scope.alerts = [
+            {closable: true},
+            {},
+            {closable: false}
+          ];
+
+        element = angular.element(
+          '<div>' +
+            '<alert ng-repeat="alert in alerts" closable="alert.closable">' +
+            '</alert>' +
+          '</div>');
+
+          var alerts = createAlerts();
+          expect(hasCloseButton(0)).toBe(false);
+          expect(hasCloseButton(1)).toBe(false);
+          expect(hasCloseButton(2)).toBe(false);
+      });
+    });
   });
 
 });

--- a/template/alert/alert.html
+++ b/template/alert/alert.html
@@ -1,4 +1,4 @@
-<div class='alert' ng-class='type && "alert-" + type'>
-    <button ng-show='closeable' type='button' class='close' ng-click='close()'>&times;</button>
+<div class="alert" ng-class="type && 'alert-' + type">
+    <button ng-show="closable" type="button" class="close" ng-click="close()">&times;</button>
     <div ng-transclude></div>
 </div>


### PR DESCRIPTION
Mixing closable and non-closable alerts in dynamic structures (ie ng-repeat) was not possible by just relying on the presence of the `close` attribute.
