### PR TITLE
feat(datepicker): add `calculate-postion` option

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -259,7 +259,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.position'])
   closeText: 'Done',
   closeOnDateSelection: true,
   appendToBody: false,
-  showButtonBar: true
+  showButtonBar: true,
+  calculatePosition: true
 })
 
 .directive('datepickerPopup', ['$compile', '$parse', '$document', '$position', 'dateFilter', 'datepickerPopupConfig', 'datepickerConfig',
@@ -271,7 +272,8 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
       var scope = originalScope.$new(), // create a child scope so we are not polluting original one
           dateFormat,
           closeOnDateSelection = angular.isDefined(attrs.closeOnDateSelection) ? originalScope.$eval(attrs.closeOnDateSelection) : datepickerPopupConfig.closeOnDateSelection,
-          appendToBody = angular.isDefined(attrs.datepickerAppendToBody) ? originalScope.$eval(attrs.datepickerAppendToBody) : datepickerPopupConfig.appendToBody;
+          appendToBody = angular.isDefined(attrs.datepickerAppendToBody) ? originalScope.$eval(attrs.datepickerAppendToBody) : datepickerPopupConfig.appendToBody,
+          calculatePosition = angular.isDefined(attrs.calculatePosition) ? originalScope.$eval(attrs.calculatePosition) : datepickerPopupConfig.calculatePosition;
 
       attrs.$observe('datepickerPopup', function(value) {
           dateFormat = value || datepickerPopupConfig.dateFormat;
@@ -377,7 +379,7 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
 
       element.bind('input change keyup', function() {
         scope.$apply(function() {
-          updateCalendar();
+          scope.date = ngModel.$modelValue;
         });
       });
 
@@ -385,14 +387,8 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
       ngModel.$render = function() {
         var date = ngModel.$viewValue ? dateFilter(ngModel.$viewValue, dateFormat) : '';
         element.val(date);
-
-        updateCalendar();
-      };
-
-      function updateCalendar() {
         scope.date = ngModel.$modelValue;
-        updatePosition();
-      }
+      };
 
       function addWatchableAttribute(attribute, scopeProperty, datepickerAttribute) {
         if (attribute) {
@@ -415,8 +411,13 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
       }
 
       function updatePosition() {
-        scope.position = appendToBody ? $position.offset(element) : $position.position(element);
-        scope.position.top = scope.position.top + element.prop('offsetHeight');
+        if ( appendToBody || calculatePosition ) {
+          scope.position = appendToBody ? $position.offset(element) : $position.position(element);
+          scope.position.top = scope.position.top + element.prop('offsetHeight') + 'px';
+          scope.position.left += 'px';
+        } else {
+          scope.position = { top: 'initial', left: 'initial' };
+        }
       }
 
       var documentBindingInitialized = false, elementFocusInitialized = false;

--- a/src/datepicker/docs/demo.html
+++ b/src/datepicker/docs/demo.html
@@ -9,7 +9,7 @@
     <h4>Popup</h4>
     <div class="form-horizontal">
         <p>
-            <input type="text" datepicker-popup="{{format}}" ng-model="dt" is-open="opened" min="minDate" max="'2015-06-22'" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" close-text="Close" />
+            <input type="text" datepicker-popup="{{format}}" ng-model="dt" is-open="opened" min="minDate" max="'2015-06-22'" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" close-text="Close" calculate-position="false" />
             <button class="btn" ng-click="open()"><i class="icon-calendar"></i></button>
         </p>
         <p><i>Format options:</i> <select ng-model="format" ng-options="f for f in formats"><option></option></select></p>

--- a/src/datepicker/docs/readme.md
+++ b/src/datepicker/docs/readme.md
@@ -98,3 +98,7 @@ Specific settings for the `datepicker-popup`, that can globally configured throu
  * `datepicker-append-to-body`
   _(Default: false)_:
   Append the datepicker popup element to `body`, rather than inserting after `datepicker-popup`. For global configuration, use `datepickerPopupConfig.appendToBody`.
+
+ * `calculate-position`
+  _(Default: true)_:
+  Whether the popup's position is absolutely calculated every time it is shown. Otherwise, it is just toggle on the initial position.

--- a/template/datepicker/popup.html
+++ b/template/datepicker/popup.html
@@ -1,4 +1,4 @@
-<ul class="dropdown-menu" ng-style="{display: (isOpen && 'block') || 'none', top: position.top+'px', left: position.left+'px'}">
+<ul class="dropdown-menu" ng-style="{display: (isOpen && 'block') || 'none', top: position.top, left: position.left}">
 	<li ng-transclude></li>
 	<li ng-show="showButtonBar" style="padding:10px 9px 2px">
 		<span class="btn-group">


### PR DESCRIPTION
Remove position updates useful only in extreme cases. Now the only time the position is updated is when the popup is displayed.

Also, there are cases (like in our demo page) that the position of the element does not need to be calculated, and just toggle at it's initial position. For this reason, the calculate-position is added that may help people experiencing performance problems.
