### PR TITLE
Proposal to delay datepicker template rendering

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -596,7 +596,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       var $popup;
       function ensurePopupCompiled() {
         if (!angular.isUndefined($popup)) {
-          return;
+          return ;
         }
         $popup = $compile(popupEl)(scope);
         if ( appendToBody ) {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -564,6 +564,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
 
       scope.$watch('isOpen', function(value) {
         if (value) {
+          ensurePopupCompiled();
           scope.$broadcast('datepicker.focus');
           scope.position = appendToBody ? $position.offset(element) : $position.position(element);
           scope.position.top = scope.position.top + element.prop('offsetHeight');
@@ -592,15 +593,23 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
         element[0].focus();
       };
 
-      var $popup = $compile(popupEl)(scope);
-      if ( appendToBody ) {
-        $document.find('body').append($popup);
-      } else {
-        element.after($popup);
+      var $popup;
+      function ensurePopupCompiled() {
+        if (!angular.isUndefined($popup)) {
+          return;
+        }
+        $popup = $compile(popupEl)(scope);
+        if ( appendToBody ) {
+          $document.find('body').append($popup);
+        } else {
+          element.after($popup);
+        }
       }
 
       scope.$on('$destroy', function() {
-        $popup.remove();
+        if (!angular.isUndefined($popup)) {
+          $popup.remove();
+        }
         element.unbind('keydown', keydown);
         $document.unbind('click', documentClickBind);
       });


### PR DESCRIPTION
I was wondering if it would be possible to delay the compilation of datepicker popup template until it is about to be displayed. The issue I had with instant compilation, is that when adding a bunch of datepicker popups on one page (8 in my case), page rendering lags visibly (~0.5 sec using eyeballing measurement, on a lower-end laptop). 

The way I implemented it seems to work for me, but it does break some of the tests. The commit below is merely a proposal to consider a (rather) minor optimization.