### PR TITLE
feat(popover): support templates

### DIFF
--- a/src/popover/docs/demo.html
+++ b/src/popover/docs/demo.html
@@ -2,14 +2,27 @@
     <h4>Dynamic</h4>
     <div class="form-group">
       <label>Popup Text:</label>
-      <input type="text" ng-model="dynamicPopover" class="form-control">
+      <input type="text" ng-model="dynamicPopover.content" class="form-control">
     </div>
     <div class="form-group">
       <label>Popup Title:</label>
-      <input type="text" ng-model="dynamicPopoverTitle" class="form-control">
+      <input type="text" ng-model="dynamicPopover.title" class="form-control">
     </div>
-    <button popover="{{dynamicPopover}}" popover-title="{{dynamicPopoverTitle}}" class="btn btn-default">Dynamic Popover</button>
-    
+    <div class="form-group">
+      <label>Popup Template:</label>
+      <input type="text" ng-model="dynamicPopover.templateUrl" class="form-control">
+    </div>
+    <button popover="{{dynamicPopover.content}}" popover-title="{{dynamicPopover.title}}" class="btn btn-default">Dynamic Popover</button>
+
+    <button popover-template="{{dynamicPopover.templateUrl}}" popover-template-title="{{dynamicPopover.title}}" class="btn btn-default">Popover With Template</button>
+
+    <script type="text/ng-template" id="myPopoverTemplate.html">
+        <div>{{dynamicPopover.content}}</div>
+        <div class="form-group">
+          <label>Popup Title:</label>
+          <input type="text" ng-model="dynamicPopover.title" class="form-control">
+        </div>
+    </script>
     <hr />
     <h4>Positional</h4>
     <button popover-placement="top" popover="On the Top!" class="btn btn-default">Top</button>

--- a/src/popover/docs/demo.js
+++ b/src/popover/docs/demo.js
@@ -1,4 +1,7 @@
 angular.module('ui.bootstrap.demo').controller('PopoverDemoCtrl', function ($scope) {
-  $scope.dynamicPopover = 'Hello, World!';
-  $scope.dynamicPopoverTitle = 'Title';
+  $scope.dynamicPopover = {
+    content: 'Hello, World!',
+    templateUrl: 'myTemplatePopover.html',
+    title: 'Title'
+  };
 });

--- a/src/popover/docs/readme.md
+++ b/src/popover/docs/readme.md
@@ -4,6 +4,13 @@ directive supports multiple placements, optional transition animation, and more.
 Like the Bootstrap jQuery plugin, the popover **requires** the tooltip
 module.
 
+There are two versions of the popover: `popover` and `popover-template`:
+
+- `popover` takes text only and will escape any HTML provided for the popover
+  body.
+- `popover-template` takes text that specifies the location of a template to
+  use for the popover body.
+
 The popover directives provides several optional attributes to control how it
 will display:
 

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -5,6 +5,20 @@
  */
 angular.module( 'ui.bootstrap.popover', [ 'ui.bootstrap.tooltip' ] )
 
+.directive( 'popoverTemplatePopup', function () {
+  return {
+    restrict: 'EA',
+    replace: true,
+    scope: { title: '@', content: '@', placement: '@', animation: '&', isOpen: '&',
+      originScope: '&' },
+    templateUrl: 'template/popover/popover-template.html'
+  };
+})
+
+.directive( 'popoverTemplate', [ '$tooltip', function ( $tooltip ) {
+  return $tooltip( 'popoverTemplate', 'popoverTemplate', 'click' );
+}])
+
 .directive( 'popoverPopup', function () {
   return {
     restrict: 'EA',

--- a/src/popover/test/popover-template.spec.js
+++ b/src/popover/test/popover-template.spec.js
@@ -1,0 +1,66 @@
+describe('popover template', function() {
+  var elm,
+      elmBody,
+      scope,
+      elmScope,
+      tooltipScope;
+
+  // load the popover code
+  beforeEach(module('ui.bootstrap.popover'));
+
+  // load the template
+  beforeEach(module('template/popover/popover.html'));
+  beforeEach(module('template/popover/popover-template.html'));
+
+  beforeEach(inject(function ($templateCache) {
+    $templateCache.put('myUrl', [200, '<span>{{ myTemplateText }}</span>', {}]);
+  }));
+
+  beforeEach(inject(function($rootScope, $compile) {
+    elmBody = angular.element(
+      '<div><span popover-template="{{ templateUrl }}">Selector Text</span></div>'
+    );
+
+    scope = $rootScope;
+    $compile(elmBody)(scope);
+    scope.templateUrl = 'myUrl';
+
+    scope.$digest();
+    elm = elmBody.find('span');
+    elmScope = elm.scope();
+    tooltipScope = elmScope.$$childTail;
+  }));
+
+  it('should open on click', inject(function() {
+    elm.trigger( 'click' );
+    expect( tooltipScope.isOpen ).toBe( true );
+
+    expect( elmBody.children().length ).toBe( 2 );
+  }));
+
+  it('should not open on click if templateUrl is empty', inject(function() {
+    scope.templateUrl = null;
+    scope.$digest();
+
+    elm.trigger( 'click' );
+    expect( tooltipScope.isOpen ).toBe( false );
+
+    expect( elmBody.children().length ).toBe( 1 );
+  }));
+
+  it('should show updated text', inject(function() {
+    scope.myTemplateText = 'some text';
+    scope.$digest();
+
+    elm.trigger( 'click' );
+    expect( tooltipScope.isOpen ).toBe( true );
+
+    expect( elmBody.children().eq(1).text().trim() ).toBe( 'some text' );
+
+    scope.myTemplateText = 'new text';
+    scope.$digest();
+
+    expect( elmBody.children().eq(1).text().trim() ).toBe( 'new text' );
+  }));
+});
+

--- a/src/tooltip/docs/demo.html
+++ b/src/tooltip/docs/demo.html
@@ -20,6 +20,8 @@
       <a href="#" tooltip-animation="false" tooltip="I don't fade. :-(">fading</a>
       at elementum eu, facilisis sed odio morbi quis commodo odio. In cursus
       <a href="#" tooltip-popup-delay='1000' tooltip='appears with delay'>delayed</a> turpis massa tincidunt dui ut.
+      <a href="#" tooltip-template="myTooltipTemplate.html">Custom template</a>
+      nunc sed velit dignissim sodales ut eu sem integer vitae. Turpis egestas
     </p>
 
     <p>
@@ -58,4 +60,8 @@
           tooltip-enable="!inputModel" />
       </div>
     </form>
+
+    <script type="text/ng-template" id="myTooltipTemplate.html">
+      <span>Special Tooltip with <strong>markup</strong> and {{ dynamicTooltipText }}</span>
+    </script>
 </div>

--- a/src/tooltip/docs/readme.md
+++ b/src/tooltip/docs/readme.md
@@ -1,11 +1,16 @@
 A lightweight, extensible directive for fancy tooltip creation. The tooltip
 directive supports multiple placements, optional transition animation, and more.
 
-There are two versions of the tooltip: `tooltip` and `tooltip-html-unsafe`. The
-former takes text only and will escape any HTML provided. The latter takes
-whatever HTML is provided and displays it in a tooltip; it's called "unsafe"
-because the HTML is not sanitized. *The user is responsible for ensuring the
-content is safe to put into the DOM!*
+There are three versions of the tooltip: `tooltip`, `tooltip-template`, and
+`tooltip-html-unsafe`:
+
+- `tooltip` takes text only and will escape any HTML provided.
+- `tooltip-template` takes text that specifies the location of a template to
+  use for the tooltip.
+- `tooltip-html-unsafe` takes
+  whatever HTML is provided and displays it in a tooltip; it's called "unsafe"
+  because the HTML is not sanitized. *The user is responsible for ensuring the
+  content is safe to put into the DOM!*
 
 The tooltip directives provide several optional attributes to control how they
 will display:

--- a/src/tooltip/test/tooltip-template.spec.js
+++ b/src/tooltip/test/tooltip-template.spec.js
@@ -1,0 +1,65 @@
+describe('tooltip template', function() {
+  var elm,
+      elmBody,
+      scope,
+      elmScope,
+      tooltipScope;
+
+  // load the popover code
+  beforeEach(module('ui.bootstrap.tooltip'));
+
+  // load the template
+  beforeEach(module('template/tooltip/tooltip-template-popup.html'));
+
+  beforeEach(inject(function ($templateCache) {
+    $templateCache.put('myUrl', [200, '<span>{{ myTemplateText }}</span>', {}]);
+  }));
+
+  beforeEach(inject(function($rootScope, $compile) {
+    elmBody = angular.element(
+      '<div><span tooltip-template="{{ templateUrl }}">Selector Text</span></div>'
+    );
+
+    scope = $rootScope;
+    $compile(elmBody)(scope);
+    scope.templateUrl = 'myUrl';
+
+    scope.$digest();
+    elm = elmBody.find('span');
+    elmScope = elm.scope();
+    tooltipScope = elmScope.$$childTail;
+  }));
+
+  it('should open on mouseenter', inject(function() {
+    elm.trigger( 'mouseenter' );
+    expect( tooltipScope.isOpen ).toBe( true );
+
+    expect( elmBody.children().length ).toBe( 2 );
+  }));
+
+  it('should not open on mouseenter if templateUrl is empty', inject(function() {
+    scope.templateUrl = null;
+    scope.$digest();
+
+    elm.trigger( 'mouseenter' );
+    expect( tooltipScope.isOpen ).toBe( false );
+
+    expect( elmBody.children().length ).toBe( 1 );
+  }));
+
+  it('should show updated text', inject(function() {
+    scope.myTemplateText = 'some text';
+    scope.$digest();
+
+    elm.trigger( 'mouseenter' );
+    expect( tooltipScope.isOpen ).toBe( true );
+
+    expect( elmBody.children().eq(1).text().trim() ).toBe( 'some text' );
+
+    scope.myTemplateText = 'new text';
+    scope.$digest();
+
+    expect( elmBody.children().eq(1).text().trim() ).toBe( 'new text' );
+  }));
+});
+

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -434,6 +434,23 @@ function ($animate ,  $sce ,  $compile ,  $templateRequest) {
   return $tooltip( 'tooltip', 'tooltip', 'mouseenter' );
 }])
 
+.directive( 'tooltipTemplatePopup', function () {
+  return {
+    restrict: 'EA',
+    replace: true,
+    scope: { title: '@', content: '@', placement: '@', animation: '&', isOpen: '&',
+      originScope: '&' },
+    templateUrl: 'template/tooltip/tooltip-template-popup.html'
+  };
+})
+
+.directive( 'tooltipTemplate', [ '$tooltip', function ( $tooltip ) {
+  return $tooltip( 'tooltipTemplate', 'tooltipTemplate', 'mouseenter' );
+}])
+
+/*
+Deprecated
+*/
 .directive( 'tooltipHtmlUnsafePopup', function () {
   return {
     restrict: 'EA',

--- a/template/popover/popover-template.html
+++ b/template/popover/popover-template.html
@@ -1,0 +1,10 @@
+<div class="popover {{placement}}" ng-class="{ in: isOpen(), fade: animation() }">
+  <div class="arrow"></div>
+
+  <div class="popover-inner">
+      <h3 class="popover-title" ng-bind="title" ng-show="title"></h3>
+      <div class="popover-content"
+        tooltip-template-transclude="content"
+        tooltip-template-transclude-scope="originScope()"></div>
+  </div>
+</div>

--- a/template/tooltip/tooltip-template-popup.html
+++ b/template/tooltip/tooltip-template-popup.html
@@ -1,0 +1,6 @@
+<div class="tooltip {{placement}}" ng-class="{ in: isOpen(), fade: animation() }">
+  <div class="tooltip-arrow"></div>
+  <div class="tooltip-inner"
+    tooltip-template-transclude="content"
+    tooltip-template-transclude-scope="originScope()"></div>
+</div>


### PR DESCRIPTION
**Update: This is ready to merge.**
~~Here's a poll for anybody to get involved in voting to name this directive:
http://goo.gl/forms/oxW1B4L81B~~ Thank you. It'll be called `popover-template` and `tooltip-template`.

Update: I finally got to this. This should be ready for testing.

TODO:
- [x] Needs Tests
- [x] Needs documentation
- [x] Doesn't support live updating of the positioning after the template has been reloaded
- [x] Doesn't support changing of the template URL (there's no watcher)

This is a proof of concept to use a tooltipController to transclude a template.

It's based off #1600 and most of the changes are from that. See https://github.com/chrisirhc/angular-ui-bootstrap/commit/0a1510c957bd385db61dcb1a8366fef97fd38e74 for actual changes for the popoverWindow.
![record](https://f.cloud.github.com/assets/132584/2243498/a3e7f958-9d2c-11e3-9a2f-ae1bea980598.gif)

Tests are missing but I wanted to open this up for discussion or comment.

Fixes #220