### PR TITLE
feat(tooltip): Add isOpen to tooltip level for toggle of tooltip

### DIFF
--- a/src/popover/test/popover.spec.js
+++ b/src/popover/test/popover.spec.js
@@ -45,6 +45,27 @@ describe('popover', function() {
     expect( elmScope.tt_isOpen ).toBe( false );
   }));
 
+  it('should open on isOpen change', inject(function($compile, $timeout) {
+    scope.popIsOpen = false;
+
+    // Localize our tests to a specific element
+    var elmBody = $compile( angular.element(
+      '<div><span popover="popover text" popover-is-open="{{ popIsOpen }}">Selector Text</span></div>'
+    ) )( scope );
+    scope.$apply();
+
+    var elm = elmBody.find('span');
+    var elmScope = elm.scope();
+
+    expect( elmScope.tt_isOpen ).toBe( false );
+
+    scope.popIsOpen = true;
+    scope.$apply();
+
+    expect( elmScope.tt_isOpen ).toBe( true );
+
+  }));
+
   it('should not unbind event handlers created by other directives - issue 456', inject( function( $compile ) {
 
     scope.click = function() {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -198,7 +198,13 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
 
               // And show the tooltip.
               scope.tt_isOpen = true;
-              scope.$digest(); // digest required as $apply is not called
+
+              // Check to see if we're being called from an $observe call
+              if (!scope.$$phase) {
+
+                // digest required as $apply is not called
+                scope.$digest();
+              }
 
               // Return positioning function as promise callback for correct
               // positioning after draw.
@@ -234,7 +240,9 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
               tooltip = tooltipLinker(scope, function () {});
 
               // Get contents rendered into the tooltip
-              scope.$digest();
+              if (!scope.$$phase) {
+                scope.$digest();
+              }
             }
 
             function removeTooltip() {
@@ -304,6 +312,17 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
               }
             });
             }
+
+            attrs.$observe( prefix+'IsOpen', function ( val ) {
+              var isOpen = angular.isDefined( val ) ? $parse( val )( scope ) : false;
+
+              // show and hide will set tt_isOpen for us
+              if (isOpen) {
+                show();
+              } else {
+                hide();
+              }
+            });
 
             // Make sure tooltip is destroyed and removed.
             scope.$on('$destroy', function onDestroyTooltip() {


### PR DESCRIPTION
This feature allows the user to provide an expression to tooltips (and popovers) so that they can programmatically close and open the tooltips.