### PR TITLE
refactor(progressbar): apply number filter and in `bar` template

### DIFF
--- a/src/progressbar/test/progressbar.spec.js
+++ b/src/progressbar/test/progressbar.spec.js
@@ -81,8 +81,6 @@ describe('progressbar directive', function () {
 
     var bar = getBar(0);
     expect(bar.css('width')).toBe('50.34%');
-
-    expect(bar.attr('aria-valuenow')).toBe('50');
     expect(bar.attr('aria-valuetext')).toBe('50%');
   });
 

--- a/template/progressbar/bar.html
+++ b/template/progressbar/bar.html
@@ -1,1 +1,1 @@
-<div class="progress-bar" ng-class="type && 'progress-bar-' + type" role="progressbar" aria-valuenow="{{value}}" aria-valuemin="0" aria-valuemax="{{max}}" ng-style="{width: percent + '%'}" aria-valuetext="{{percent}}%" ng-transclude></div>
+<div class="progress-bar" ng-class="type && 'progress-bar-' + type" role="progressbar" aria-valuenow="{{value}}" aria-valuemin="0" aria-valuemax="{{max}}" ng-style="{width: percent + '%'}" aria-valuetext="{{percent | number:0}}%" ng-transclude></div>

--- a/template/progressbar/progressbar.html
+++ b/template/progressbar/progressbar.html
@@ -1,3 +1,3 @@
 <div class="progress">
-  <div class="progress-bar" ng-class="type && 'progress-bar-' + type" role="progressbar" aria-valuenow="{{value | number:0}}" aria-valuemin="0" aria-valuemax="{{max}}" ng-style="{width: percent + '%'}" aria-valuetext="{{percent | number:0}}%" ng-transclude></div>
+  <div class="progress-bar" ng-class="type && 'progress-bar-' + type" role="progressbar" aria-valuenow="{{value}}" aria-valuemin="0" aria-valuemax="{{max}}" ng-style="{width: percent + '%'}" aria-valuetext="{{percent | number:0}}%" ng-transclude></div>
 </div>


### PR DESCRIPTION
Zero fraction filter should only be applied in `percent`, not in `value`.
