### PR TITLE
refactor(alert): move logic to controller & add tests

### DIFF
--- a/src/alert/alert.js
+++ b/src/alert/alert.js
@@ -1,15 +1,19 @@
-angular.module("ui.bootstrap.alert", []).directive('alert', function () {
+angular.module("ui.bootstrap.alert", [])
+
+.controller('AlertController', ['$scope', '$attrs', function ($scope, $attrs) {
+  $scope.closeable = 'close' in $attrs;
+}])
+
+.directive('alert', function () {
   return {
     restrict:'EA',
+    controller:'AlertController',
     templateUrl:'template/alert/alert.html',
     transclude:true,
     replace:true,
     scope: {
       type: '=',
       close: '&'
-    },
-    link: function(scope, iElement, iAttrs) {
-      scope.closeable = "close" in iAttrs;
     }
   };
 });

--- a/src/alert/test/alert.spec.js
+++ b/src/alert/test/alert.spec.js
@@ -51,6 +51,14 @@ describe("alert", function () {
     expect(alerts.eq(2)).not.toHaveClass('alert-block');
   });
 
+  it("should show close buttons", function () {
+    var alerts = createAlerts();
+
+    for (var i = 0, n = alerts.length; i < n; i++) {
+      expect(findCloseButton(i).css('display')).not.toBe('none');
+    }
+  });
+
   it("should fire callback when closed", function () {
 
     var alerts = createAlerts();
@@ -59,7 +67,9 @@ describe("alert", function () {
       scope.removeAlert = jasmine.createSpy();
     });
 
+    expect(findCloseButton(0).css('display')).not.toBe('none');
     findCloseButton(1).click();
+
     expect(scope.removeAlert).toHaveBeenCalledWith(1);
   });
 


### PR DESCRIPTION
Move logic to controller, so it is easier to modify behavior. For example to accomplish something like in #1305 :-)
Also, added some missing tests that `close` button is actually visible, because tests were passing even if link function was empty.

@pkozlowski-opensource Does this LGTY?
