### PR TITLE
Optional autofocus on typeahead selection

### DIFF
--- a/misc/test-lib/helpers.js
+++ b/misc/test-lib/helpers.js
@@ -13,6 +13,18 @@ beforeEach(function() {
       var element = angular.element(this.actual);
       return element.hasClass('ng-hide') ||
         element.css('display') == 'none';
+    },
+    toHaveFocus: function() {
+      this.message = function() {
+        return "Expected '" + angular.mock.dump(this.actual) + "' to have focus";
+      };
+      return document.activeElement === this.actual[0];
+    },
+    toNotHaveFocus: function() {
+      this.message = function() {
+        return "Expected '" + angular.mock.dump(this.actual) + "' to not have focus";
+      };
+      return document.activeElement !== this.actual[0];
     }
   });
 });

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -373,6 +373,52 @@ describe('typeahead tests', function () {
       expect($scope.$label).toEqual('Alaska');
     });
 
+    it('should autofocus input after selection', function () {
+      var element = prepareInputEl('<div><input ng-model="result" typeahead="item for item in source | filter:$viewValue"></div>');
+      var inputEl = findInput(element);
+
+      // Note that this bug can only be found when element is in the document
+      $document.find('body').append(element);
+      // Extra teardown for this spec
+      this.after(function () { element.remove(); });
+
+      changeInputValueTo(element, 'b');
+      var match = $(findMatches(element)[0]).find('a')[0];
+
+      $(match).click();
+      $scope.$digest();
+
+      expect(inputEl.val()).toEqual('bar');
+
+      // Flush the focus $timeout
+      $timeout.flush();
+
+      expect(inputEl).toHaveFocus();
+    });
+
+    it('should not autofocus input when typeahead-autofocus is set to false', function () {
+      var element = prepareInputEl('<div><input ng-model="result" typeahead-autofocus="false" typeahead="item for item in source | filter:$viewValue"></div>');
+      var inputEl = findInput(element);
+
+      // Note that this bug can only be found when element is in the document
+      $document.find('body').append(element);
+      // Extra teardown for this spec
+      this.after(function () { element.remove(); });
+
+      changeInputValueTo(element, 'b');
+      var match = $(findMatches(element)[0]).find('a')[0];
+
+      $(match).click();
+      $scope.$digest();
+
+      expect(inputEl.val()).toEqual('bar');
+
+      // Flush the focus $timeout
+      $timeout.flush();
+
+      expect(inputEl).toNotHaveFocus();
+    });
+
     it('should correctly update inputs value on mapping where label is not derived from the model', function () {
 
       var element = prepareInputEl('<div><input ng-model="result" typeahead="state.code as state.name for state in states | filter:$viewValue"></div>');

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -48,6 +48,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       //should it restrict model values to the ones selected from the popup only?
       var isEditable = originalScope.$eval(attrs.typeaheadEditable) !== false;
+      
+      //autofocus input after selection?
+      var inputAutofocus = originalScope.$eval(attrs.typeaheadAutofocus) || false;
 
       //binding to a variable that indicates if matches are being retrieved asynchronously
       var isLoadingSetter = $parse(attrs.typeaheadLoading).assign || angular.noop;
@@ -261,7 +264,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
         //return focus to the input element if a match was selected via a mouse click event
         // use timeout to avoid $rootScope:inprog error
-        $timeout(function() { element[0].focus(); }, 0, false);
+        if(inputAutofocus) $timeout(function() { element[0].focus(); }, 0, false);
       };
 
       //bind keyboard events: arrows up(38) / down(40), enter(13) and tab(9), esc(27)

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -264,7 +264,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
         //return focus to the input element if a match was selected via a mouse click event
         // use timeout to avoid $rootScope:inprog error
-        if(inputAutofocus) $timeout(function() { element[0].focus(); }, 0, false);
+        if(inputAutofocus) {
+          $timeout(function() { element[0].focus(); }, 0, false);
+        }
       };
 
       //bind keyboard events: arrows up(38) / down(40), enter(13) and tab(9), esc(27)

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -50,7 +50,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       var isEditable = originalScope.$eval(attrs.typeaheadEditable) !== false;
       
       //autofocus input after selection?
-      var inputAutofocus = originalScope.$eval(attrs.typeaheadAutofocus) || false;
+      var inputAutofocus = attrs.typeaheadAutofocus || true;
 
       //binding to a variable that indicates if matches are being retrieved asynchronously
       var isLoadingSetter = $parse(attrs.typeaheadLoading).assign || angular.noop;
@@ -264,7 +264,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
         //return focus to the input element if a match was selected via a mouse click event
         // use timeout to avoid $rootScope:inprog error
-        if(inputAutofocus) {
+        if(inputAutofocus === true) {
           $timeout(function() { element[0].focus(); }, 0, false);
         }
       };


### PR DESCRIPTION
There are some issues when you want an input to clear value on focus and after selection it gets cleared again because of the autofocus. I added an optional parameter for autofocus on selection, it is disabled by default.