### PR TITLE
fix(modal): port @thcipriani's solution to modal body shift

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -144,7 +144,6 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         var scrollDiv = angular.element('<div class="'+MEASURE_SCROLLBAR_CLASS+'"></div>');
         bodyEl.append(scrollDiv);
         var width = scrollDiv[0].offsetWidth - scrollDiv[0].clientWidth;
-        console.log('measureScrollbar', width);
         scrollDiv.remove();
         return width;
       }
@@ -153,7 +152,6 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
       function setScrollbar() {
         if (scrollbarWidth) {
           var bodyPad = parseInt(bodyEl.css('padding-right') || 0, 10);
-          console.log('setting scrollbar: ', bodyPad, scrollbarWidth);
           bodyEl.css('padding-right', bodyPad + scrollbarWidth + 'px');
         }
       }

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -135,7 +135,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
 
       // From twbs/bootstrap modal
       function checkScrollbar() {
-        if (bodyEl[0].clientWidth >= $window.innerWidth) { return; }
+        if (bodyEl[0].clientWidth >= $window.innerWidth) { scrollbarWidth = 0; return; }
         scrollbarWidth = scrollbarWidth || measureScrollbar();
       }
 


### PR DESCRIPTION
This pull request addresses the scrolling problem that dates back to an old issue https://github.com/twbs/bootstrap/issues/9855, which is also related to #879.

When the modal dialog opens, the content of `body` is shifted due to the absence of the vertical scrollbar.

![out](https://cloud.githubusercontent.com/assets/108608/3488990/6e63bc44-0510-11e4-943e-0dc3162c7bae.gif)

Demonstration of the bug: http://plnkr.co/edit/aEaIphp0kGBC3G9dNw6j

[The solution](https://github.com/twbs/bootstrap/pull/13103) was proposed by @thcipriani in March this year, and is shipped with Bootstrap v3.2.0. This pull request contains a port of @thcipriani 's solution.

Demonstration of the solution: http://plnkr.co/edit/n1OQrpXPx7MTcozZrJA7

For Bootstrap v3.1.1, we need to add the following CSS for the solution to work.

```css
.modal-scrollbar-measure {
  position: absolute;
  top: -9999px;
  width: 50px;
  height: 50px;
  overflow: scroll;
}

.modal-open .modal {
  overflow-x: hidden;
  overflow-y: auto;
}
```
