### PR TITLE
FIX - DatePicker now accepts input value fields with the right formatDate

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -381,7 +381,7 @@ function ($compile, $parse, $document, $position, dateFilter, datepickerPopupCon
             var date = new Date(dateStr);
             if (dateParts.length === 3){
               date = new Date(dateParts[2], dateParts[1] - 1, dateParts[0]);
-            }  
+            }
             if (isNaN(date)) {
               ngModel.$setValidity('date', false);
               return undefined;


### PR DESCRIPTION
I noticed that when you type the date in a input field instead of picking it. It was not parsing it right through the dateFormat informed, saw this problem on some issues: (#956, #1107, #1430).

This Fix will parse the input value typed with the dateFormat informed and pick it on the datepicker if the date is valid. Hope it can help others. Working fine for me now when dateFormat is 'dd/MM/YYYY'. I can type date in this format and it will pick it right in the datepicker.
