### PR TITLE
fix(modal): support close animation

### DIFF
--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -104,6 +104,7 @@ describe('$modal', function () {
 
   function dismiss(modal, reason) {
     modal.dismiss(reason);
+    $timeout.flush();
     $rootScope.$digest();
   }
 
@@ -120,6 +121,9 @@ describe('$modal', function () {
       dismiss(modal, 'closing in test');
 
       expect($document).toHaveModalsOpen(0);
+
+      // Backdrop animation
+      $timeout.flush();
       expect($document).not.toHaveBackdrop();
     });
 
@@ -135,6 +139,9 @@ describe('$modal', function () {
       dismiss(modal, 'closing in test');
 
       expect($document).toHaveModalsOpen(0);
+
+      // Backdrop animation
+      $timeout.flush();
       expect($document).not.toHaveBackdrop();
     });
 
@@ -144,6 +151,7 @@ describe('$modal', function () {
       expect($document).toHaveModalsOpen(1);
 
       triggerKeyDown($document, 27);
+      $timeout.flush();
       $rootScope.$digest();
 
       expect($document).toHaveModalsOpen(0);
@@ -155,6 +163,7 @@ describe('$modal', function () {
       expect($document).toHaveModalsOpen(1);
 
       $document.find('body > div.modal').click();
+      $timeout.flush();
       $rootScope.$digest();
 
       expect($document).toHaveModalsOpen(0);
@@ -386,6 +395,9 @@ describe('$modal', function () {
         expect(backdropEl).toHaveClass('in');
 
         dismiss(modal);
+        // Backdrop animation
+        $timeout.flush();
+
         modal = open({ template: '<div>With backdrop</div>' });
         backdropEl = $document.find('body > div.modal-backdrop');
         expect(backdropEl).not.toHaveClass('in');


### PR DESCRIPTION
Closes #1341

The second commit, to fix tests isn't necessary. It's here just for thoughts as the `in` class determines whether the modal or backdrop is actually visible.

Notes:

I'm not using the `$transition` method itself to create any transitions. I'm actually using the transition module just to determine if the browser supports transitions. Checking for transition support isn't actually necessary as modal still closes within 500ms due to the timeout fallback mechanism.

I understand that it's a little hacky that I did a `removeClass('in')` within the remove logic instead of attempting to change the `scope.animate`. However, changing the scope.animate for the modal isn't trivial as the modelWindow directive is using an isolate scope. Since the scope has been destroyed, there won't be a conflict between states, the ng-class on modelBackdrop and modelWindow directives no longer have any effect.

I realized that isn't any need for multiple backdrop element instances and that the element can be left in the DOM after its first creation, and hidden instead of being removed. This can be a future fix.
