### PR TITLE
fix(datepicker): works without ng-model

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -81,8 +81,10 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.position'])
     if ( this.element ) {
       this._refreshView();
 
-      var date = ngModelCtrl.$modelValue ? new Date(ngModelCtrl.$modelValue) : null;
-      ngModelCtrl.$setValidity('date-disabled', !date || (this.element && !this.isDisabled(date)));
+      if (ngModelCtrl.$modelValue) {
+        var date = ngModelCtrl.$modelValue ? new Date(ngModelCtrl.$modelValue) : null;
+        ngModelCtrl.$setValidity('date-disabled', !date || (this.element && !this.isDisabled(date)));
+      }
     }
   };
 

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -690,6 +690,39 @@ describe('datepicker directive', function () {
 
   });
 
+  describe('attribute `ng-model`', function() {
+    var dateFilter, today;
+    beforeEach(inject(function(_dateFilter_) {
+      dateFilter = _dateFilter_;
+      today = new Date();
+      element = $compile('<datepicker></datepicker>')($rootScope);
+      $rootScope.$digest();
+    }));
+
+    it('should work without model on day-mode', function() {
+      var title = dateFilter(today, 'MMMM yyyy');
+      expect(getTitle()).toBe(title);
+    });
+
+    it('should work without model on month-mode', function() {
+      clickTitleButton();
+      var title = dateFilter(today, 'yyyy');
+      expect(getTitle()).toBe(title);
+    });
+
+    it('should work without model on year-mode', function() {
+      clickTitleButton();
+      clickTitleButton();
+
+      // Simulate datepicker's algorithm for year ranges
+      var start = parseInt((today.getFullYear() - 1) / 20, 10) * 20 + 1;
+      var end = start + 19; // The default range is 20;
+      var title = start + ' - ' + end;
+
+      expect(getTitle()).toBe(title);
+    });
+  });
+
   describe('attribute `starting-day`', function () {
     beforeEach(function() {
       $rootScope.startingDay = 1;


### PR DESCRIPTION
This was one of the things we needed to fix on datepicker for the next version. It just needed a guard to check that there is a ngModel present.

For the tests, well, that is a hard part. There is no difference visually on the datepicker without ng-model, the only difference now is that it doesn't throw an exception :P. So I decided to test that the actual month is showed.

Testing for actual date is pretty hard because you can't hardcode anything so I decided to check that the title is the correct one.

I had to improvise a little bit on the year one :P

Ping @bekos