### PR TITLE
fix(datepicker): Fix `init-date`

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -44,7 +44,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
   $scope.datepickerMode = $scope.datepickerMode || datepickerConfig.datepickerMode;
   $scope.uniqueId = 'datepicker-' + $scope.$id + '-' + Math.floor(Math.random() * 10000);
-  this.activeDate = angular.isDefined($attrs.initDate) ? new Date($interpolate($attrs.initDate)($scope.$parent)) : new Date();
+  this.activeDate = angular.isDefined($attrs.initDate) ? new Date($scope.$parent.$eval($attrs.initDate)) : new Date();
 
   $scope.isActive = function(dateObject) {
     if (self.compare(dateObject.date, self.activeDate) === 0) {
@@ -487,9 +487,6 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       });
       if (attrs.dateDisabled) {
         datepickerEl.attr('date-disabled', 'dateDisabled({ date: date, mode: mode })');
-      }
-      if (attrs.initDate) {
-        datepickerEl.attr('init-date', scope.$parent.$eval(attrs.initDate));
       }
 
       function parseDate(viewValue) {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -44,7 +44,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
   $scope.datepickerMode = $scope.datepickerMode || datepickerConfig.datepickerMode;
   $scope.uniqueId = 'datepicker-' + $scope.$id + '-' + Math.floor(Math.random() * 10000);
-  this.activeDate = angular.isDefined($attrs.initDate) ? $scope.$parent.$eval($attrs.initDate) : new Date();
+  this.activeDate = angular.isDefined($attrs.initDate) ? new Date($interpolate($attrs.initDate)($scope.$parent)) : new Date();
 
   $scope.isActive = function(dateObject) {
     if (self.compare(dateObject.date, self.activeDate) === 0) {
@@ -487,6 +487,9 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       });
       if (attrs.dateDisabled) {
         datepickerEl.attr('date-disabled', 'dateDisabled({ date: date, mode: mode })');
+      }
+      if (attrs.initDate) {
+        datepickerEl.attr('init-date', scope.$parent.$eval(attrs.initDate));
       }
 
       function parseDate(viewValue) {

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1692,29 +1692,28 @@ describe('datepicker directive', function () {
       expect(getTitle()).toBe('2013');
     });
   });
-});
 
   describe('`init-date` as datepickerOptions', function () {
     var originalConfig = {};
-      beforeEach(inject(function(datepickerConfig) {
-        angular.extend(originalConfig, datepickerConfig);
-        datepickerConfig.initDate = '"November 9, 1980"';
+    beforeEach(inject(function(datepickerConfig) {
+      angular.extend(originalConfig, datepickerConfig);
+      datepickerConfig.initDate = '"November 9, 1980"';
 
-        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup><div>')($rootScope);
-        $rootScope.$digest();
-        assignElements(wrapElement);
-      }));
-      afterEach(inject(function(datepickerConfig) {
-        // return it to the original state
-        angular.extend(datepickerConfig, originalConfig);
-      }));
+      var wrapElement = $compile('<div><input ng-model="date" datepicker-popup><div>')($rootScope);
+      $rootScope.$digest();
+      assignElements(wrapElement);
+    }));
+    afterEach(inject(function(datepickerConfig) {
+      // return it to the original state
+      angular.extend(datepickerConfig, originalConfig);
+    }));
 
-      it('does not alter the model', function() {
-        expect($rootScope.date).toBe(null);
-      });
+    it('does not alter the model', function() {
+      expect($rootScope.date).toBe(null);
+    });
 
-      it('shows the correct title', function() {
-        expect(getTitle()).toBe('November 1980');
-      });
+    it('shows the correct title', function() {
+      expect(getTitle()).toBe('November 1980');
     });
   });
+});

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1597,6 +1597,27 @@ describe('datepicker directive', function () {
         }
       });
     });
+
+    describe('`init-date` as datepickerOptions', function () {
+      beforeEach(inject(function(datepickerConfig) {
+        $rootScope.date = null;
+        $rootScope.opts = {
+          initDate: '"November 9, 1980"'
+        };
+        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup datepicker-options="opts" is-open="true"></div>')($rootScope);
+
+        $rootScope.$digest();
+        assignElements(wrapElement);
+      }));
+
+      it('does not alter the model', function() {
+        expect($rootScope.date).toBe(null);
+      });
+
+      it('shows the correct title', function() {
+        expect(getTitle()).toBe('November 1980');
+      });
+    });
   });
 
   describe('with empty initial state', function () {
@@ -1690,31 +1711,6 @@ describe('datepicker directive', function () {
       expect(getTitle()).toBe('2013');
       clickTitleButton();
       expect(getTitle()).toBe('2013');
-    });
-  });
-
-  describe('`init-date` as datepickerOptions', function () {
-    var originalConfig = {};
-    beforeEach(inject(function(datepickerConfig) {
-      $rootScope.date = null;
-      angular.extend(originalConfig, datepickerConfig);
-      datepickerConfig.initDate = '"November 9, 1980"';
-
-      var wrapElement = $compile('<div><input ng-model="date" datepicker-popup><div>')($rootScope);
-      $rootScope.$digest();
-      assignElements(wrapElement);
-    }));
-    afterEach(inject(function(datepickerConfig) {
-      // return it to the original state
-      angular.extend(datepickerConfig, originalConfig);
-    }));
-
-    it('does not alter the model', function() {
-      expect($rootScope.date).toBe(null);
-    });
-
-    it('shows the correct title', function() {
-      expect(getTitle()).toBe('November 1980');
     });
   });
 });

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1693,3 +1693,28 @@ describe('datepicker directive', function () {
     });
   });
 });
+
+  describe('`init-date` as datepickerOptions', function () {
+    var originalConfig = {};
+      beforeEach(inject(function(datepickerConfig) {
+        angular.extend(originalConfig, datepickerConfig);
+        datepickerConfig.initDate = "'November 9, 1980'";
+
+        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup><div>')($rootScope);
+        $rootScope.$digest();
+        assignElements(wrapElement);
+      }));
+      afterEach(inject(function(datepickerConfig) {
+        // return it to the original state
+        angular.extend(datepickerConfig, originalConfig);
+      }));
+
+      it('does not alter the model', function() {
+        expect($rootScope.date).toBe(null);
+      });
+
+      it('shows the correct title', function() {
+        expect(getTitle()).toBe('November 1980');
+      });
+    });
+  });

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1698,7 +1698,7 @@ describe('datepicker directive', function () {
     var originalConfig = {};
       beforeEach(inject(function(datepickerConfig) {
         angular.extend(originalConfig, datepickerConfig);
-        datepickerConfig.initDate = "'November 9, 1980'";
+        datepickerConfig.initDate = '"November 9, 1980"';
 
         var wrapElement = $compile('<div><input ng-model="date" datepicker-popup><div>')($rootScope);
         $rootScope.$digest();

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1696,6 +1696,7 @@ describe('datepicker directive', function () {
   describe('`init-date` as datepickerOptions', function () {
     var originalConfig = {};
     beforeEach(inject(function(datepickerConfig) {
+      $rootScope.date = null;
       angular.extend(originalConfig, datepickerConfig);
       datepickerConfig.initDate = '"November 9, 1980"';
 


### PR DESCRIPTION
When passing 'init-date' through datepickerOptions, need to create Date object again
Also, this allow passing 'init-date' as string