### PR TITLE
fix(datepicker): Prevent from extending beyond the right screen edge

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -417,7 +417,13 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
       function updatePosition() {
         scope.position = appendToBody ? $position.offset(element) : $position.position(element);
         scope.position.top = scope.position.top + element.prop('offsetHeight');
+        var bodyWidth = angular.element($document[0].body).prop('offsetWidth');
+        var popupWidth = popupEl.prop('offsetWidth');
+        if (scope.position.left + popupWidth > bodyWidth) {
+          scope.position.left = bodyWidth - popupWidth;
+        }
       }
+      scope.$watch(updatePosition);
 
       var documentBindingInitialized = false, elementFocusInitialized = false;
       scope.$watch('isOpen', function(value) {


### PR DESCRIPTION
When input Datepicker is attached to is close to the right screen edge Datepicker's container may extend beyond the right screen edge leading to appearing of horisontal scrolling.
This fix addresses issue https://github.com/angular-ui/bootstrap/issues/1012 and probably some others.

PS: I'm not sure that calling updatePosition at each digest cycle is a good idea but I do not know any other way to achive the same.
