### PR TITLE
refactor(modal): change watch expression to check local binding

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -120,8 +120,8 @@ angular.module('ui.bootstrap.modal', [])
         return topBackdropIndex;
       }
 
-      $rootScope.$watch(openedWindows.length, function(noOfModals){
-        body.toggleClass('modal-open', openedWindows.length() > 0);
+      $rootScope.$watch(openedWindows.length(), function(noOfModals){
+        body.toggleClass('modal-open', noOfModals > 0);
       });
 
       $rootScope.$watch(backdropIndex, function(newBackdropIndex){


### PR DESCRIPTION
$$stackedMap data structure has a length() function to check number of opened modals. 'modal-open' class on body is maintained by $watch expression. It was monitoring openedWindows.length which is always non-zero (since it's a function). $watch expression now watches openedWindows.length() and hands this value to listener callback local binding noOfModals.
