### PR TITLE
style(all): Remove all unused variables and parameters

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,6 +7,7 @@
   "boss": true,
   "eqnull": true,
   "quotmark": "single",
+  "unused": true,
   "trailing": true,
   "globals": {
     "angular": true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -332,7 +332,6 @@ module.exports = function(grunt) {
     if (process.env.TRAVIS) {
       grunt.task.run('karma:travis');
     } else {
-      var isToRunJenkinsTask = !!this.args.length;
       if(grunt.option('coverage')) {
         var karmaOptions = grunt.config.get('karma.options'),
           coverageOpts = grunt.config.get('karma.coverage');

--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -26,7 +26,7 @@ angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse'])
     var that = this;
     this.groups.push(groupScope);
 
-    groupScope.$on('$destroy', function (event) {
+    groupScope.$on('$destroy', function () {
       that.removeGroup(groupScope);
     });
   };

--- a/src/accordion/docs/demo.js
+++ b/src/accordion/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 function AccordionDemoCtrl($scope) {
   $scope.oneAtATime = true;
 

--- a/src/accordion/test/accordion.spec.js
+++ b/src/accordion/test/accordion.spec.js
@@ -271,7 +271,6 @@ describe('accordion', function () {
     });
 
     describe('is-open attribute with dynamic groups', function () {
-      var model;
       beforeEach(function () {
         var tpl =
           '<accordion>' +

--- a/src/alert/docs/demo.js
+++ b/src/alert/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 function AlertDemoCtrl($scope) {
   $scope.alerts = [
     { type: 'danger', msg: 'Oh snap! Change a few things up and try submitting again.' },

--- a/src/alert/test/alert.spec.js
+++ b/src/alert/test/alert.spec.js
@@ -6,7 +6,7 @@ describe('alert', function () {
   beforeEach(module('ui.bootstrap.alert'));
   beforeEach(module('template/alert/alert.html'));
 
-  beforeEach(inject(function ($rootScope, _$compile_, $controller) {
+  beforeEach(inject(function ($rootScope, _$compile_) {
 
     scope = $rootScope;
     $compile = _$compile_;
@@ -69,7 +69,7 @@ describe('alert', function () {
 
   it('should fire callback when closed', function () {
 
-    var alerts = createAlerts();
+    createAlerts();
 
     scope.$apply(function () {
       scope.removeAlert = jasmine.createSpy();

--- a/src/buttons/docs/demo.js
+++ b/src/buttons/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var ButtonsCtrl = function ($scope) {
 
   $scope.singleModel = 1;

--- a/src/carousel/docs/demo.js
+++ b/src/carousel/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 function CarouselDemoCtrl($scope) {
   $scope.myInterval = 5000;
   var slides = $scope.slides = [];

--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -1,6 +1,6 @@
 angular.module('ui.bootstrap.collapse', ['ui.bootstrap.transition'])
 
-  .directive('collapse', ['$transition', function ($transition, $timeout) {
+  .directive('collapse', ['$transition', function ($transition) {
 
     return {
       link: function (scope, element, attrs) {

--- a/src/collapse/docs/demo.js
+++ b/src/collapse/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 function CollapseDemoCtrl($scope) {
   $scope.isCollapsed = false;
 }

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -465,7 +465,7 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
     replace: true,
     transclude: true,
     templateUrl: 'template/datepicker/popup.html',
-    link:function (scope, element, attrs) {
+    link:function (scope, element) {
       element.bind('click', function(event) {
         event.preventDefault();
         event.stopPropagation();

--- a/src/datepicker/docs/demo.js
+++ b/src/datepicker/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var DatepickerDemoCtrl = function ($scope) {
   $scope.today = function() {
     $scope.dt = new Date();

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -953,7 +953,7 @@ describe('datepicker directive', function () {
   });
 
   describe('as popup', function () {
-    var divElement, inputEl, dropdownEl, changeInputValueTo, $document;
+    var inputEl, dropdownEl, changeInputValueTo, $document;
 
     function assignElements(wrapElement) {
       inputEl = wrapElement.find('input');

--- a/src/dropdownToggle/docs/demo.js
+++ b/src/dropdownToggle/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 function DropdownCtrl($scope) {
   $scope.items = [
     'The first choice!',

--- a/src/dropdownToggle/dropdownToggle.js
+++ b/src/dropdownToggle/dropdownToggle.js
@@ -17,7 +17,7 @@ angular.module('ui.bootstrap.dropdownToggle', []).directive('dropdownToggle', ['
       closeMenu   = angular.noop;
   return {
     restrict: 'CA',
-    link: function(scope, element, attrs) {
+    link: function(scope, element) {
       scope.$on('$locationChangeSuccess', function() { closeMenu(); });
       element.parent().bind('click', function() { closeMenu(); });
       element.bind('click', function (event) {

--- a/src/modal/docs/demo.js
+++ b/src/modal/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var ModalDemoCtrl = function ($scope, $modal, $log) {
 
   $scope.items = ['item1', 'item2', 'item3'];

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -286,7 +286,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
 
           function getResolvePromises(resolves) {
             var promisesArr = [];
-            angular.forEach(resolves, function (value, key) {
+            angular.forEach(resolves, function (value) {
               if (angular.isFunction(value) || angular.isArray(value)) {
                 promisesArr.push($q.when($injector.invoke(value)));
               }

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -153,7 +153,7 @@ describe('$modal', function () {
 
     it('should support closing on ESC', function () {
 
-      var modal = open({template: '<div>Content</div>'});
+      open({template: '<div>Content</div>'});
       expect($document).toHaveModalsOpen(1);
 
       triggerKeyDown($document, 27);
@@ -165,7 +165,7 @@ describe('$modal', function () {
 
     it('should support closing on backdrop click', function () {
 
-      var modal = open({template: '<div>Content</div>'});
+      open({template: '<div>Content</div>'});
       expect($document).toHaveModalsOpen(1);
 
       $document.find('body > div.modal').click();
@@ -213,7 +213,7 @@ describe('$modal', function () {
     it('should allow overriding default options in a provider', function () {
 
       $modalProvider.options.backdrop = false;
-      var modal = open({template: '<div>Content</div>'});
+      open({template: '<div>Content</div>'});
 
       expect($document).toHaveModalOpenWithContent('Content', 'div');
       expect($document).not.toHaveBackdrop();
@@ -224,7 +224,7 @@ describe('$modal', function () {
       $modalProvider.options = {
         backdrop: false
       };
-      var modal = open({template: '<div>Content</div>'});
+      open({template: '<div>Content</div>'});
 
       expect($document).toHaveModalOpenWithContent('Content', 'div');
       expect($document).not.toHaveBackdrop();
@@ -237,7 +237,7 @@ describe('$modal', function () {
 
       it('should throw an error if none of template and templateUrl are provided', function () {
         expect(function(){
-          var modal = open({});
+          open({});
         }).toThrow(new Error('One of template or templateUrl options is required.'));
       });
 
@@ -259,7 +259,7 @@ describe('$modal', function () {
           $scope.isModalInstance = angular.isObject($modalInstance) && angular.isFunction($modalInstance.close);
         };
 
-        var modal = open({template: '<div>{{fromCtrl}} {{isModalInstance}}</div>', controller: TestCtrl});
+        open({template: '<div>{{fromCtrl}} {{isModalInstance}}</div>', controller: TestCtrl});
         expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
       });
     });
@@ -440,8 +440,8 @@ describe('$modal', function () {
 
     it('should not close any modals on ESC if the topmost one does not allow it', function () {
 
-      var modal1 = open({template: '<div>Modal1</div>'});
-      var modal2 = open({template: '<div>Modal2</div>', keyboard: false});
+      open({template: '<div>Modal1</div>'});
+      open({template: '<div>Modal2</div>', keyboard: false});
 
       triggerKeyDown($document, 27);
       $rootScope.$digest();
@@ -451,8 +451,8 @@ describe('$modal', function () {
 
     it('should not close any modals on click if a topmost modal does not have backdrop', function () {
 
-      var modal1 = open({template: '<div>Modal1</div>'});
-      var modal2 = open({template: '<div>Modal2</div>', backdrop: false});
+      open({template: '<div>Modal1</div>'});
+      open({template: '<div>Modal2</div>', backdrop: false});
 
       $document.find('body > div.modal-backdrop').click();
       $rootScope.$digest();
@@ -462,8 +462,8 @@ describe('$modal', function () {
 
     it('multiple modals should not interfere with default options', function () {
 
-      var modal1 = open({template: '<div>Modal1</div>', backdrop: false});
-      var modal2 = open({template: '<div>Modal2</div>'});
+      open({template: '<div>Modal1</div>', backdrop: false});
+      open({template: '<div>Modal2</div>'});
       $rootScope.$digest();
 
       expect($document).toHaveBackdrop();

--- a/src/pagination/docs/demo.js
+++ b/src/pagination/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var PaginationDemoCtrl = function ($scope) {
   $scope.totalItems = 64;
   $scope.currentPage = 4;

--- a/src/popover/docs/demo.js
+++ b/src/popover/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var PopoverDemoCtrl = function ($scope) {
   $scope.dynamicPopover = 'Hello, World!';
   $scope.dynamicPopoverTitle = 'Title';

--- a/src/progressbar/docs/demo.js
+++ b/src/progressbar/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var ProgressDemoCtrl = function ($scope) {
 
   $scope.max = 200;

--- a/src/rating/docs/demo.js
+++ b/src/rating/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var RatingDemoCtrl = function ($scope) {
   $scope.rate = 7;
   $scope.max = 10;

--- a/src/tabs/docs/demo.js
+++ b/src/tabs/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var TabsDemoCtrl = function ($scope) {
   $scope.tabs = [
     { title:'Dynamic Title 1', content:'Dynamic content 1' },

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -248,7 +248,7 @@ angular.module('ui.bootstrap.tabs', [])
   return {
     restrict: 'A',
     require: '^tab',
-    link: function(scope, elm, attrs, tabCtrl) {
+    link: function(scope, elm) {
       scope.$watch('headingElement', function updateHeadingElement(heading) {
         if (heading) {
           elm.html('');

--- a/src/timepicker/docs/demo.js
+++ b/src/timepicker/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var TimepickerDemoCtrl = function ($scope) {
   $scope.mytime = new Date();
 

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -137,7 +137,7 @@ angular.module('ui.bootstrap.timepicker', [])
           }
         };
 
-        hoursInputEl.bind('blur', function(e) {
+        hoursInputEl.bind('blur', function() {
           if ( !scope.validHours && scope.hours < 10) {
             scope.$apply( function() {
               scope.hours = pad( scope.hours );
@@ -156,7 +156,7 @@ angular.module('ui.bootstrap.timepicker', [])
           }
         };
 
-        minutesInputEl.bind('blur', function(e) {
+        minutesInputEl.bind('blur', function() {
           if ( !scope.invalidMinutes && scope.minutes < 10 ) {
             scope.$apply( function() {
               scope.minutes = pad( scope.minutes );

--- a/src/tooltip/docs/demo.js
+++ b/src/tooltip/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 var TooltipDemoCtrl = function ($scope) {
   $scope.dynamicTooltip = 'Hello, World!';
   $scope.dynamicTooltipText = 'dynamic';

--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -143,7 +143,7 @@ describe('tooltip', function() {
     expect( elmBody.children().length ).toBe( 0 );
   }));
 
-  it('issue 1191 - isolate scope on the popup should always be child of correct element scope', inject( function ( $compile ) {
+  it('issue 1191 - isolate scope on the popup should always be child of correct element scope', function () {
     var ttScope;
     elm.trigger( 'mouseenter' );
 
@@ -159,7 +159,7 @@ describe('tooltip', function() {
     expect( ttScope.$parent ).toBe( elmScope );
 
     elm.trigger( 'mouseleave' );
-  }));
+  });
 
   describe('with specified enable expression', function() {
 
@@ -283,18 +283,16 @@ describe('tooltip', function() {
 
       $compile(elmBody)(scope);
       scope.$apply();
-      var elm1 = elmBody.find('input').eq(0);
-      var elm2 = elmBody.find('input').eq(1);
-      var elmScope1 = elm1.scope();
-      var elmScope2 = elm2.scope();
+      var elm = elmBody.find('input').eq(1);
+      var elmScope = elm.scope();
 
       scope.$apply('test = false');
 
-      elm2.trigger('mouseenter');
-      expect( elmScope2.tt_isOpen ).toBeFalsy();
+      elm.trigger('mouseenter');
+      expect( elmScope.tt_isOpen ).toBeFalsy();
 
-      elm2.click();
-      expect( elmScope2.tt_isOpen ).toBeTruthy();
+      elm.click();
+      expect( elmScope.tt_isOpen ).toBeTruthy();
     }));
   });
 
@@ -352,19 +350,16 @@ describe('tooltip', function() {
       tooltipScope = elmScope.$$childTail;
     }));
 
-    it( 'should not contain a cached reference when visible', inject( function( $timeout ) {
+    it( 'should not contain a cached reference when visible', function() {
       expect( inCache() ).toBeTruthy();
       elmScope.$destroy();
       expect( inCache() ).toBeFalsy();
-    }));
+    });
   });
 });
 
 describe('tooltipWithDifferentSymbols', function() {
-    var elm,
-        elmBody,
-        scope,
-        elmScope;
+    var elmBody;
 
     // load the tooltip code
     beforeEach(module('ui.bootstrap.tooltip'));
@@ -441,8 +436,7 @@ describe( '$tooltipProvider', function() {
   var elm,
       elmBody,
       scope,
-      elmScope,
-      body;
+      elmScope;
 
   describe( 'popupDelay', function() {
     beforeEach(module('ui.bootstrap.tooltip', function($tooltipProvider){

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -108,7 +108,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
       return {
         restrict: 'EA',
         scope: true,
-        compile: function (tElem, tAttrs) {
+        compile: function () {
           var tooltipLinker = $compile( template );
 
           return function link ( scope, element, attrs ) {

--- a/src/transition/transition.js
+++ b/src/transition/transition.js
@@ -16,7 +16,7 @@ angular.module('ui.bootstrap.transition', [])
     var deferred = $q.defer();
     var endEventName = $transition[options.animation ? 'animationEndEventName' : 'transitionEndEventName'];
 
-    var transitionEndHandler = function(event) {
+    var transitionEndHandler = function() {
       $rootScope.$apply(function() {
         element.unbind(endEventName, transitionEndHandler);
         deferred.resolve(element);

--- a/src/typeahead/docs/demo.js
+++ b/src/typeahead/docs/demo.js
@@ -1,3 +1,5 @@
+/*jshint unused:false */
+
 function TypeaheadCtrl($scope, $http) {
 
   $scope.selected = undefined;

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -210,7 +210,7 @@ describe('typeahead tests', function () {
     it('should bind loading indicator expression', inject(function ($timeout) {
 
       $scope.isLoading = false;
-      $scope.loadMatches = function (viewValue) {
+      $scope.loadMatches = function () {
         return $timeout(function () {
           return [];
         }, 1000);
@@ -274,7 +274,6 @@ describe('typeahead tests', function () {
       $templateCache.put('custom.html', '<p>{{ index }} {{ match.label }}</p>');
 
       var element = prepareInputEl('<div><input ng-model="result" typeahead-template-url="custom.html" typeahead="state as state.name for state in states | filter:$viewValue"></div>');
-      var inputEl = findInput(element);
 
       changeInputValueTo(element, 'Al');
 
@@ -341,7 +340,6 @@ describe('typeahead tests', function () {
         $scope.$label = $label;
       };
       var element = prepareInputEl('<div><input ng-model="result" typeahead-on-select="onSelect($item, $model, $label)" typeahead="state.code as state.name for state in states | filter:$viewValue"></div>');
-      var inputEl = findInput(element);
 
       changeInputValueTo(element, 'Alas');
       triggerKeyDown(element, 13);
@@ -447,7 +445,6 @@ describe('typeahead tests', function () {
 
     it('issue 231 - closes matches popup on click outside typeahead', function () {
       var element = prepareInputEl('<div><input ng-model="result" typeahead="item for item in source | filter:$viewValue"></div>');
-      var inputEl = findInput(element);
 
       changeInputValueTo(element, 'b');
 
@@ -513,7 +510,6 @@ describe('typeahead tests', function () {
         });
       };
       var element = prepareInputEl('<div><input ng-model="result" typeahead-min-length="2" typeahead-loading="isLoading" typeahead="item for item in items($viewValue)"></div>');
-      var inputEl = findInput(element);
 
       changeInputValueTo(element, 'match');
       $scope.$digest();

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -12,7 +12,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
   return {
     parse:function (input) {
 
-      var match = input.match(TYPEAHEAD_REGEXP), modelMapper, viewMapper, source;
+      var match = input.match(TYPEAHEAD_REGEXP);
       if (!match) {
         throw new Error(
           'Expected typeahead specification in form of "_modelValue_ (as _label_)? for _item_ in _collection_"' +
@@ -256,7 +256,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         }
       });
 
-      element.bind('blur', function (evt) {
+      element.bind('blur', function () {
         hasFocus = false;
       });
 


### PR DESCRIPTION
From @Gamemaniak PR and @belkos idea, I open this.

I am not sure if I like the changes to be honest.

There was a lot of stuff to change but I spotted some stuff:

There are a lot of stuff that should be removed. A lot of unused injects, and some variables created in a `beforEach` that are not used.

Then, there are complaints about `link` functions parameters that are not used. Not sure what to think about this.

The docs are easily fix overriding the rule.

Then, in the tests, there was a lot of dirt, but maybe and I say maybe some of those dirt are good for readability.

Also, we have the hacky reflow in `collapse` and `carousel` which I don't see a happy way to jump that (removing the reflow makes the tests pass, that means that the reflow is not needed or that our tests are not that good, and I vote for the later).

For me is :-1: (Is this my PR right? :P). I would vote to clean what is really dirty (a lot of unused stuff) but maybe leave the link function params and things like that. The downside is that we are not enforcing anything then.

PD: I don't know why a commit for another PR I made is here too, my git-fu sucks, but well, out of curiosity, it helps with the cleanup also.

PD2: Seems like I branched my branch :P
