### PR TITLE
add backdrop style position: fixed

### DIFF
--- a/template/modal/backdrop.html
+++ b/template/modal/backdrop.html
@@ -1,4 +1,5 @@
 <div class="modal-backdrop fade"
      ng-class="{in: animate}"
      ng-style="{'z-index': 1040 + (index && 1 || 0) + index*10}"
+     style="position: fixed;"
 ></div>


### PR DESCRIPTION
fixes a bug on ipad (etc?) when focussing a modal input "removes" backdrop partially. position fixed keeps the backdrop always in the visible area.
