### PR TITLE
Add css class to an open accordion group

### DIFF
--- a/template/accordion/accordion-group.html
+++ b/template/accordion/accordion-group.html
@@ -1,5 +1,5 @@
 <div class="panel panel-default">
-  <div class="panel-heading" ng-class=\"{\'open\': isOpen}\">
+  <div class="panel-heading" ng-class=\"{'open': isOpen}\">
     <h4 class="panel-title">
       <a class="accordion-toggle" ng-click="toggleOpen()" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
     </h4>


### PR DESCRIPTION
(This is probably a duplicate of #2223, sorry about that)

Our project required discrete CSS rules for the panel heading depending on whether it was open or close.

This minor change to the template seemed like the only way to do it.
