### PR TITLE
feat(carousel): no-wrap attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,41 +123,53 @@
  * `on-select-page` is removed since `ng-change` can now be used.
 
   Before:
-
+  
+  ```html
   <pagination page="current" on-select-page="changed(page)" ...></pagination>
-
+  ```
+  
   After:
 
+  ```html
   <pagination ng-model="current" ng-change="changed()" ...></pagination>
-
+  ```
+  
 - **rating:** 
  `rating` is now integrated with `ngModelController`.
  * `value` is replaced from `ng-model`.
 
   Before:
 
+  ```html
   <rating value="rate" ...></rating>
-
+  ```
+  
   After:
-
+  
+  ```html
   <rating ng-model="rate" ...></rating>
-
+  ```
+  
 - **tabs:**
 
  Use interpolation for type attribute.
 
   Before:
-
+  
+  ```html
   <tabset type="'pills'" ...></tabset >
-  or
+  <!-- or -->
   <tabset type="navtype" ...></tabset>
-
+  ```
+  
   After:
-
+  
+  ```html
   <tabset type="pills" ...></tabset>
-  or
+  <!-- or -->
   <tabset type="{{navtype}}" ...></tabset>
- 
+  ```
+  
 # 0.10.0 (2014-01-13)
 
 _This release adds AngularJS 1.2 support_

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-karma');
   grunt.loadNpmTasks('grunt-conventional-changelog');
   grunt.loadNpmTasks('grunt-ngdocs');
+  grunt.loadNpmTasks('grunt-ddescribe-iit');
 
   // Project configuration.
   grunt.util.linefeed = '\n';
@@ -190,12 +191,17 @@ module.exports = function(grunt) {
         src: ['src/**/*.js', 'src/**/*.ngdoc'],
         title: 'API Documentation'
       }
+    },
+    'ddescribe-iit': {
+      files: [
+        'src/**/*.spec.js'
+      ]
     }
   });
 
   //register before and after test tasks so we've don't have to change cli
   //options on the goole's CI server
-  grunt.registerTask('before-test', ['enforce', 'jshint', 'html2js']);
+  grunt.registerTask('before-test', ['enforce', 'ddescribe-iit', 'jshint', 'html2js']);
   grunt.registerTask('after-test', ['build', 'copy']);
 
   //Rename our watch task to 'delta', then make actual 'watch'

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ We are always looking for the quality contributions! Please check the [CONTRIBUT
 You can generate a custom build, containing only needed modules, from the project's homepage.
 Alternatively you can run local Grunt build from the command line and list needed modules as shown below:
 
-```
+```javascript
 grunt build:modal:tabs:alert:popover:dropdownToggle:buttons:progressbar
 ```
 
@@ -115,7 +115,7 @@ templates to match your desired look & feel, add new functionality etc.
 
 The easiest way to override an individual template is to use the `<script>` directive:
 
-```javascript
+```html
 <script id="template/alert/alert.html" type="text/ng-template">
     <div class='alert' ng-class='type && "alert-" + type'>
         <button ng-show='closeable' type='button' class='close' ng-click='close()'>Close</button>
@@ -131,7 +131,7 @@ Let's have a look:
 Your own template url is `views/partials/ui-bootstrap-tpls/alert/alert.html`.
 
 Add "html2js" task to your Gruntfile
-```
+```javascript
 html2js: {
   options: {
     base: '.',
@@ -152,7 +152,7 @@ Make sure to load your template.js file
 `<script src="/ui-templates.js"></script>`
 
 Inject the `ui-templates` module in your `app.js`
-```
+```javascript
 angular.module('myApp', [
   'ui.bootstrap',
   'ui-templates'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "grunt-karma": "~0.4.4",
     "node-markdown": "0.1.1",
     "semver": "~2.2.0",
-    "shelljs": "~0.2.0"
+    "shelljs": "~0.2.0",
+    "grunt-ddescribe-iit": "0.0.4"
   },
   "license": "MIT"
 }

--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -120,7 +120,7 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
 
   function timerFn() {
     if (isPlaying) {
-      $scope.next();
+      if ($scope.canSlideRight()) { $scope.next(); }
       restartTimer();
     } else {
       $scope.pause();
@@ -138,6 +138,12 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
       isPlaying = false;
       resetTimer();
     }
+  };
+  $scope.canSlideLeft = function() {
+    return slides.length > 1 && (!$scope.noWrap || currentIndex > 0);
+  };
+  $scope.canSlideRight = function() {
+    return slides.length > 1 && (!$scope.noWrap || currentIndex != slides.length - 1);
   };
 
   self.addSlide = function(slide, element) {
@@ -182,6 +188,7 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
  * @param {number=} interval The time, in milliseconds, that it will take the carousel to go to the next slide.
  * @param {boolean=} noTransition Whether to disable transitions on the carousel.
  * @param {boolean=} noPause Whether to disable pausing on the carousel (by default, the carousel interval pauses on hover).
+ * @param {boolean=} noWrap Whether to disable carousel slides wrapping around.
  *
  * @example
 <example module="ui.bootstrap">
@@ -220,7 +227,8 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
     scope: {
       interval: '=',
       noTransition: '=',
-      noPause: '='
+      noPause: '=',
+      noWrap: '='
     }
   };
 }])

--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -79,6 +79,7 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
   };
 
   $scope.next = function() {
+    if (!$scope.canSlideRight()) {return;}
     var newIndex = (currentIndex + 1) % slides.length;
 
     //Prevent this user-triggered transition from occurring if there is already one in progress
@@ -88,6 +89,7 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
   };
 
   $scope.prev = function() {
+    if (!$scope.canSlideLeft()) {return;}
     var newIndex = currentIndex - 1 < 0 ? slides.length - 1 : currentIndex - 1;
 
     //Prevent this user-triggered transition from occurring if there is already one in progress
@@ -139,11 +141,12 @@ angular.module('ui.bootstrap.carousel', ['ui.bootstrap.transition'])
       resetTimer();
     }
   };
+
   $scope.canSlideLeft = function() {
-    return slides.length > 1 && (!$scope.noWrap || currentIndex > 0);
+    return !$scope.noWrap || slides.length > 1 && (currentIndex > 0);
   };
   $scope.canSlideRight = function() {
-    return slides.length > 1 && (!$scope.noWrap || currentIndex != slides.length - 1);
+    return !$scope.noWrap || slides.length > 1 && (currentIndex != slides.length - 1);
   };
 
   self.addSlide = function(slide, element) {

--- a/src/carousel/test/carousel.spec.js
+++ b/src/carousel/test/carousel.spec.js
@@ -93,6 +93,32 @@ describe('carousel', function() {
       expect(navPrev.length).toBe(0);
     });
 
+    function noWrapTest(isLast) {
+      scope.slides=[{active:!isLast,content:'one'},{active:isLast,content:'two'}];
+      scope.$apply();
+      elm = $compile(
+        '<carousel interval="interval" no-transition="true" no-wrap="true">' +
+          '<slide ng-repeat="slide in slides" active="slide.active">' +
+          '{{slide.content}}' +
+          '</slide>' +
+          '</carousel>'
+      )(scope);
+      scope.$apply();
+      var navNext = elm.find('a.right.ng-hide');
+      expect(navNext.length).toBe(isLast ? 1 : 0);
+
+      var navPrev = elm.find('a.left.ng-hide');
+      expect(navPrev.length).toBe(isLast ? 0 : 1);
+    }
+
+    it('should hide left navigation and show right navigation when it is first slide and noWrap is true', function() {
+      noWrapTest(false);
+    });
+
+    it('should hide right navigation and show left navigation when it is last slide and noWrap is true', function() {
+      noWrapTest(true);
+    });
+
     it('should show navigation when there are 3 slides', function () {
       var indicators = elm.find('ol.carousel-indicators > li');
       expect(indicators.length).not.toBe(0);

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -30,7 +30,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     self[key] = angular.isDefined($attrs[key]) ? (index < 8 ? $interpolate($attrs[key])($scope.$parent) : $scope.$parent.$eval($attrs[key])) : datepickerConfig[key];
   });
 
-  // Watchable attributes
+  // Watchable date attributes
   angular.forEach(['minDate', 'maxDate'], function( key ) {
     if ( $attrs[key] ) {
       $scope.$parent.$watch($parse($attrs[key]), function(value) {
@@ -477,12 +477,24 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
         });
       }
 
-      angular.forEach(['minDate', 'maxDate'], function( key ) {
+      scope.watchData = {};
+      angular.forEach(['minDate', 'maxDate', 'datepickerMode'], function( key ) {
         if ( attrs[key] ) {
-          scope.$parent.$watch($parse(attrs[key]), function(value){
-            scope[key] = value;
+          var getAttribute = $parse(attrs[key]);
+          scope.$parent.$watch(getAttribute, function(value){
+            scope.watchData[key] = value;
           });
-          datepickerEl.attr(cameltoDash(key), key);
+          datepickerEl.attr(cameltoDash(key), 'watchData.' + key);
+
+          // Propagate changes from datepicker to outside
+          if ( key === 'datepickerMode' ) {
+            var setAttribute = getAttribute.assign;
+            scope.$watch('watchData.' + key, function(value, oldvalue) {
+              if ( value !== oldvalue ) {
+                setAttribute(scope.$parent, value);
+              }
+            });
+          }
         }
       });
       if (attrs.dateDisabled) {

--- a/src/datepicker/docs/demo.js
+++ b/src/datepicker/docs/demo.js
@@ -30,7 +30,6 @@ angular.module('ui.bootstrap.demo').controller('DatepickerDemoCtrl', function ($
     startingDay: 1
   };
 
-  $scope.initDate = new Date('2016-15-20');
   $scope.formats = ['dd-MMMM-yyyy', 'yyyy/MM/dd', 'dd.MM.yyyy', 'shortDate'];
   $scope.format = $scope.formats[0];
 });

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1597,6 +1597,25 @@ describe('datepicker directive', function () {
         }
       });
     });
+
+    describe('`datepicker-mode`', function () {
+      beforeEach(inject(function() {
+        $rootScope.date = new Date('August 11, 2013');
+        $rootScope.mode = 'month';
+        wrapElement = $compile('<div><input ng-model="date" datepicker-popup datepicker-mode="mode"></div>')($rootScope);
+        $rootScope.$digest();
+        assignElements(wrapElement);
+      }));
+
+      it('shows the correct title', function() {
+        expect(getTitle()).toBe('2013');
+      });
+
+      it('updates binding', function() {
+        clickTitleButton();
+        expect($rootScope.mode).toBe('year');
+      });
+    });
   });
 
   describe('with empty initial state', function () {

--- a/src/modal/docs/readme.md
+++ b/src/modal/docs/readme.md
@@ -6,7 +6,8 @@ The `$modal` service has only one method: `open(options)` where available option
 * `templateUrl` - a path to a template representing modal's content
 * `template` - inline template representing the modal's content
 * `scope` - a scope instance to be used for the modal's content (actually the `$modal` service is going to create a child scope of a provided scope). Defaults to `$rootScope`
-* `controller` - a controller for a modal instance - it can initialize scope used by modal. Accepts the "controller-as" syntax, and can be injected with `$modalInstance`
+* `controller` - a controller for a modal instance - it can initialize scope used by modal. Accepts the "controller-as" syntax in the form 'SomeCtrl as myctrl'; can be injected with `$modalInstance`
+* `controllerAs` - an alternative to the controller-as syntax, matching the API of directive definitions. Requires the `controller` option to be provided as well
 * `resolve` - members that will be resolved and passed to the controller as locals; it is equivalent of the `resolve` property for AngularJS routes
 * `backdrop` - controls presence of a backdrop. Allowed values: true (default), false (no backdrop), `'static'` - backdrop is present but modal window is not closed when clicking outside of the modal window.
 * `keyboard` - indicates whether the dialog should be closable by hitting the ESC key, defaults to true
@@ -27,4 +28,4 @@ In addition the scope associated with modal's content is augmented with 2 method
 * `$close(result)`
 * `$dismiss(reason)`
 
-Those methods make it easy to close a modal window without a need to create a dedicated controller
+Those methods make it easy to close a modal window without a need to create a dedicated controller.

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -365,7 +365,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
                   ctrlLocals[key] = tplAndVars[resolveIter++];
                 });
 
-                $controller(modalOptions.controller, ctrlLocals);
+                $controller(modalOptions.controllerAs ? modalOptions.controller + ' as ' + modalOptions.controllerAs : modalOptions.controller, ctrlLocals);
               }
 
               $modalStack.open(modalInstance, {

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -303,8 +303,9 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
 
           function getTemplatePromise(options) {
             return options.template ? $q.when(options.template) :
-              $http.get(options.templateUrl, {cache: $templateCache}).then(function (result) {
-                return result.data;
+              $http.get(angular.isFunction(options.templateUrl) ? (options.templateUrl)() : options.templateUrl,
+                {cache: $templateCache}).then(function (result) {
+                  return result.data;
               });
           }
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -354,7 +354,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
               modalScope.$close = modalInstance.close;
               modalScope.$dismiss = modalInstance.dismiss;
 
-              var ctrlLocals = {};
+              var ctrlInstance, ctrlLocals = {};
               var resolveIter = 1;
 
               //controllers
@@ -365,7 +365,10 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
                   ctrlLocals[key] = tplAndVars[resolveIter++];
                 });
 
-                $controller(modalOptions.controllerAs ? modalOptions.controller + ' as ' + modalOptions.controllerAs : modalOptions.controller, ctrlLocals);
+                ctrlInstance = $controller(modalOptions.controller, ctrlLocals);
+                if (modalOptions.controller) {
+                  modalScope[modalOptions.controllerAs] = ctrlInstance;
+                }
               }
 
               $modalStack.open(modalInstance, {

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -1,4 +1,4 @@
-ddescribe('$modal', function () {
+describe('$modal', function () {
   var $controllerProvider, $rootScope, $document, $compile, $templateCache, $timeout, $q;
   var $modal, $modalProvider;
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -1,4 +1,4 @@
-describe('$modal', function () {
+ddescribe('$modal', function () {
   var $controllerProvider, $rootScope, $document, $compile, $templateCache, $timeout, $q;
   var $modal, $modalProvider;
 
@@ -277,6 +277,23 @@ describe('$modal', function () {
 
         $templateCache.put('whitespace.html', '  <div>Whitespaces</div>  ');
         open({templateUrl: 'whitespace.html'});
+        expect($document).toHaveModalOpenWithContent('Whitespaces', 'div');
+      });
+
+      it('should accept template as a function', function () {
+        open({template: function() {
+          return '<div>From a function</div>';
+        }});
+
+        expect($document).toHaveModalOpenWithContent('From a function', 'div');
+      });
+
+      it('should not fail if a templateUrl as a function', function () {
+
+        $templateCache.put('whitespace.html', '  <div>Whitespaces</div>  ');
+        open({templateUrl: function(){
+          return 'whitespace.html';
+        }});
         expect($document).toHaveModalOpenWithContent('Whitespaces', 'div');
       });
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -313,6 +313,14 @@ describe('$modal', function () {
         open({template: '<div>{{test.fromCtrl}} {{test.isModalInstance}}</div>', controller: 'TestCtrl', controllerAs: 'test'});
         expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
       });
+
+      it('should allow defining in-place controller-as controllers', function () {
+        open({template: '<div>{{test.fromCtrl}} {{test.isModalInstance}}</div>', controller: function($modalInstance) {
+          this.fromCtrl = 'Content from ctrl';
+          this.isModalInstance = angular.isObject($modalInstance) && angular.isFunction($modalInstance.close);
+        }, controllerAs: 'test'});
+        expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
+      });
     });
 
     describe('resolve', function () {

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -1,5 +1,5 @@
 describe('$modal', function () {
-  var $rootScope, $document, $compile, $templateCache, $timeout, $q;
+  var $controllerProvider, $rootScope, $document, $compile, $templateCache, $timeout, $q;
   var $modal, $modalProvider;
 
   var triggerKeyDown = function (element, keyCode) {
@@ -290,7 +290,7 @@ describe('$modal', function () {
           $scope.isModalInstance = angular.isObject($modalInstance) && angular.isFunction($modalInstance.close);
         };
 
-        var modal = open({template: '<div>{{fromCtrl}} {{isModalInstance}}</div>', controller: TestCtrl});
+        open({template: '<div>{{fromCtrl}} {{isModalInstance}}</div>', controller: TestCtrl});
         expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
       });
 
@@ -300,10 +300,19 @@ describe('$modal', function () {
           this.isModalInstance = angular.isObject($modalInstance) && angular.isFunction($modalInstance.close);
         });
 
-        var modal = open({template: '<div>{{test.fromCtrl}} {{test.isModalInstance}}</div>', controller: 'TestCtrl as test'});
+        open({template: '<div>{{test.fromCtrl}} {{test.isModalInstance}}</div>', controller: 'TestCtrl as test'});
         expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
       });
 
+      it('should respect the controllerAs property as an alternative for the controller-as syntax', function () {
+        $controllerProvider.register('TestCtrl', function($modalInstance) {
+          this.fromCtrl = 'Content from ctrl';
+          this.isModalInstance = angular.isObject($modalInstance) && angular.isFunction($modalInstance.close);
+        });
+
+        open({template: '<div>{{test.fromCtrl}} {{test.isModalInstance}}</div>', controller: 'TestCtrl', controllerAs: 'test'});
+        expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
+      });
     });
 
     describe('resolve', function () {

--- a/src/typeahead/docs/demo.js
+++ b/src/typeahead/docs/demo.js
@@ -9,12 +9,10 @@ angular.module('ui.bootstrap.demo').controller('TypeaheadCtrl', function($scope,
         address: val,
         sensor: false
       }
-    }).then(function(res){
-      var addresses = [];
-      angular.forEach(res.data.results, function(item){
-        addresses.push(item.formatted_address);
+    }).then(function(response){
+      return response.data.results.map(function(item){
+        return item.formatted_address;
       });
-      return addresses;
     });
   };
 

--- a/template/carousel/carousel.html
+++ b/template/carousel/carousel.html
@@ -3,6 +3,6 @@
         <li ng-repeat="slide in slides track by $index" ng-class="{active: isActive(slide)}" ng-click="select(slide)"></li>
     </ol>
     <div class="carousel-inner" ng-transclude></div>
-    <a class="left carousel-control" ng-click="prev()" ng-show="slides.length > 1"><span class="glyphicon glyphicon-chevron-left"></span></a>
-    <a class="right carousel-control" ng-click="next()" ng-show="slides.length > 1"><span class="glyphicon glyphicon-chevron-right"></span></a>
+    <a class="left carousel-control" ng-click="prev()" ng-show="canSlideLeft()"><span class="glyphicon glyphicon-chevron-left"></span></a>
+    <a class="right carousel-control" ng-click="next()" ng-show="canSlideRight()"><span class="glyphicon glyphicon-chevron-right"></span></a>
 </div>


### PR DESCRIPTION
Hey,

I wonder how to implement impossibility to wrap carousel around (i.e. user can't move it back when there's first slide and can't move it forward when there's last slide). This is possible implementation.

P.S. Implementing this I found a problem with and old test 'should hide navigation when only one slide' for carousel. 
If I change scope.slides=[{active:false,content:'one'}]; to scope.slides=[{active:false,content:'one'}, {active:false,content:'two'}]; test doesn't fail. I tried to add another $apply() call but it doesn't seems to work so I leave it as it is.

Thanks