### PR TITLE
fix(tooltip): leaking watchers on toggling (WIP)

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -148,7 +148,7 @@ describe('tooltip', function() {
     elm.trigger( 'mouseenter' );
 
     ttScope = angular.element( elmBody.children()[1] ).isolateScope();
-    expect( ttScope.$parent ).toBe( elmScope );
+    expect( ttScope.$parent.$parent ).toBe( elmScope );
 
     elm.trigger( 'mouseleave' );
 
@@ -156,7 +156,7 @@ describe('tooltip', function() {
     elm.trigger( 'mouseenter' );
 
     ttScope = angular.element( elmBody.children()[1] ).isolateScope();
-    expect( ttScope.$parent ).toBe( elmScope );
+    expect( ttScope.$parent.$parent ).toBe( elmScope );
 
     elm.trigger( 'mouseleave' );
   }));
@@ -326,13 +326,13 @@ describe('tooltip', function() {
   });
 
   describe('cleanup', function () {
-    var elmBody, elm, elmScope, tooltipScope;
+    var elmBody, elm, elmScope, tooltipChildScope;
 
     function inCache() {
       var match = false;
 
       angular.forEach(angular.element.cache, function (item) {
-        if (item.data && item.data.$isolateScope === tooltipScope) {
+        if (item.data && item.data.$scope === tooltipChildScope) {
           match = true;
         }
       });
@@ -349,7 +349,7 @@ describe('tooltip', function() {
       elm = elmBody.find('input');
       elmScope = elm.scope();
       elm.trigger('fooTrigger');
-      tooltipScope = elmScope.$$childTail;
+      tooltipChildScope = elmScope.$$childTail;
     }));
 
     it( 'should not contain a cached reference when visible', inject( function( $timeout ) {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -262,7 +262,9 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
               if (tooltip) {
                 removeTooltip();
               }
-              tooltip = tooltipLinker(scope, function () {});
+              // Make sure to use a new child scope every time as watchers leak into scope.
+              // If linked DOM is removed, watchers from that DOM isn't removed.
+              tooltip = tooltipLinker(scope.$new(), function () {});
 
               // Get contents rendered into the tooltip
               scope.$digest();


### PR DESCRIPTION
Make sure to use a new child scope every time as watchers leak into
scope. If linked DOM is removed, watchers from directives in that DOM
aren't removed.

Regression from #1455

This seems like a tough one to add a test for besides counting the number of total watchers. Perhaps that's a good strategy. I'll keep that in mind and possibly add that tomorrow. Heading to sleep.
