### PR TITLE
Candidate fix for #1812 - Modal + iOS virtual keyboard

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -117,8 +117,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
     };
   }])
 
-  .factory('$modalStack', ['$transition', '$timeout', '$document', '$compile', '$rootScope', '$$stackedMap', '$userAgent', '$window',
-    function ($transition, $timeout, $document, $compile, $rootScope, $$stackedMap, $userAgent, $window) {
+  .factory('$modalStack', ['$transition', '$timeout', '$document', '$compile', '$rootScope', '$$stackedMap', '$userAgent',
+    function ($transition, $timeout, $document, $compile, $rootScope, $$stackedMap, $userAgent) {
 
       var OPENED_MODAL_CLASS = 'modal-open';
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -1,6 +1,17 @@
 angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
 
 /**
+ * A helper to determine if the user agent is iOS (see issue #1812). This can be removed at the point when iOS fixes the bug.
+ */
+  .factory('$userAgent', ['$window', function ($window) {
+    return {
+      isIOS: function () {
+        return /iPhone|iPad|iPod/i.test($window.navigator.userAgent);
+      }
+    }
+  }])
+
+/**
  * A helper, internal data structure that acts as a map but also allows getting / removing
  * elements in the LIFO order
  */
@@ -106,8 +117,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
     };
   }])
 
-  .factory('$modalStack', ['$transition', '$timeout', '$document', '$compile', '$rootScope', '$$stackedMap',
-    function ($transition, $timeout, $document, $compile, $rootScope, $$stackedMap) {
+  .factory('$modalStack', ['$transition', '$timeout', '$document', '$compile', '$rootScope', '$$stackedMap', '$userAgent', '$window',
+    function ($transition, $timeout, $document, $compile, $rootScope, $$stackedMap, $userAgent, $window) {
 
       var OPENED_MODAL_CLASS = 'modal-open';
 
@@ -235,6 +246,16 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         openedWindows.top().value.modalDomEl = modalDomEl;
         body.append(modalDomEl);
         body.addClass(OPENED_MODAL_CLASS);
+
+        // Workaround for issue #1812. This can be removed at the point when iOS fixes the bug.
+        if ($userAgent.isIOS()) {
+          setTimeout(function () {
+            angularDomEl.addClass('modal-ios');
+            $('.modal').height($document.height());
+            $('.modal-backdrop').height($document.height());
+            $window.scrollTo(0, 0);
+          }, 0);
+        }
       };
 
       $modalStack.close = function (modalInstance, result) {

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -251,8 +251,9 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         if ($userAgent.isIOS()) {
           setTimeout(function () {
             angularDomEl.addClass('modal-ios');
-            $('.modal-backdrop').height($document.height());
-            $('.modal')
+            angular.element($document[0].getElementsByClassName('modal-backdrop'))
+              .height($document.height());
+            angular.element($document[0].getElementsByClassName('modal'))
               .height($document.height())
               .css({'margin-top': $document.scrollTop() + 'px'});
           }, 0);

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -251,9 +251,10 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         if ($userAgent.isIOS()) {
           setTimeout(function () {
             angularDomEl.addClass('modal-ios');
-            $('.modal').height($document.height());
             $('.modal-backdrop').height($document.height());
-            $window.scrollTo(0, 0);
+            $('.modal')
+              .height($document.height())
+              .css({'margin-top': $document.scrollTop() + 'px'});
           }, 0);
         }
       };

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -8,7 +8,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
       isIOS: function () {
         return /iPhone|iPad|iPod/i.test($window.navigator.userAgent);
       }
-    }
+    };
   }])
 
 /**


### PR DESCRIPTION
If the user-agent is iOS, then:

1. Add an extra class so that people can choose to opt in to the workaround by adding a style.
2. Adjust the heights for the modal and backdrop.
3. Ensure modal opens inside the viewport by adding top margin.

Style needed to complete the workaround:

```css
.modal-ios {
	position: absolute;
	overflow: visible
}
```

You could add the style inline, but probably better to just offer a hook for people to opt-in to.

Ref: #1812 