### PR TITLE
fix(datepicker): Convert `init-date` to Date when it's a String

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -45,6 +45,9 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   $scope.datepickerMode = $scope.datepickerMode || datepickerConfig.datepickerMode;
   $scope.uniqueId = 'datepicker-' + $scope.$id + '-' + Math.floor(Math.random() * 10000);
   this.activeDate = angular.isDefined($attrs.initDate) ? $scope.$parent.$eval($attrs.initDate) : new Date();
+  if (angular.isString(this.activeDate)) {
+    this.activeDate = new Date(this.activeDate);
+  }
 
   $scope.isActive = function(dateObject) {
     if (self.compare(dateObject.date, self.activeDate) === 0) {


### PR DESCRIPTION
Example, which currently is not working, but this commit fixes it:
```html
<input type="text" datepicker-popup="true" datepicker-options="{'init-date': '2014-02-18'}" />
```