### PR TITLE
refactor(tooltip): remove observers

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -271,7 +271,7 @@ describe('tooltip', function() {
       expect( elmScope.tt_isOpen ).toBeFalsy();
     }));
 
-    it('should not share triggers among different element instances - issue 692', inject( function ($compile) {
+    it('should only set up triggers once', inject( function ($compile) {
 
       scope.test = true;
       elmBody = angular.element(
@@ -290,10 +290,12 @@ describe('tooltip', function() {
 
       scope.$apply('test = false');
 
-      elm2.trigger('mouseenter');
+      // click trigger isn't set
+      elm2.click();
       expect( elmScope2.tt_isOpen ).toBeFalsy();
 
-      elm2.click();
+      // mouseenter trigger is still set
+      elm2.trigger('mouseenter');
       expect( elmScope2.tt_isOpen ).toBeTruthy();
     }));
   });

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -281,7 +281,8 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
               element.unbind(triggers.hide, hideTooltipBind);
             };
 
-            attrs.$observe( prefix+'Trigger', function ( val ) {
+            function prepTriggers() {
+              var val = attrs[ prefix + 'Trigger' ];
               unregisterTriggers();
 
               triggers = getTriggers( val );
@@ -292,7 +293,8 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
                 element.bind( triggers.show, showTooltipBind );
                 element.bind( triggers.hide, hideTooltipBind );
               }
-            });
+            }
+            prepTriggers();
 
             var animation = scope.$eval(attrs[prefix + 'Animation']);
             scope.tt_animation = angular.isDefined(animation) ? !!animation : options.animation;


### PR DESCRIPTION
Part of #1600. Lazily evaluate values only when they're needed.

Breaking change:
- Set up triggers only once, so the triggers can't be changed later

It's possible to remove the observers for title and content and lazily evaluate them as well. That part can also be abstracted into a controller method.
