### PR TITLE
refactor(accordion): transclude function in compile is deprecated.

### DIFF
--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -100,13 +100,11 @@ angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse'])
     template: '',       // In effect remove this element!
     replace: true,
     require: '^accordionGroup',
-    compile: function(element, attr, transclude) {
-      return function link(scope, element, attr, accordionGroupCtrl) {
-        // Pass the heading to the accordion-group controller
-        // so that it can be transcluded into the right place in the template
-        // [The second parameter to transclude causes the elements to be cloned so that they work in ng-repeat]
-        accordionGroupCtrl.setHeading(transclude(scope, function() {}));
-      };
+    link: function(scope, element, attr, accordionGroupCtrl, transclude) {
+      // Pass the heading to the accordion-group controller
+      // so that it can be transcluded into the right place in the template
+      // [The second parameter to transclude causes the elements to be cloned so that they work in ng-repeat]
+      accordionGroupCtrl.setHeading(transclude(scope, function() {}));
     }
   };
 })


### PR DESCRIPTION
In official AngularJS document http://docs.angularjs.org/api/ng.$compile, transclude function in compile is deprecated, and should use the transclude function that is passed to the link function instead.

```
transclude - [DEPRECATED!] A transclude linking function: function(scope, cloneLinkingFn)
```
