### PR TITLE
fix(timepicker): if a date is passed as ng-model respect that date

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -10,12 +10,16 @@ angular.module('ui.bootstrap.timepicker', [])
 })
 
 .controller('TimepickerController', ['$scope', '$attrs', '$parse', '$log', '$locale', 'timepickerConfig', function($scope, $attrs, $parse, $log, $locale, timepickerConfig) {
-  var selected = new Date(),
+  var selected,
       ngModelCtrl = { $setViewValue: angular.noop }, // nullModelCtrl
       meridians = angular.isDefined($attrs.meridians) ? $scope.$parent.$eval($attrs.meridians) : timepickerConfig.meridians || $locale.DATETIME_FORMATS.AMPMS;
 
   this.init = function( ngModelCtrl_, inputs ) {
     ngModelCtrl = ngModelCtrl_;
+
+    // if a date is passed via ng-model update "selected", otherwise, use now
+    selected = ngModelCtrl.$modelValue instanceof Date ? ngModelCtrl.$modelValue : new Date();
+
     ngModelCtrl.$render = this.render;
 
     var hoursInputEl = inputs.eq(0),


### PR DESCRIPTION
If a date is passed to the timepicker component, then it is ignored and `var selected` is set to `new Date()`. This is not expected behaviour, if a date is passed it should be used.
