### PR TITLE
fix(modal): Grab reference to body when it is needed in lieu of when the factory is created

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -106,7 +106,6 @@ angular.module('ui.bootstrap.modal', [])
 
       var backdropjqLiteEl, backdropDomEl;
       var backdropScope = $rootScope.$new(true);
-      var body = $document.find('body').eq(0);
       var openedWindows = $$stackedMap.createNew();
       var $modalStack = {};
 
@@ -166,7 +165,9 @@ angular.module('ui.bootstrap.modal', [])
           backdrop: modal.backdrop,
           keyboard: modal.keyboard
         });
-          
+
+        var body = $document.find('body').eq(0);
+
         if (backdropIndex() >= 0 && !backdropDomEl) {
             backdropjqLiteEl = angular.element('<div modal-backdrop></div>');
             backdropDomEl = $compile(backdropjqLiteEl)(backdropScope);


### PR DESCRIPTION
We encountered an issue where modals would stop appearing once we navigated (we are using HTML5 mode and have the body element tagged with ngView) to another controller and back (reloading the page makes it work again).  

I traced it down to what appears to be a "stale" reference to body in the `$modalStack` factory.  This DOM reference is created when the factory is instantiated and then later used when `open` is called.

This pull request simply moves where the body reference is created from the factory instantiation to inside the `open` method where body is actually used.  With this patch in place, the modal works as expected after navigating to another controller and back.
