### PR TITLE
fix(tooltip): animation causes tooltip to hide on show

### DIFF
--- a/src/tooltip/test/tooltip2.spec.js
+++ b/src/tooltip/test/tooltip2.spec.js
@@ -102,4 +102,35 @@ describe('tooltip directive', function () {
     });
 
   });
+
+  it('should show even after close trigger is called multiple times - issue #1847', function () {
+    var fragment = compileTooltip('<span tooltip="tooltip text">Trigger here</span>');
+
+    fragment.find('span').trigger( 'mouseenter' );
+    expect(fragment).toHaveOpenTooltips();
+
+    closeTooltip(fragment.find('span'), null, true);
+    // Close trigger is called again before timer completes
+    // The close trigger can be called any number of times (even after close has already been called)
+    // since users can trigger the hide triggers manually.
+    closeTooltip(fragment.find('span'), null, true);
+    expect(fragment).toHaveOpenTooltips();
+
+    fragment.find('span').trigger( 'mouseenter' );
+    expect(fragment).toHaveOpenTooltips();
+
+    $timeout.flush();
+    expect(fragment).toHaveOpenTooltips();
+  });
+
+  it('should hide even after show trigger is called multiple times', function () {
+    var fragment = compileTooltip('<span tooltip="tooltip text" tooltip-popup-delay="1000">Trigger here</span>');
+
+    fragment.find('span').trigger( 'mouseenter' );
+    fragment.find('span').trigger( 'mouseenter' );
+
+    closeTooltip(fragment.find('span'));
+    expect(fragment).not.toHaveOpenTooltips();
+  });
+
 });


### PR DESCRIPTION
Add logic to handle cases where hide/show can be called multiple times
even before their timeouts complete.

This is more ugly logic to handle degenerate cases. Hopefully switching
over to ngAnimate and cleaning up the logic of tooltips will be better.

Fixes #1847
