### PR TITLE
feat(pagination): add ids to the pagination control

### DIFF
--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -42,6 +42,9 @@ angular.module('ui.bootstrap.pagination', [])
   $scope.getText = function( key ) {
     return $scope[key + 'Text'] || self.config[key + 'Text'];
   };
+  $scope.getId = function( key ) {
+    return ($scope['id'] || self.config['id']) + key;
+  };
   $scope.noPrevious = function() {
     return $scope.page === 1;
   };
@@ -72,7 +75,8 @@ angular.module('ui.bootstrap.pagination', [])
   previousText: 'Previous',
   nextText: 'Next',
   lastText: 'Last',
-  rotate: true
+  rotate: true,
+  id: 'pagination'
 })
 
 .directive('pagination', ['$parse', 'paginationConfig', function($parse, paginationConfig) {
@@ -83,7 +87,8 @@ angular.module('ui.bootstrap.pagination', [])
       firstText: '@',
       previousText: '@',
       nextText: '@',
-      lastText: '@'
+      lastText: '@',
+      id: '@'
     },
     require: ['pagination', '?ngModel'],
     controller: 'PaginationController',
@@ -98,7 +103,8 @@ angular.module('ui.bootstrap.pagination', [])
 
       // Setup configuration parameters
       var maxSize = angular.isDefined(attrs.maxSize) ? scope.$parent.$eval(attrs.maxSize) : paginationConfig.maxSize,
-          rotate = angular.isDefined(attrs.rotate) ? scope.$parent.$eval(attrs.rotate) : paginationConfig.rotate;
+          rotate = angular.isDefined(attrs.rotate) ? scope.$parent.$eval(attrs.rotate) : paginationConfig.rotate,
+          id = angular.isDefined(attrs.id) ? attrs.id : paginationConfig.id;
       scope.boundaryLinks = angular.isDefined(attrs.boundaryLinks) ? scope.$parent.$eval(attrs.boundaryLinks) : paginationConfig.boundaryLinks;
       scope.directionLinks = angular.isDefined(attrs.directionLinks) ? scope.$parent.$eval(attrs.directionLinks) : paginationConfig.directionLinks;
 

--- a/src/pagination/test/pagination.spec.js
+++ b/src/pagination/test/pagination.spec.js
@@ -546,6 +546,7 @@ describe('pagination directive', function () {
       paginationConfig.previousText = 'PR';
       paginationConfig.nextText = 'NE';
       paginationConfig.lastText = 'LA';
+      paginationConfig.id = 'PG_';
       element = $compile('<pagination total-items="total" ng-model="currentPage"></pagination>')($rootScope);
       $rootScope.$digest();
 
@@ -553,6 +554,11 @@ describe('pagination directive', function () {
       expect(getPaginationEl(1).text()).toBe('PR');
       expect(getPaginationEl(-2).text()).toBe('NE');
       expect(getPaginationEl(-1).text()).toBe('LA');
+
+      expect(getPaginationEl(0).find('a').attr('id')).toBe('PG_first');
+      expect(getPaginationEl(1).find('a').attr('id')).toBe('PG_previous');
+      expect(getPaginationEl(-2).find('a').attr('id')).toBe('PG_next');
+      expect(getPaginationEl(-1).find('a').attr('id')).toBe('PG_last');
     });
 
     it('contains number of pages + 2 li elements', function() {
@@ -574,7 +580,7 @@ describe('pagination directive', function () {
 
   describe('override configuration from attributes', function () {
     beforeEach(function() {
-      element = $compile('<pagination boundary-links="true" first-text="<<" previous-text="<" next-text=">" last-text=">>" total-items="total" ng-model="currentPage"></pagination>')($rootScope);
+      element = $compile('<pagination id="p1_" boundary-links="true" first-text="<<" previous-text="<" next-text=">" last-text=">>" total-items="total" ng-model="currentPage"></pagination>')($rootScope);
       $rootScope.$digest();
     });
 
@@ -587,6 +593,11 @@ describe('pagination directive', function () {
       expect(getPaginationEl(1).text()).toBe('<');
       expect(getPaginationEl(-2).text()).toBe('>');
       expect(getPaginationEl(-1).text()).toBe('>>');
+
+      expect(getPaginationEl(0).find('a').attr('id')).toBe('p1_first');
+      expect(getPaginationEl(1).find('a').attr('id')).toBe('p1_previous');
+      expect(getPaginationEl(-2).find('a').attr('id')).toBe('p1_next');
+      expect(getPaginationEl(-1).find('a').attr('id')).toBe('p1_last');
     });
   });
 

--- a/template/pagination/pagination.html
+++ b/template/pagination/pagination.html
@@ -1,7 +1,7 @@
 <ul class="pagination">
-  <li ng-if="boundaryLinks" ng-class="{disabled: noPrevious()}"><a href ng-click="selectPage(1)">{{getText('first')}}</a></li>
-  <li ng-if="directionLinks" ng-class="{disabled: noPrevious()}"><a href ng-click="selectPage(page - 1)">{{getText('previous')}}</a></li>
-  <li ng-repeat="page in pages track by $index" ng-class="{active: page.active}"><a href ng-click="selectPage(page.number)">{{page.text}}</a></li>
-  <li ng-if="directionLinks" ng-class="{disabled: noNext()}"><a href ng-click="selectPage(page + 1)">{{getText('next')}}</a></li>
-  <li ng-if="boundaryLinks" ng-class="{disabled: noNext()}"><a href ng-click="selectPage(totalPages)">{{getText('last')}}</a></li>
+  <li ng-if="boundaryLinks" ng-class="{disabled: noPrevious()}"><a id="{{getId('first')}}" href ng-click="selectPage(1)">{{getText('first')}}</a></li>
+  <li ng-if="directionLinks" ng-class="{disabled: noPrevious()}"><a id="{{getId('previous')}}" href ng-click="selectPage(page - 1)">{{getText('previous')}}</a></li>
+  <li ng-repeat="page in pages track by $index" ng-class="{active: page.active}"><a id="{{getId(page.number)}}" href ng-click="selectPage(page.number)">{{page.text}}</a></li>
+  <li ng-if="directionLinks" ng-class="{disabled: noNext()}"><a id="{{getId('next')}}" href ng-click="selectPage(page + 1)">{{getText('next')}}</a></li>
+  <li ng-if="boundaryLinks" ng-class="{disabled: noNext()}"><a id="{{getId('last')}}" href ng-click="selectPage(totalPages)">{{getText('last')}}</a></li>
 </ul>


### PR DESCRIPTION
Our testing environment requires ids on controls. This branch contains a small commit that adds id's to the pagination control <a> tags in a controlled way.  You can either use the default id in the config or if you have multiple pagination controls on a page, you can define the id along with the directive so each can be unique. I updated the unit tests to reflect the change as well.
