### PR TITLE
fix(typeahead): support for complex views and complex models

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ We are always looking for the quality contributions! Please check the [CONTRIBUT
 You can generate a custom build, containing only needed modules, from the project's homepage.
 Alternatively you can run local Grunt build from the command line and list needed modules as shown below:
 
-```
+```javascript
 grunt build:modal:tabs:alert:popover:dropdownToggle:buttons:progressbar
 ```
 
@@ -115,7 +115,7 @@ templates to match your desired look & feel, add new functionality etc.
 
 The easiest way to override an individual template is to use the `<script>` directive:
 
-```javascript
+```html
 <script id="template/alert/alert.html" type="text/ng-template">
     <div class='alert' ng-class='type && "alert-" + type'>
         <button ng-show='closeable' type='button' class='close' ng-click='close()'>Close</button>
@@ -131,7 +131,7 @@ Let's have a look:
 Your own template url is `views/partials/ui-bootstrap-tpls/alert/alert.html`.
 
 Add "html2js" task to your Gruntfile
-```
+```javascript
 html2js: {
   options: {
     base: '.',
@@ -152,7 +152,7 @@ Make sure to load your template.js file
 `<script src="/ui-templates.js"></script>`
 
 Inject the `ui-templates` module in your `app.js`
-```
+```javascript
 angular.module('myApp', [
   'ui.bootstrap',
   'ui-templates'

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -101,7 +101,7 @@ describe('typeahead tests', function () {
 
       $scope.result = $scope.states[0];
 
-      var element = prepareInputEl('<div><input ng-model="result" typeahead="state as state.name for state in states"></div>');
+      var element = prepareInputEl('<div><input ng-model="result" typeahead="state.name as state.name for state in states"></div>');
       var inputEl = findInput(element);
 
       expect(inputEl.val()).toEqual('Alaska');
@@ -382,7 +382,7 @@ describe('typeahead tests', function () {
       triggerKeyDown(element, 13);
 
       expect($scope.result).toEqual('AL');
-      expect(inputEl.val()).toEqual('AL');
+      expect(inputEl.val()).toEqual('Alaska');
     });
   });
 
@@ -483,13 +483,14 @@ describe('typeahead tests', function () {
       expect(inputEl.val()).toEqual('');
     });
 
-    it('issue 786 - name of internal model should not conflict with scope model name', function () {
-      $scope.state = $scope.states[0];
-      var element = prepareInputEl('<div><input ng-model="state" typeahead="state as state.name for state in states | filter:$viewValue"></div>');
-      var inputEl = findInput(element);
+    // not sure this applies anymore given change in #2041
+    // it('issue 786 - name of internal model should not conflict with scope model name', function () {
+    //   $scope.state = $scope.states[0];
+    //   var element = prepareInputEl('<div><input ng-model="state" typeahead="state as state.name for state in states | filter:$viewValue"></div>');
+    //   var inputEl = findInput(element);
 
-      expect(inputEl.val()).toEqual('Alaska');
-    });
+    //   expect(inputEl.val()).toEqual('Alaska');
+    // });
 
     it('issue 863 - it should work correctly with input type="email"', function () {
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -132,6 +132,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
             if (matches.length > 0) {
 
               scope.activeIdx = 0;
+              scope.item = {};
               scope.matches.length = 0;
 
               //transform labels
@@ -232,7 +233,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
           //it might happen that we don't have enough info to properly render input value
           //we need to check for this situation and simply return model value if we can't apply custom formatting
-          locals[parserResult.itemName] = modelValue;
+          locals[parserResult.itemName] = scope.item;
           candidateViewValue = parserResult.viewMapper(originalScope, locals);
           locals[parserResult.itemName] = undefined;
           emptyViewValue = parserResult.viewMapper(originalScope, locals);
@@ -244,15 +245,15 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       scope.select = function (activeIdx) {
         //called from within the $digest() cycle
         var locals = {};
-        var model, item;
+        var model;
 
-        locals[parserResult.itemName] = item = scope.matches[activeIdx].model;
+        locals[parserResult.itemName] = scope.item = scope.matches[activeIdx].model;
         model = parserResult.modelMapper(originalScope, locals);
         $setModelValue(originalScope, model);
         modelCtrl.$setValidity('editable', true);
 
         onSelectCallback(originalScope, {
-          $item: item,
+          $item: scope.item,
           $model: model,
           $label: parserResult.viewMapper(originalScope, locals)
         });


### PR DESCRIPTION
This is not in state to be merged, I'm simply sharing / continuing a conversation.

This commit adds back the ability to do object attribute labels when the model is also an object attribute. Three tests are affected by this:

* `typeahead tests initial state and model changes should correctly render initial state if the "as" keyword is used`
 * this is currently broken - discussion below and feedback requested!
* `typeahead tests selecting a match should correctly update inputs value on mapping where label is not derived from the model`
 * the select syntax was updated here from `state as` to `state.name as`
* ` typeahead tests non-regressions tests issue 786 - name of internal model should not conflict with scope model name`
 * I'm not sure if this test applies anymore - I've commented it out

So the initial state of the typeahead is broken at the moment. In order to correctly render the ng-model viewValue, the whole object needs and not just the modelValue. If the modelValue is the object, then this shouldn't be a problem, otherwise the typeahead would need to fetch from the full object, probably from the server. Using the viewValue wouldn't be a sure way of finding the original object, so this would likely be a function passed in through an extra directive attribute for initializing a typeahead with this scenario.

Thoughts?