### PR TITLE
feat(carousel): Callbacks when carousel transitions begin and end.

### DIFF
--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -34,6 +34,11 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
     function goNext() {
       // Scope has been destroyed, stop here.
       if (destroyed) { return; }
+  
+      // Support for transition-begin callbacks.
+      if (nextSlide.$element) { nextSlide.$element[0]._invokeEnteringTransitionBeginCallback(); }
+      if (self.currentSlide && self.currentSlide.$element) { self.currentSlide.$element[0]._invokeLeavingTransitionBeginCallback(); }
+        
       //If we have a slide to transition from and we have a transition type and we're allowed, go
       if (self.currentSlide && angular.isString(direction) && !$scope.noTransition && nextSlide.$element) {
         //We shouldn't do class manip in here, but it's the same weird thing bootstrap does. need to fix sometime
@@ -67,6 +72,10 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
       angular.extend(next, {direction: '', active: true, leaving: false, entering: false});
       angular.extend(current||{}, {direction: '', active: false, leaving: false, entering: false});
       $scope.$currentTransition = null;
+      
+      // Support for transition-end callbacks:
+      if (nextSlide.$element) { next.$element[0]._invokeEnteringTransitionEndCallback(); }
+      if (current && current.$element) { current.$element[0]._invokeLeavingTransitionEndCallback(); }
     }
   };
   $scope.$on('$destroy', function () {
@@ -277,6 +286,23 @@ function CarouselDemoCtrl($scope) {
       active: '=?'
     },
     link: function (scope, element, attrs, carouselCtrl) {
+
+      // Support for transition begin/end  callbacks.
+      // Invoke the appropriate transition begin/end callback (if any callback expressions were given).
+      // The expression will be evaluated in the parent scope's context.
+      element[0]._invokeEnteringTransitionBeginCallback = function () {
+          if (attrs.onenteringtransitionbegin) { scope.$parent.$eval(attrs.onenteringtransitionbegin); }
+      };
+      element[0]._invokeEnteringTransitionEndCallback = function () {
+          if (attrs.onenteringtransitionend) { scope.$parent.$eval(attrs.onenteringtransitionend); }
+      };
+      element[0]._invokeLeavingTransitionBeginCallback = function () {
+          if (attrs.onleavingtransitionbegin) { scope.$parent.$eval(attrs.onleavingtransitionbegin); }
+      };
+      element[0]._invokeLeavingTransitionEndCallback = function () {
+          if (attrs.onleavingtransitionend) { scope.$parent.$eval(attrs.onleavingtransitionend); }
+      };
+ 
       carouselCtrl.addSlide(scope, element);
       //when the scope is destroyed then remove the slide from the current slides array
       scope.$on('$destroy', function() {

--- a/src/carousel/test/carousel.spec.js
+++ b/src/carousel/test/carousel.spec.js
@@ -263,6 +263,58 @@ describe('carousel', function() {
       expect($timeout.flush).toThrow('No deferred tasks to be flushed');
     });
 
+    it('should invoke the transition begin/end callbacks when transitioning to another slide', function () {
+
+        scope.slideEnteringBeganCount = 0;
+        scope.slideEnteringBegan = function slideEnteringBegan(theSlide) {
+            scope.slideEnteringBeganCount++;
+        };
+        scope.slideEnteringEndedCount = 0;
+        scope.slideEnteringEnded = function slideEnteringEnded(theSlide) {
+            scope.slideEnteringEndedCount++;
+        };
+
+        scope.slideLeavingBeganCount = 0;
+        scope.slideLeavingBegan = function slideLeavingBegan(theSlide) {
+            scope.slideLeavingBeganCount++;
+        };
+        scope.slideLeavingEndedCount = 0;
+        scope.slideLeavingEnded = function slideLeavingEnded(theSlide) {
+            scope.slideLeavingEndedCount++;
+        };
+
+
+        scope.$apply();
+        elm = $compile(
+            '<carousel interval="interval" no-transition="true">' +
+              '<slide ng-repeat="myslide in slides" active="slide.active" ' +
+              '       onenteringtransitionbegin="slideEnteringBegan(myslide)" onenteringtransitionend="slideEnteringEnded(myslide)" ' +
+              '       onleavingtransitionbegin="slideLeavingBegan(myslide)" onleavingtransitionend="slideLeavingEnded(myslide)"  >' +
+                '{{slide.content}}' +
+              '</slide>' +
+            '</carousel>'
+          )(scope);
+        scope.$apply();
+
+        var navNext = elm.find('a.right');
+
+        scope.slideEnteringBeganCount = scope.slideEnteringEndedCount = 0;
+        scope.slideLeavingBeganCount = scope.slideLeavingEndedCount = 0;
+        navNext.click();
+        expect(scope.slideEnteringBeganCount).toBe(1);
+        expect(scope.slideEnteringEndedCount).toBe(1);
+        expect(scope.slideLeavingBeganCount).toBe(1);
+        expect(scope.slideLeavingEndedCount).toBe(1);
+        navNext.click();
+        expect(scope.slideEnteringBeganCount).toBe(2);
+        expect(scope.slideEnteringEndedCount).toBe(2);
+        expect(scope.slideLeavingBeganCount).toBe(2);
+        expect(scope.slideLeavingEndedCount).toBe(2);
+    });
+
+
+
+
   });
 
   describe('controller', function() {


### PR DESCRIPTION
This commit adds callbacks for the begin and end of the transition animations.
When a transition starts, the begin callbacks are invoked (for entering or leaving slides).
When the transitioning ends, the end callbacks are invoked (for entering or leaving slides).

This introduces the following attributes on the slide directive:
* onenteringtransitionbegin
* onenteringtransitionend
* onleavingtransitionbegin
* onleavingtransitionend

These will cause the corresponding callback expression to be evaluated (within the scope).

Example:

<pre>
&lt;slide ... onenteringtransitionbegin="enteringEnded()" ...>
</pre>
Where the scope has the following function:  
<pre>
$scope.enteringEnded = function enteringEnded() { ... };
</pre>