### PR TITLE
Date 2014-05-00 should be invalid

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -113,6 +113,8 @@ angular.module('ui.bootstrap.dateparser', [])
   // Check if date is valid for specific month (and year for February).
   // Month: 0 = Jan, 1 = Feb, etc
   function isValid(year, month, date) {
+    if (date <1) return false;
+
     if ( month === 1 && date > 28) {
         return date === 29 && ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0);
     }

--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -113,7 +113,9 @@ angular.module('ui.bootstrap.dateparser', [])
   // Check if date is valid for specific month (and year for February).
   // Month: 0 = Jan, 1 = Feb, etc
   function isValid(year, month, date) {
-    if (date <1) return false;
+    if (date <1) {
+      return false;
+    }
 
     if ( month === 1 && date > 28) {
         return date === 29 && ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0);

--- a/src/dateparser/test/dateparser.spec.js
+++ b/src/dateparser/test/dateparser.spec.js
@@ -83,6 +83,9 @@ describe('date parser', function () {
     it('should not work for invalid number of days in February', function() {
       expect(dateParser.parse('29.02.2013', 'dd.MM.yyyy')).toBeUndefined();
     });
+  it('should not work for 0 number of days', function() {
+      expect(dateParser.parse('00.02.2013', 'dd.MM.yyyy')).toBeUndefined();
+    });
 
     it('should work for 29 days in February for leap years', function() {
       expectParse('29.02.2000', 'dd.MM.yyyy', new Date(2000, 1, 29, 0));


### PR DESCRIPTION
When I type date in format yyyy-mm-dd, ex. (2014-05-00) , parser give me previous day (2014-04-30). From my perspective it's wrong. This date should be invalid. So I made neccessary modifications.

I'm doing it from a timezone UTC+2.
