### PR TITLE
fix(dropdown): use $animate for adding and removing classes

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -41,7 +41,7 @@ angular.module('ui.bootstrap.dropdown', [])
   };
 }])
 
-.controller('DropdownController', ['$scope', '$attrs', 'dropdownConfig', 'dropdownService', function($scope, $attrs, dropdownConfig, dropdownService, $animate) {
+.controller('DropdownController', ['$scope', '$attrs', 'dropdownConfig', 'dropdownService','$animate', function($scope, $attrs, dropdownConfig, dropdownService, $animate) {
   var self = this, openClass = dropdownConfig.openClass;
 
   this.init = function( element ) {
@@ -54,10 +54,12 @@ angular.module('ui.bootstrap.dropdown', [])
   };
 
   $scope.$watch('isOpen', function( value ) {
-    if (value) 
+    if (value)  {
       $animate.addClass(self.$element, openClass);
-    else
+    }
+    else {
       $animate.removeClass(self.$element, openClass);
+    }
 
     if ( value ) {
       dropdownService.open( $scope );


### PR DESCRIPTION
As AngularJS 1.2 was released, there is a need to use $animate for adding and removing classes.
