### PR TITLE
feat(windowId): Added ability to specify a windowId for modal window

### DIFF
--- a/misc/test-lib/helpers.js
+++ b/misc/test-lib/helpers.js
@@ -8,6 +8,13 @@ beforeEach(function() {
       };
 
       return this.actual.hasClass(cls);
+    },
+    toHaveId: function(id) {
+      this.message = function() {
+        return "Expected '" + this.actual + "'" + (this.isNot ? ' not ' : ' ') + "to have id '" + id + "'.";
+      };
+
+      return this.actual.attr('id') === id;
     }
   });
 });

--- a/src/modal/docs/readme.md
+++ b/src/modal/docs/readme.md
@@ -10,6 +10,7 @@ The `$modal` service has only one method: `open(options)` where available option
 * `resolve` - members that will be resolved and passed to the controller as locals; it is equivalent of the `resolve` property for AngularJS routes
 * `backdrop` - controls presence of a backdrop. Allowed values: true (default), false (no backdrop), `'static'` - backdrop is present but modal window is not closed when clicking outside of the modal window.
 * `keyboard` - indicates whether the dialog should be closable by hitting the ESC key, defaults to true
+* `windowId` - ID to be added to a modal window template
 * `windowClass` - additional CSS class(es) to be added to a modal window template
 
 The `open` method returns a modal instance, an object with the following properties:

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -84,6 +84,7 @@ angular.module('ui.bootstrap.modal', [])
       transclude: true,
       templateUrl: 'template/modal/window.html',
       link: function (scope, element, attrs) {
+        scope.windowId    = attrs.windowId || '';
         scope.windowClass = attrs.windowClass || '';
 
         $timeout(function () {
@@ -183,6 +184,7 @@ angular.module('ui.bootstrap.modal', [])
         }
           
         var angularDomEl = angular.element('<div modal-window></div>');
+        angularDomEl.attr('window-id', modal.windowId);
         angularDomEl.attr('window-class', modal.windowClass);
         angularDomEl.attr('index', openedWindows.length() - 1);
         angularDomEl.html(modal.content);
@@ -301,6 +303,7 @@ angular.module('ui.bootstrap.modal', [])
                 content: tplAndVars[0],
                 backdrop: modalOptions.backdrop,
                 keyboard: modalOptions.keyboard,
+                windowId: modalOptions.windowId,
                 windowClass: modalOptions.windowClass
               });
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -393,6 +393,18 @@ describe('$modal', function () {
       });
     });
 
+    describe('custom window id', function () {
+
+      it('should support additional window id as string', function () {
+        open({
+          template: '<div>With custom window id</div>',
+          windowId: 'test'
+        });
+
+        expect($document.find('div.modal')).toHaveId('test');
+      });
+    });
+
     describe('custom window classes', function () {
 
       it('should support additional window class as string', function () {

--- a/src/modal/test/modalWindow.spec.js
+++ b/src/modal/test/modalWindow.spec.js
@@ -9,6 +9,13 @@ describe('modal window', function () {
     $compile = _$compile_;
   }));
 
+  it('should support custom CSS ID as string', function () {
+    var windowEl = $compile('<div modal-window window-id="test">content</div>')($rootScope);
+    $rootScope.$digest();
+
+    expect(windowEl).toHaveId('test');
+  });
+
   it('should support custom CSS classes as string', function () {
     var windowEl = $compile('<div modal-window window-class="test">content</div>')($rootScope);
     $rootScope.$digest();

--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,3 +1,3 @@
-<div tabindex="-1" class="modal fade {{ windowClass }}" ng-class="{in: animate}" ng-style="{'z-index': 1050 + index*10, display: 'block'}" ng-click="close($event)">
+<div tabindex="-1" id="{{ windowId }}" class="modal fade {{ windowClass }}" ng-class="{in: animate}" ng-style="{'z-index': 1050 + index*10, display: 'block'}" ng-click="close($event)">
     <div class="modal-dialog"><div class="modal-content" ng-transclude></div></div>
 </div>


### PR DESCRIPTION
So after updating from 0.7 to 0.9, I notice I can no longer specify an ID for my modal windows (as I don't control that part anymore).
I see that you can only specify custom windowClasses and think it would be good to also allow a custom windowId as they're known to be much more performant.

I'm using overlays quite a bit throughout my app as they sit on top of the page, giving the user the feeling that they never go anywhere, such as:
- login
- register
- overview pages, etc

so my SCSS structure looks somewhat like:

``` files
scss/app.scss
scss/core/_base.scss
scss/pages/_home.scss
scss/overlays/_login.scss
scss/overlays/_register.scss
scss/overlays/_game-overview.scss
scss/overlays/_property-overview.scss
```

_login.scss:

``` SCSS
#loginModal {
    background-image: url('some-crazy-marketing-background.jpg');
    > .modal-dialog {
        width: 800px;
    }
    // Some other stuff 
}
```

_game-overview.scss:

``` SCSS
#gameOverviewModal {
    background-image: url('some-other-crazy-marketing-background.jpg');
    > .modal-dialog {
        width: 900px;
    }
    // Some other stuff
}
```

So anyway, when you're working with a bunch of designers, they'll make sure to make every part of the application look very special (like a nice login page with lots of little frills and an overview page with more frilly stuff) and would like to specify that as an ID, as though it was it's own page.

I don't want to do .loginModal as there's only going to be one, and I don't want the CSS to have to search my DOM for that class to apply the styles.
With Twitter Bootstrap, you can get quite far with the utility classes/grid provided but design will force particular things outside of the grid and some weird stuff!

Good idea?
