### PR TITLE
fix(timepicker): Enhanced minutes/hours interaction

### DIFF
--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -755,10 +755,74 @@ describe('timepicker directive', function () {
       expect(element.hasClass('ng-invalid-time')).toBe(false);
     });
 
+    it('clears model when input hours starts with an invalid character & alerts the UI', function() {
+      var el = getHoursInputEl();
+
+      changeInputValueTo(el, '!5');
+      expect($rootScope.time).toBe(null);
+      expect(el.parent().hasClass('has-error')).toBe(true);
+      expect(element.hasClass('ng-invalid-time')).toBe(true);
+
+      changeInputValueTo(el, 8);
+      el.blur();
+      $rootScope.$digest();
+      expect(getTimeState()).toEqual(['08', '40', 'PM']);
+      expect(getModelState()).toEqual([20, 40]);
+      expect(el.parent().hasClass('has-error')).toBe(false);
+      expect(element.hasClass('ng-invalid-time')).toBe(false);
+    });
+
+    it('clears model when input hours ends with an invalid character & alerts the UI', function() {
+      var el = getHoursInputEl();
+
+      changeInputValueTo(el, '5!');
+      expect($rootScope.time).toBe(null);
+      expect(el.parent().hasClass('has-error')).toBe(true);
+      expect(element.hasClass('ng-invalid-time')).toBe(true);
+
+      changeInputValueTo(el, 8);
+      el.blur();
+      $rootScope.$digest();
+      expect(getTimeState()).toEqual(['08', '40', 'PM']);
+      expect(getModelState()).toEqual([20, 40]);
+      expect(el.parent().hasClass('has-error')).toBe(false);
+      expect(element.hasClass('ng-invalid-time')).toBe(false);
+    });
+
     it('clears model when input minutes is invalid & alerts the UI', function() {
       var el = getMinutesInputEl();
 
       changeInputValueTo(el, 'pizza');
+      expect($rootScope.time).toBe(null);
+      expect(el.parent().hasClass('has-error')).toBe(true);
+      expect(element.hasClass('ng-invalid-time')).toBe(true);
+
+      changeInputValueTo(el, 22);
+      expect(getTimeState()).toEqual(['02', '22', 'PM']);
+      expect(getModelState()).toEqual([14, 22]);
+      expect(el.parent().hasClass('has-error')).toBe(false);
+      expect(element.hasClass('ng-invalid-time')).toBe(false);
+    });
+
+    it('clears model when input minutes starts with an invalid & alerts the UI', function() {
+      var el = getMinutesInputEl();
+
+      changeInputValueTo(el, '!5');
+      expect($rootScope.time).toBe(null);
+      expect(el.parent().hasClass('has-error')).toBe(true);
+      expect(element.hasClass('ng-invalid-time')).toBe(true);
+
+      changeInputValueTo(el, 22);
+      expect(getTimeState()).toEqual(['02', '22', 'PM']);
+      expect(getModelState()).toEqual([14, 22]);
+      expect(el.parent().hasClass('has-error')).toBe(false);
+      expect(element.hasClass('ng-invalid-time')).toBe(false);
+    });
+
+    it('clears model when input minutes ends with an invalid & alerts the UI', function() {
+      var el = getMinutesInputEl();
+
+      changeInputValueTo(el, '5!');
       expect($rootScope.time).toBe(null);
       expect(el.parent().hasClass('has-error')).toBe(true);
       expect(element.hasClass('ng-invalid-time')).toBe(true);
@@ -889,4 +953,3 @@ describe('timepicker directive', function () {
   });
 
 });
-

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -66,7 +66,7 @@ angular.module('ui.bootstrap.timepicker', [])
   // Get $scope.hours in 24H mode if valid
   function getHoursFromTemplate ( ) {
     var hours = parseInt( $scope.hours, 10 );
-    var valid = ( $scope.showMeridian ) ? (hours > 0 && hours < 13) : (hours >= 0 && hours < 24);
+    var valid = !isNaN($scope.hours * 1) && ($scope.showMeridian ? (hours > 0 && hours < 13) : (hours >= 0 && hours < 24));
     if ( !valid ) {
       return undefined;
     }
@@ -84,7 +84,7 @@ angular.module('ui.bootstrap.timepicker', [])
 
   function getMinutesFromTemplate() {
     var minutes = parseInt($scope.minutes, 10);
-    return ( minutes >= 0 && minutes < 60 ) ? minutes : undefined;
+    return !isNaN($scope.minutes * 1) && ( minutes >= 0 && minutes < 60 ) ? minutes : undefined;
   }
 
   function pad( value ) {
@@ -169,7 +169,6 @@ angular.module('ui.bootstrap.timepicker', [])
         });
       }
     });
-
   };
 
   this.render = function() {
@@ -201,14 +200,17 @@ angular.module('ui.bootstrap.timepicker', [])
   }
 
   function updateTemplate( keyboardChange ) {
-    var hours = selected.getHours(), minutes = selected.getMinutes();
+    //We only need to manually update the hours/minutes model when changes occur through the mousewheel
+    if (!keyboardChange) {
+      var hours = selected.getHours(), minutes = selected.getMinutes();
 
-    if ( $scope.showMeridian ) {
-      hours = ( hours === 0 || hours === 12 ) ? 12 : hours % 12; // Convert 24 to 12 hour system
+      if ( $scope.showMeridian ) {
+        hours = ( hours === 0 || hours === 12 ) ? 12 : hours % 12; // Convert 24 to 12 hour system
+      }
+      $scope.hours = pad(hours);
+      $scope.minutes = pad(minutes);
     }
 
-    $scope.hours = keyboardChange === 'h' ? hours : pad(hours);
-    $scope.minutes = keyboardChange === 'm' ? minutes : pad(minutes);
     $scope.meridian = selected.getHours() < 12 ? meridians[0] : meridians[1];
   }
 


### PR DESCRIPTION
Minutes & hours will now properly validate user input in all cases. Before both only handled 'X1' and now both validate '1X' as well. Additionally, we do not update the minutes/hours model unless needed to via non-keyboard interaction.