### PR TITLE
feat(progressbar): allow fractional values for bar width

### DIFF
--- a/src/progressbar/progressbar.js
+++ b/src/progressbar/progressbar.js
@@ -20,7 +20,7 @@ angular.module('ui.bootstrap.progressbar', [])
         this.bars.push(bar);
 
         bar.$watch('value', function( value ) {
-            bar.percent = Math.round(100 * value / $scope.max);
+            bar.percent = +(100 * value / $scope.max).toFixed(2);
         });
 
         bar.$on('$destroy', function() {

--- a/src/progressbar/test/progressbar.spec.js
+++ b/src/progressbar/test/progressbar.spec.js
@@ -65,6 +65,27 @@ describe('progressbar directive', function () {
       expect(bar.attr('aria-valuetext')).toBe('60%');
     });
 
+  it('allows fractional "bar" width values, rounded to two places', function () {
+    $rootScope.value = 5.625;
+    $rootScope.$digest();
+    expect(getBar(0).css('width')).toBe('5.63%');
+
+    $rootScope.value = 1.3;
+    $rootScope.$digest();
+    expect(getBar(0).css('width')).toBe('1.3%');
+  });
+
+  it('does not include decimals in aria values', function () {
+    $rootScope.value = 50.34;
+    $rootScope.$digest();
+
+    var bar = getBar(0);
+    expect(bar.css('width')).toBe('50.34%');
+
+    expect(bar.attr('aria-valuenow')).toBe('50');
+    expect(bar.attr('aria-valuetext')).toBe('50%');
+  });
+
   describe('"max" attribute', function () {
     beforeEach(inject(function() {
       $rootScope.max = 200;

--- a/template/progressbar/progressbar.html
+++ b/template/progressbar/progressbar.html
@@ -1,3 +1,3 @@
 <div class="progress">
-  <div class="progress-bar" ng-class="type && 'progress-bar-' + type" role="progressbar" aria-valuenow="{{value}}" aria-valuemin="0" aria-valuemax="{{max}}" ng-style="{width: percent + '%'}" aria-valuetext="{{percent}}%" ng-transclude></div>
+  <div class="progress-bar" ng-class="type && 'progress-bar-' + type" role="progressbar" aria-valuenow="{{value | number:0}}" aria-valuemin="0" aria-valuemax="{{max}}" ng-style="{width: percent + '%'}" aria-valuetext="{{percent | number:0}}%" ng-transclude></div>
 </div>


### PR DESCRIPTION
I was trying to get the animation of the progress bar to match the transition speed (.2 seconds by default) and couldn't get it to work exactly right for my code because the progress bar was always fitting to integer percentages.

I don't think there is any technical reason that the progress bar should be limited to integer steps. Here, I've used $filter('number') to truncate the progress bar value to a max precision of three decimals. Now, it can cover a larger range of values than just integers, but pathologically long fractions like 0.33333333333 won't creep in to the DOM.
