### PR TITLE
Allow keeping the dropdown open when items are clicked.

### DIFF
--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -24,7 +24,7 @@ angular.module('ui.bootstrap.dropdownToggle', []).directive('dropdownToggle', ['
       scope.$watch('$location.path', function() { closeMenu(); });
       element.parent().bind('click', function() { closeMenu(); });
       element.parent().find('.dropdown-menu').bind('click', function(event) {
-          if (!!scope.keepOnMenuClick) {
+          if (!!scope.keepOnMenuClick && !$(event.target).is(':button,:submit,a')) {
               event.preventDefault();
               event.stopPropagation();
           }

--- a/src/dropdownToggle/test/dropdownToggle.spec.js
+++ b/src/dropdownToggle/test/dropdownToggle.spec.js
@@ -64,11 +64,18 @@ describe('dropdownToggle', function() {
     expect(elm2.hasClass('open')).toBe(true);
   });
 
-  it('should allow keeping a dropdown open when a link is clicked', function() {
-    var elm = $compile('<li class="dropdown"><a dropdown-toggle></a><ul dropdown-toggle keep-on-menu-click="true"><li>Hello</li></ul><ul class="dropdown-menu"><li><a href="">World</a></li></ul></li>')($rootScope);
+  it('should allow keeping a dropdown open when an input is clicked', function() {
+    var elm = $compile('<li class="dropdown"><a dropdown-toggle></a><ul dropdown-toggle keep-on-menu-click="true"><li>Hello</li></ul><ul class="dropdown-menu"><li><input type="text" /></li></ul></li>')($rootScope);
+    elm.children('a').click();
+    elm.find('.dropdown-menu input').click();
+    expect(elm.hasClass('open')).toBe(true);
+  });
+
+  it('should close when a link is clicked', function() {
+    var elm = $compile('<li class="dropdown"><a dropdown-toggle></a><ul dropdown-toggle keep-on-menu-click="true"><li>Hello</li></ul><ul class="dropdown-menu"><li><a href="#">World</a></li></ul></li>')($rootScope);
     elm.children('a').click();
     elm.find('.dropdown-menu a').click();
-    expect(elm.hasClass('open')).toBe(true);
+    expect(elm.hasClass('open')).toBe(false);
   });
 
   it('should close on click of child element', function() {


### PR DESCRIPTION
For some scenarios, it is very beneficial if the dropdown menu is not
closed when items in the dropdown is clicked. An example is a button
that shows a dropdown with a form inside, e.g. login controls.

This commit adds a "keep-on-menu-click" attribute that can be set to
true when you want the menu to stay open on internal clicks.
