### PR TITLE
chore(Gruntfile): add `grunt-ddescribe-iit` task to CI checks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-karma');
   grunt.loadNpmTasks('grunt-conventional-changelog');
   grunt.loadNpmTasks('grunt-ngdocs');
+  grunt.loadNpmTasks('grunt-ddescribe-iit');
 
   // Project configuration.
   grunt.util.linefeed = '\n';
@@ -190,12 +191,17 @@ module.exports = function(grunt) {
         src: ['src/**/*.js', 'src/**/*.ngdoc'],
         title: 'API Documentation'
       }
+    },
+    'ddescribe-iit': {
+      files: [
+        'src/**/*.spec.js'
+      ]
     }
   });
 
   //register before and after test tasks so we've don't have to change cli
   //options on the goole's CI server
-  grunt.registerTask('before-test', ['enforce', 'jshint', 'html2js']);
+  grunt.registerTask('before-test', ['enforce', 'ddescribe-iit', 'jshint', 'html2js']);
   grunt.registerTask('after-test', ['build', 'copy']);
 
   //Rename our watch task to 'delta', then make actual 'watch'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "grunt-karma": "~0.4.4",
     "node-markdown": "0.1.1",
     "semver": "~2.2.0",
-    "shelljs": "~0.2.0"
+    "shelljs": "~0.2.0",
+    "grunt-ddescribe-iit": "0.0.4"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This should prevent `ddescribe` and `iit` blocks in tests from being checked into the tree, as they
were in #2311.
