### PR TITLE
Bug fixes / enhancements to modal (autofocus issue and opened promise is...

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -187,7 +187,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
           });
         } else {
           // Ensure this call is async
-          $timeout(afterAnimating);
+          $timeout(afterAnimating, 0);
         }
 
         function afterAnimating() {
@@ -275,11 +275,6 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         return openedWindows.top();
       };
 
-      // Added get method (by modalInstance) to $modalStack
-      $modalStack.get = function (modalInstance) {
-        return openedWindows.get(modalInstance);
-      };
-
       return $modalStack;
     }])
 
@@ -290,8 +285,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         backdrop: true, //can be also false or 'static'
         keyboard: true
       },
-      $get: ['$injector', '$rootScope', '$q', '$http', '$templateCache', '$controller', '$modalStack', '$transition', '$timeout',
-        function ($injector, $rootScope, $q, $http, $templateCache, $controller, $modalStack, $transition, $timeout) {
+      $get: ['$injector', '$rootScope', '$q', '$http', '$templateCache', '$controller', '$modalStack',
+        function ($injector, $rootScope, $q, $http, $templateCache, $controller, $modalStack) {
 
           var $modal = {};
 


### PR DESCRIPTION
...sue)

1) Auto-focusing of a freshly-opened modal element causes any child elements with the autofocus attribute to loose focus. This is an issue on touch based devices which will show and then hide the onscreen keyboard. Attempts to refocus the autofocus element via JavaScript will not reopen the onscreen keyboard. Fixed by updated the focusing logic to only autofocus the modal element if the modal does not contain an autofocus element.

2) Added $modalStack.get(modalInstance) method, which is used by the next fix.

3) Moved the modalOpenedDeferred to a transition end event (when available) so that the opened promise doesn't get resolved until the modal is in the DOM and visible / accessible.

Signed-off-by: Michael Lilli mlilli@innov8ia.com
