### PR TITLE
Added support for up/down arrow keys on timepicker

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -6,7 +6,8 @@ angular.module('ui.bootstrap.timepicker', [])
   showMeridian: true,
   meridians: null,
   readonlyInput: false,
-  mousewheel: true
+  mousewheel: true,
+  arrowKeys: true
 })
 
 .controller('TimepickerController', ['$scope', '$attrs', '$parse', '$log', '$locale', 'timepickerConfig', function($scope, $attrs, $parse, $log, $locale, timepickerConfig) {
@@ -24,6 +25,11 @@ angular.module('ui.bootstrap.timepicker', [])
     var mousewheel = angular.isDefined($attrs.mousewheel) ? $scope.$parent.$eval($attrs.mousewheel) : timepickerConfig.mousewheel;
     if ( mousewheel ) {
       this.setupMousewheelEvents( hoursInputEl, minutesInputEl );
+    }
+    
+    var arrowKeys = angular.isDefined($attrs.arrowKeys) ? $scope.$parent.$eval($attrs.arrowKeys) : timepickerConfig.arrowKeys;
+    if ( arrowKeys ) {
+      this.setupArrowKeyEvents( hoursInputEl, minutesInputEl );
     }
 
     $scope.readonlyInput = angular.isDefined($attrs.readonlyInput) ? $scope.$parent.$eval($attrs.readonlyInput) : timepickerConfig.readonlyInput;
@@ -112,6 +118,25 @@ angular.module('ui.bootstrap.timepicker', [])
       e.preventDefault();
     });
 
+  };
+  
+  // Respond on up/down arrow keys
+  this.setupArrowKeyEvents = function( hoursInputEl, minutesInputEl ) {
+    hoursInputEl.bind('keydown', function(e) {
+      if ( e.which === 38 ) {
+        $scope.$apply($scope.incrementHours());
+      } else if( e.which === 40 ){
+        $scope.$apply($scope.decrementHours());
+      }
+    });
+    
+    minutesInputEl.bind('keydown', function(e) {
+      if ( e.which == 38 ) {
+        $scope.$apply($scope.incrementMinutes());
+      }else if( e.which == 40 ){
+        $scope.$apply($scope.decrementMinutes());
+      }
+    });
   };
 
   this.setupInputEvents = function( hoursInputEl, minutesInputEl ) {


### PR DESCRIPTION
Added the ability for the user to adjust hours and minutes for the timepicker by using the up/down keyboard arrow keys. This allow the user to adjust time without the need to use the mouse as they can simply tab across the input boxes (as I haven't used `e.preventDefault()` for the `keydown` event).
By default the arrow keys are supported but this can be turned off by using an additional timepicker attribute `arrow-keys="false"`