### PR TITLE
fix(modal): leaking watchers due to scope re-use

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -110,8 +110,7 @@ angular.module('ui.bootstrap.modal', [])
 
       var OPENED_MODAL_CLASS = 'modal-open';
 
-      var backdropjqLiteEl, backdropDomEl;
-      var backdropScope = $rootScope.$new(true);
+      var backdropDomEl, backdropScope;
       var openedWindows = $$stackedMap.createNew();
       var $modalStack = {};
 
@@ -127,7 +126,9 @@ angular.module('ui.bootstrap.modal', [])
       }
 
       $rootScope.$watch(backdropIndex, function(newBackdropIndex){
-        backdropScope.index = newBackdropIndex;
+        if (backdropScope) {
+          backdropScope.index = newBackdropIndex;
+        }
       });
 
       function removeModalWindow(modalInstance) {
@@ -146,6 +147,9 @@ angular.module('ui.bootstrap.modal', [])
         if (backdropDomEl && backdropIndex() == -1) {
           backdropDomEl.remove();
           backdropDomEl = undefined;
+
+          backdropScope.$destroy();
+          backdropScope = undefined;
         }
 
         //destroy scope
@@ -174,12 +178,14 @@ angular.module('ui.bootstrap.modal', [])
           keyboard: modal.keyboard
         });
 
-        var body = $document.find('body').eq(0);
+        var body = $document.find('body').eq(0),
+            currBackdropIndex = backdropIndex();
 
-        if (backdropIndex() >= 0 && !backdropDomEl) {
-            backdropjqLiteEl = angular.element('<div modal-backdrop></div>');
-            backdropDomEl = $compile(backdropjqLiteEl)(backdropScope);
-            body.append(backdropDomEl);
+        if (currBackdropIndex >= 0 && !backdropDomEl) {
+          backdropScope = $rootScope.$new(true);
+          backdropScope.index = currBackdropIndex;
+          backdropDomEl = $compile('<div modal-backdrop></div>')(backdropScope);
+          body.append(backdropDomEl);
         }
           
         var angularDomEl = angular.element('<div modal-window></div>');


### PR DESCRIPTION
Previously, the backdropScope was being re-used and each time it was
linked, it would attach more watchers to the scope.

Resolves #1491

Note: Due to a bug in pre-1.2 AngularJS (replaced directives with templateUrls lose reference to the node, [plunker here](http://plnkr.co/edit/1dcBt1B3GQh6Z0Fuv28L?p=preview)), the backdrop's template can't be cached and re-used. Post-Angular 1.2 we should compile the backdrop element only once and re-use it after.
