### PR TITLE
fix(modal): prevent error when closing non-opened

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -245,7 +245,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
       };
 
       $modalStack.close = function (modalInstance, result) {
-        var modalWindow = openedWindows.get(modalInstance).value;
+        var opened = openedWindows.get(modalInstance);
+        var modalWindow = opened ? opened.value : false;
         if (modalWindow) {
           modalWindow.deferred.resolve(result);
           removeModalWindow(modalInstance);
@@ -253,7 +254,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
       };
 
       $modalStack.dismiss = function (modalInstance, reason) {
-        var modalWindow = openedWindows.get(modalInstance).value;
+        var opened = openedWindows.get(modalInstance);
+        var modalWindow = opened ? opened.value : false;
         if (modalWindow) {
           modalWindow.deferred.reject(reason);
           removeModalWindow(modalInstance);


### PR DESCRIPTION
$modalStack.close() and $modalStack.dismiss() were assuming that openedWindows.get(modalInstance) always returned something and this might have led to thrown errors when trying to close a modal window who was actually not open.
