### PR TITLE
Avoid TypeError when accessing matches

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -129,7 +129,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
           //but we are interested only in responses that correspond to the current view value
           var onCurrentRequest = (inputValue === modelCtrl.$viewValue);
           if (onCurrentRequest && hasFocus) {
-            if (matches.length > 0) {
+            if (matches && matches.length > 0) {
 
               scope.activeIdx = 0;
               scope.matches.length = 0;


### PR DESCRIPTION
Accessing length on matches may cause a TypeError if matches isn't an array.

Maybe I'm using the directive wrong, but occasionally, I'll run into this issue and get `TypeError: Cannot read property 'length' of undefined`.