### PR TITLE
fix(tooltip): empty string should be valid tooltip content

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -247,7 +247,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
            * Observe the relevant attributes.
            */
           attrs.$observe( type, function ( val ) {
-            if (val) {
+            if (val || val === '') {
               scope.tt_content = val;
             } else {
               if ( scope.tt_isOpen ) {


### PR DESCRIPTION
So the tooltip with dynamic content works as expected.
