### PR TITLE
test(modal): Add test for `controllerAs` syntax

### DIFF
--- a/src/modal/docs/readme.md
+++ b/src/modal/docs/readme.md
@@ -6,7 +6,7 @@ The `$modal` service has only one method: `open(options)` where available option
 * `templateUrl` - a path to a template representing modal's content
 * `template` - inline template representing the modal's content
 * `scope` - a scope instance to be used for the modal's content (actually the `$modal` service is going to create a child scope of a provided scope). Defaults to `$rootScope`
-* `controller` - a controller for a modal instance - it can initialize scope used by modal. A controller can be injected with `$modalInstance`
+* `controller` - a controller for a modal instance - it can initialize scope used by modal. Accepts the "controller-as" syntax, and can be injected with `$modalInstance`
 * `resolve` - members that will be resolved and passed to the controller as locals; it is equivalent of the `resolve` property for AngularJS routes
 * `backdrop` - controls presence of a backdrop. Allowed values: true (default), false (no backdrop), `'static'` - backdrop is present but modal window is not closed when clicking outside of the modal window.
 * `keyboard` - indicates whether the dialog should be closable by hitting the ESC key, defaults to true

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -19,7 +19,8 @@ describe('$modal', function () {
   beforeEach(module('ui.bootstrap.modal'));
   beforeEach(module('template/modal/backdrop.html'));
   beforeEach(module('template/modal/window.html'));
-  beforeEach(module(function(_$modalProvider_){
+  beforeEach(module(function(_$controllerProvider_, _$modalProvider_){
+    $controllerProvider = _$controllerProvider_;
     $modalProvider = _$modalProvider_;
   }));
 
@@ -250,10 +251,9 @@ describe('$modal', function () {
 
     });
 
-    describe('controllers', function () {
+    describe('controller', function () {
 
       it('should accept controllers and inject modal instances', function () {
-
         var TestCtrl = function($scope, $modalInstance) {
           $scope.fromCtrl = 'Content from ctrl';
           $scope.isModalInstance = angular.isObject($modalInstance) && angular.isFunction($modalInstance.close);
@@ -262,6 +262,17 @@ describe('$modal', function () {
         var modal = open({template: '<div>{{fromCtrl}} {{isModalInstance}}</div>', controller: TestCtrl});
         expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
       });
+
+      it('should accept controllerAs alias', function () {
+        $controllerProvider.register('TestCtrl', function($modalInstance) {
+          this.fromCtrl = 'Content from ctrl';
+          this.isModalInstance = angular.isObject($modalInstance) && angular.isFunction($modalInstance.close);
+        });
+
+        var modal = open({template: '<div>{{test.fromCtrl}} {{test.isModalInstance}}</div>', controller: 'TestCtrl as test'});
+        expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
+      });
+
     });
 
     describe('resolve', function () {


### PR DESCRIPTION
Let's add this since it's kinda the recommended way to do things since v1.1.5.
