### PR TITLE
chore(build): make travis build bower-repo for each module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
- language: node_js
- node_js:
-   - "0.8"
+language: node_js
+node_js:
+ - "0.8"
+env:
+  global:
+    secure: |-
+      UIWglpU0Wb3EhXyY6bFw8SX/muaKlSogZM1axrLNzpuHafJLixexEgrFy19j2uXnF/IpaIgiEfPiCY/ym9lA/uHYVi19QExm+msxItEiObhD6sUcP9SXZbcucIaC1WBtmz0uCvawz3nwvSvwLoZ+OMnmNWvWWvhl9rekdUG/Lyk=
+before_script:
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+- npm install --quiet -g grunt-cli karma bower
+- npm install
 
- before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - npm install --quiet -g grunt-cli karma
-  - npm install
-
- script: grunt
+script: 
+  grunt travis

--- a/misc/travis/README.md
+++ b/misc/travis/README.md
@@ -1,0 +1,24 @@
+#### Travis & Git Overview
+
+We encrypt a github token into .travis.yml that allows us to push to remote repositories.  
+
+#### Overview
+
+We will encrypt a key that causes Travis to set the environment variable 'GH_TOKEN' to a github token that lets us push to angular-ui. Based from this tutorial: http://sleepycoders.blogspot.de/2013/03/sharing-travis-ci-generated-files.html
+
+1. Get the token for your user from github if you are an angular-ui owner, and save the output:
+```sh
+$ curl -X POST -u <your_github_username> -H "Content-Type: application/json" -d "{\"scopes\":[\"public_repo\", \"repo\"],\"note\":\"token for pushing from travis\"}" https://api.github.com/authorizations
+```
+
+1. Install `travis-encrypt` from npm, then we will use it to encrypt our token in .travis.yml.
+```sh
+$ npm install -g travis-encrypt
+```
+```sh
+$ travis-encrypt -r angular-ui/bootstrap -k GH_TOKEN -v $TOKEN_FROM_STEP_1 --add env.global
+```
+
+1. Take the output from travis-encrypt, and save it it in .travis.yml in a secure key, like we have done.
+
+Now, whenever a travis build runs it will export the environment variable `GH_TOKEN` as our github token, securely.

--- a/misc/travis/create-bower-repo.js
+++ b/misc/travis/create-bower-repo.js
@@ -1,0 +1,125 @@
+var sh = require('shelljs');
+sh.config.silent = true;
+var fs = require('fs');
+var request = require('request');
+var q = require('q');
+
+//Simple string formatter to make code more readable & easier to write.
+//Example: //'banana $0 elephant $1'.format('monkey', 'mango') 
+//           --> 'banana monkey elephant mango'
+String.prototype.format = function() {
+  var args = Array.prototype.slice.call(arguments);
+  return args.reduce(function(prev, current, index) {
+    return prev.replace(new RegExp('\\$'+index, 'g'), current);
+  }, this);
+};
+
+var MODULE_REGEX = /angular\.module\(*.*\)/;
+var GITHUB_ORG = 'angular-ui-bootstrap-bower-test';
+var SHOULD_REGISTER_BOWER = false;
+
+module.exports = function bumpBowerRepository(module, pkg, projectRoot) {
+  function readProjectFile(path) {
+    return fs.readFileSync('$0/$1'.format(projectRoot, path));
+  }
+  var repo = 'bower-bootstrap-$0'.format(module.name);
+  var repoIsNew = sh.exec(
+    'git ls-remote git://github.com/$0/$1'.format(GITHUB_ORG, repo),
+    {silent:true} //always silence this commnd because so many errors from it we don't care about
+  ).code !== 0;
+
+  console.log('Updating bower component for $0 module...'.format(module.name));
+
+  return checkoutRepo(repo, module, repoIsNew).then(function(gitDir) {
+    var bowerJson = createBowerJson(module);
+
+    bowerJson.version = pkg.version;
+
+    var js = module.srcFiles.map(readProjectFile).join('\n');
+    var tpljs = module.tpljsFiles.map(readProjectFile).join('\n');
+    var jsBundled = js + '\n' + tpljs;
+    jsBundled = jsBundled.replace(
+      MODULE_REGEX,
+      "angular.module($0, [$1])".format(module.moduleName, module.tplModules)
+    );
+
+    fs.writeFileSync('$0/ui-$1.js'.format(gitDir, module.name), js);
+    fs.writeFileSync('$0/ui-$1-tpls.js'.format(gitDir, module.name), jsBundled);
+    fs.writeFileSync('$0/bower.json'.format(gitDir), 
+                     JSON.stringify(bowerJson, null, 2));
+
+    if (repoIsNew) {
+      sh.exec('bower register $0 git://github.com/$1/$0.git'.format(GITHUB_ORG, repo));
+    }
+
+    pushRepo(gitDir, pkg);
+
+    if (repoIsNew) {
+      console.log('Bower component for $0 was created and registered at $1!'.format(module.name, bowerJson.name));
+    } else {
+      console.log('Bower component $0 is now up-to-date!'.format(bowerJson.name));
+    }
+  });
+};
+
+function checkoutRepo(repo, module, repoIsNew) {
+  var gitDir = '$0/$1'.format(process.env.HOME, repo);
+  var sshUrl = 'https://$0@github.com/$1/$2.git'
+            .format(process.env.GH_TOKEN, GITHUB_ORG, repo);
+  var deferred = q.defer();
+
+  sh.rm('-rf', gitDir);
+  sh.exec('git config --global user.email "travis@travis-ci.org"');
+  sh.exec('git config --global user.name "Travis"');
+
+  //Clone if repo already exists
+  if (!repoIsNew) {
+    sh.exec('git clone $0 $1'.format(sshUrl, gitDir));
+    sh.cd(gitDir);
+    deferred.resolve(gitDir);
+  //Init repo if not exists
+  } else {
+    sh.mkdir('-p', gitDir);
+    sh.cd(gitDir);
+    sh.exec('git init .');
+    sh.exec('git remote add origin $0'.format(sshUrl));
+
+    request({
+      url: 'https://api.github.com/orgs/$0/repos'.format(GITHUB_ORG),
+      method: 'POST',
+      headers: {
+        'User-Agent': 'angular-bootstrap-build',
+        'Content-Type': 'application/json'
+      },
+      qs: {
+        access_token: process.env.GH_TOKEN
+      },
+      body: JSON.stringify({name: repo})
+    }, function(error, response, body) {
+      body = JSON.parse(body);
+      deferred.resolve(gitDir);
+    });
+    
+  }
+  return deferred.promise;
+}
+
+function pushRepo(gitDir, pkg) {
+  sh.cd(gitDir);
+  sh.exec('git add -A');
+  sh.exec('git commit -am "release: v$0"'.format(pkg.version));
+  sh.exec('git tag v$0'.format(pkg.version));
+  sh.exec('git push --tags origin master');
+}
+
+function createBowerJson(module) {
+  return {
+    name: 'angular-bootstrap-ui-$0'.format(module.name),
+    license: 'MIT',
+    version: '0.0.0',
+    author: {
+      name: "https://github.com/angular-ui/bootstrap/graphs/contributors"
+    },
+    main: ['ui-$0-tpls.js'.format(module.name)]
+  };
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "grunt-karma": "~0.4.4",
     "node-markdown": "0.1.1",
     "semver": "~1.1.4",
-    "shelljs": "~0.1.4"
+    "shelljs": "~0.1.4",
+    "request": "~2.30.0",
+    "q": "~0.9.7"
   }
 }


### PR DESCRIPTION
Now people will be able to `bower install angular-bootstrap-ui-buttons` or any module into their project.

This will make it so every build, travis will:
1. Check if the branch name is "master"
2. If so, go through all the modules being built
3. Checkout a repository for that module in travis's $HOME/moduleName
4. Create/update bower.json for current version
5. Create ui-$module.js and ui-$module-tpls.js
6. Create tag if not exists and push an update

This means that there will always be an up-to-date bower repo of every module matching the master-snapshot version, and a bower version will be pushed out for every module every time a new version is released.

See the README.md included for how we securely push bower repos from travis.  The README.md is badly written, I perhaps should update it.  The link it references explains things better.

Check this travis log: https://travis-ci.org/ajoslin/bootstrap/builds/15978121
