### PR TITLE
fix(modal): backdrop z-index when stacking modals

### DIFF
--- a/template/modal/backdrop.html
+++ b/template/modal/backdrop.html
@@ -1,1 +1,4 @@
-<div class="modal-backdrop fade" ng-class="{in: animate}" ng-style="{'z-index': 1040 + index*10}"></div>
+<div class="modal-backdrop fade"
+     ng-class="{in: animate}"
+     ng-style="{'z-index': 1040 + (index && 1 || 0) + index*10}"
+></div>


### PR DESCRIPTION
Previously, backdrop wouldn't go over the previous open modal when a
modal is open on top of another.

Also broken the template into multiple lines, to make it more readable. Not sure if that style is better.

One way of fixing #1653 
