### PR TITLE
test(modal): Remove `ddescribe` in the $modal tests

### DIFF
--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -1,4 +1,4 @@
-ddescribe('$modal', function () {
+describe('$modal', function () {
   var $controllerProvider, $rootScope, $document, $compile, $templateCache, $timeout, $q;
   var $modal, $modalProvider;
 


### PR DESCRIPTION
The `ddescribe` is only executing the $modal tests. Removing it will allow
all other unit tests to run.

Fixes #2311.
