### PR TITLE
feat(modalEvents): added modal events

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -308,9 +308,11 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
               opened: modalOpenedDeferred.promise,
               close: function (result) {
                 $modalStack.close(modalInstance, result);
+                $rootScope.$broadcast('modalClose');
               },
               dismiss: function (reason) {
                 $modalStack.dismiss(modalInstance, reason);
+                $rootScope.$broadcast('modalDismiss');
               }
             };
 
@@ -355,6 +357,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
                 keyboard: modalOptions.keyboard,
                 windowClass: modalOptions.windowClass
               });
+              
+              $rootScope.$broadcast('modalOpen');
 
             }, function resolveError(reason) {
               modalResultDeferred.reject(reason);

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -205,6 +205,20 @@ describe('$modal', function () {
       );
       expect(modal.opened).toBeRejectedWith(false);
     });
+    
+    it('should broadcast events on open, close, and dismiss', function() {
+      spyOn($rootScope, '$broadcast').andCallThrough();
+      
+      var modal = open({template: '<div>Content</div>'});
+      expect($rootScope.$broadcast).toHaveBeenCalledWith('modalOpen');
+      
+      dismiss(modal, 'closing in test');
+      expect($rootScope.$broadcast).toHaveBeenCalledWith('modalDismiss');
+      
+      modal = open({template: '<div>Content</div>'});
+      close(modal, 'closed ok');
+      expect($rootScope.$broadcast).toHaveBeenCalledWith('modalClose');
+    });
 
   });
 


### PR DESCRIPTION
What do you think about something like this? In our particular use case we want to be able to stop the background from scrolling with the mousewheel when a modal is open, and then turn it back on when the modal is gone. 
