### PR TITLE
feat(modal): enable auto horizontal centering

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -95,6 +95,9 @@ angular.module('ui.bootstrap.modal', [])
       link: function (scope, element, attrs) {
         scope.windowClass = attrs.windowClass || '';
 
+        element.css('width', 'auto');
+        element.css({ 'left': '50%', 'margin-left': -(element.width() / 2) + 'px' });
+
         // focus a freshly-opened modal
         element[0].focus();
 


### PR DESCRIPTION
When using the modal the `width` is hard coded to `560px` and `margin-left` is hard coded to `-280px`
With this fix developers doesn't have to override the CSS and calculate the margin-left manually for each modal in their app - only set a width to the main element in the templateUrl and the modal will be horizontally centered.
