### PR TITLE
refactor(datepicker): Move the dt.secondary class on to the button

### DIFF
--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -168,7 +168,7 @@ describe('datepicker directive', function () {
       var options = getAllOptionsEl();
       for (var i = 0; i < 5; i ++) {
         for (var j = 0; j < 7; j ++) {
-          expect(options[i][j].find('button').find('span').hasClass('text-muted')).toBe( ((i === 0 && j < 3) || (i === 4 && j > 4)) );
+          expect(options[i][j].find('button').hasClass('text-muted')).toBe( ((i === 0 && j < 3) || (i === 4 && j > 4)) );
         }
       }
     });
@@ -1325,13 +1325,13 @@ describe('datepicker directive', function () {
         expect($body.children().length).toEqual(bodyLength);
       });
     });
-    
+
     describe('with setting datepickerConfig.showWeeks to false', function() {
       var originalConfig = {};
       beforeEach(inject(function(datepickerConfig) {
         angular.extend(originalConfig, datepickerConfig);
         datepickerConfig.showWeeks = false;
-        
+
         var wrapElement = $compile('<div><input ng-model="date" datepicker-popup><div>')($rootScope);
         $rootScope.$digest();
         assignElements(wrapElement);
@@ -1340,7 +1340,7 @@ describe('datepicker directive', function () {
         // return it to the original state
         angular.extend(datepickerConfig, originalConfig);
       }));
-      
+
       it('changes initial visibility for weeks', function() {
         expect(getLabelsRow().find('th').eq(0).css('display')).toBe('none');
         var tr = element.find('tbody').find('tr');

--- a/template/datepicker/datepicker.html
+++ b/template/datepicker/datepicker.html
@@ -14,7 +14,7 @@
     <tr ng-repeat="row in rows">
       <td ng-show="showWeekNumbers" class="text-center"><em>{{ getWeekNumber(row) }}</em></td>
       <td ng-repeat="dt in row" class="text-center">
-        <button type="button" style="width:100%;" class="btn btn-default btn-sm" ng-class="{'btn-info': dt.selected}" ng-click="select(dt.date)" ng-disabled="dt.disabled"><span ng-class="{'text-muted': dt.secondary}">{{dt.label}}</span></button>
+        <button type="button" style="width:100%;" class="btn btn-default btn-sm" ng-class="{'btn-info': dt.selected, 'text-muted': dt.secondary}" ng-click="select(dt.date)" ng-disabled="dt.disabled"><span>{{dt.label}}</span></button>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Having the class on the button rather than the span allows for more flexibility
when applying custom styling. e.g. wanting to hide the buttons when the date is
outside of the current month.
