### PR TITLE
feat(tabs): it should not select first not active tab as selected

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -28,10 +28,13 @@ angular.module('ui.bootstrap.tabs', [])
     tabs.push(tab);
     // we can't run the select function on the first tab
     // since that would select it twice
-    if (tabs.length === 1) {
+    if (tabs.length === 1 && tab.active !== false) {
       tab.active = true;
     } else if (tab.active) {
       ctrl.select(tab);
+    }
+    else {
+      tab.active = false;
     }
   };
 

--- a/src/tabs/test/tabs.spec.js
+++ b/src/tabs/test/tabs.spec.js
@@ -384,8 +384,13 @@ describe('tabs', function() {
 
   describe('tabset controller', function() {
     function mockTab(isActive) {
+      var _isActive;
+      if (isActive || isActive === false) {
+        _isActive = isActive;
+      }
+
       return {
-        active: !!isActive,
+        active: _isActive,
         onSelect : angular.noop,
         onDeselect : angular.noop
       };
@@ -457,6 +462,13 @@ describe('tabs', function() {
 
         ctrl.addTab(tab2);
         expect(tab1.active).toBe(true);
+      });
+
+      it('should not select first active === false tab as selected', function() {
+        var tab = mockTab(false);
+
+        ctrl.addTab(tab);
+        expect(tab.active).toBe(false);
       });
 
       it('should select a tab added that\'s already active', function() {


### PR DESCRIPTION
Tabs should behave such way that if you specifically set tab.active to "false" is should not be selected even if it's first tab.

This behavior do not change current way tabs are working. It only adds new behavior if we specifically set active === false.

Test are added to cover new funcionality.