### PR TITLE
Bugfix: Datepicker doesn't mark input field invalid if the date is invalid

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -368,7 +368,7 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
         if (!viewValue) {
           ngModel.$setValidity('date', true);
           return null;
-        } else if (angular.isDate(viewValue)) {
+        } else if (angular.isDate(viewValue) && !isNaN(viewValue)) {
           ngModel.$setValidity('date', true);
           return viewValue;
         } else if (angular.isString(viewValue)) {

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -248,6 +248,15 @@ describe('datepicker directive', function () {
           testCalendar();
           expect(angular.isDate($rootScope.date)).toBe(true);
         });
+
+        it('to a date that is invalid, it gets invalid', function() {
+          $rootScope.date = new Date('pizza');
+          $rootScope.$digest();
+          expect(element.hasClass('ng-invalid')).toBeTruthy();
+          expect(element.hasClass('ng-invalid-date')).toBeTruthy();
+          expect(angular.isDate($rootScope.date)).toBe(true);
+          expect(isNaN($rootScope.date)).toBe(true);
+        });
       });
 
       describe('not to a Date object', function() {


### PR DESCRIPTION
I wanted to use the date picker, with the danish date format "dd/MM/yyyy", and found several issues (#956, #1107, #1430) and also a TODO in the code, all refering to that this was not yet implemented for manual typing in the input field.

One solution I found described in the issues (#956) was to use: https://github.com/dnasir/angular-dateParser, which works perfect - except an error in angular UI datepicker became visible.

If your from the JS set the value of date-field to a date that is invalid (for instance new Date(undefined) or new Date("pizza"), which both return a date object, in the state "Invalid Date"), the field is not marked "invalid".

Fix is simple, right now the code just checks if the value is a date, and then marks is valid. But we just need to also check that the date is actual valid ( isNan(date) return true the date is invalid)
