### PR TITLE
refactor(pagination): move boundary & directions to the template

### DIFF
--- a/template/pagination/pager.html
+++ b/template/pagination/pager.html
@@ -1,3 +1,4 @@
 <ul class="pager">
-  <li ng-repeat="page in pages track by $index" ng-class="{disabled: page.disabled, previous: page.previous, next: page.next}"><a href ng-click="selectPage(page.number)">{{page.text}}</a></li>
+  <li ng-class="{disabled: noPrevious(), previous: align}"><a href ng-click="selectPage(page - 1)">{{getText('previous')}}</a></li>
+  <li ng-class="{disabled: noNext(), next: align}"><a href ng-click="selectPage(page + 1)">{{getText('next')}}</a></li>
 </ul>

--- a/template/pagination/pagination.html
+++ b/template/pagination/pagination.html
@@ -1,3 +1,7 @@
 <ul class="pagination">
-  <li ng-repeat="page in pages track by $index" ng-class="{active: page.active, disabled: page.disabled}"><a href ng-click="selectPage(page.number)">{{page.text}}</a></li>
+  <li ng-if="boundaryLinks" ng-class="{disabled: noPrevious()}"><a href ng-click="selectPage(1)">{{getText('first')}}</a></li>
+  <li ng-if="directionLinks" ng-class="{disabled: noPrevious()}"><a href ng-click="selectPage(page - 1)">{{getText('previous')}}</a></li>
+  <li ng-repeat="page in pages track by $index" ng-class="{active: page.active}"><a href ng-click="selectPage(page.number)">{{page.text}}</a></li>
+  <li ng-if="directionLinks" ng-class="{disabled: noNext()}"><a href ng-click="selectPage(page + 1)">{{getText('next')}}</a></li>
+  <li ng-if="boundaryLinks" ng-class="{disabled: noNext()}"><a href ng-click="selectPage(totalPages)">{{getText('last')}}</a></li>
 </ul>


### PR DESCRIPTION
Since `ng-if` is now an option, it's better to move the boundary/direction links to the template, so users can apply custom styles easier. Also, reduced the `pager`'s complexity.
