### PR TITLE
feat(dropdown): Added dropdownMenu directive to use for context menus

### DIFF
--- a/src/dropdown/docs/demo.html
+++ b/src/dropdown/docs/demo.html
@@ -42,10 +42,21 @@
       </ul>
     </div>
 
+    <!-- Context Menu -->
+    <div dropdown>
+        <button class="btn btn-default btn-sm" context-menu-toggle>Right click me</button>
+        <ul class="dropdown-menu" role="menu">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li><a href="#">Something else here</a></li>
+            <li class="divider"></li>
+            <li><a href="#">Separated link</a></li>
+        </ul>
+    </div>
+
     <hr />
     <p>
         <button type="button" class="btn btn-default btn-sm" ng-click="toggleDropdown($event)">Toggle button dropdown</button>
         <button type="button" class="btn btn-warning btn-sm" ng-click="disabled = !disabled">Enable/Disable</button>
     </p>
-
 </div>

--- a/src/dropdown/docs/demo.js
+++ b/src/dropdown/docs/demo.js
@@ -18,4 +18,20 @@ angular.module('ui.bootstrap.demo').controller('DropdownCtrl', function ($scope)
     $event.stopPropagation();
     $scope.status.isopen = !$scope.status.isopen;
   };
+})
+
+.directive('contextMenuToggle', function () {
+  return {
+    require: '^dropdown',
+    link: function (scope, element, attrs, dropdownCtrl) {
+      element.bind('contextmenu', function (evt) {
+        scope.$apply(function () {
+          console.log('context menu right clicked');
+          evt.preventDefault();
+          evt.stopPropagation();
+          dropdownCtrl.toggle(true, evt);
+        });
+      });
+    }
+  };
 });

--- a/src/dropdown/docs/readme.md
+++ b/src/dropdown/docs/readme.md
@@ -2,3 +2,6 @@
 Dropdown is a simple directive which will toggle a dropdown menu on click or programmatically.
 You can either use `is-open` to toggle or add inside a `<a dropdown-toggle>` element to toggle it when is clicked.
 There is also the `on-toggle(open)` optional expression fired when dropdown changes state.
+
+A final option is to create a directive that requires the `dropdown` controller and calls toggle(open, event).
+This will allow making context menus that open at the mouse cursors position (or anywhere else specified in the event object)

--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -179,7 +179,7 @@ angular.module('ui.bootstrap.dropdown', [])
   };
 })
 
-.directive('dropdownMenu', ['$document', function ($document) {
+.directive('dropdownMenu', ['$document', '$timeout', function ($document, $timeout) {
   return {
     restrict: 'AC',
     require: '?^dropdown',
@@ -192,21 +192,34 @@ angular.module('ui.bootstrap.dropdown', [])
         if (!coords) {
           return;
         }
-        var doc = $document[0].documentElement,
-          docLeft = (window.pageXOffset || doc.scrollLeft) - (doc.clientLeft || 0),
-          docTop = (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0),
-          elementHeight = element[0].scrollHeight,
-          docHeight = doc.clientHeight + docTop,
-          totalHeight = elementHeight + coords.y,
-          top = Math.max(coords.y - docTop, 0);
+        // Hide it before moving it in to the right place
+        element.css('display', 'none');
+        // Needs to be done in a timeout, otherwise it is not visible and thus has no width/height
+        $timeout(function () {
+          element.css('display', 'block');
+          element.css('right', 'initial'); // for rtl support
+          var doc = $document[0].documentElement,
+            docLeft = (window.pageXOffset || doc.scrollLeft) - (doc.clientLeft || 0),
+            docTop = (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0),
+            elementHeight = element[0].scrollHeight,
+            elementWidth = element[0].scrollWidth,
+            docHeight = doc.clientHeight + docTop,
+            docWidth = doc.clientWidth + docLeft,
+            totalHeight = elementHeight + coords.y,
+            totalWidth = elementWidth + coords.x,
+            top = Math.max(coords.y - docTop, 0),
+            left = Math.max(coords.x - docLeft, 0);
 
-        if (totalHeight > docHeight) {
-          top = top - (totalHeight - docHeight);
-        }
-
-        element.css('position', 'fixed');
-        element.css('top', top + 'px');
-        element.css('left', Math.max(coords.x - docLeft, 0) + 'px');
+          if (totalHeight > docHeight) {
+            top = top - (totalHeight - docHeight);
+          }
+          if (totalWidth > docWidth) {
+            left = left - (totalWidth - docWidth);
+          }
+          element.css('position', 'fixed');
+          element.css('top', top + 'px');
+          element.css('left', left + 'px');
+        });
       }
 
       scope.$on('$destroy', function () {

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -309,14 +309,15 @@ describe('dropdownToggle', function() {
       expect(menuElement.css('position')).toBe('absolute');
     });
 
-    it('should set position to fixed if event is passed to toggle', function() {
+    it('should set position to fixed if event is passed to toggle', inject(function ($timeout) {
       ctrl.toggle(true, {pageX: 5, pageY: 5});
+      $timeout.flush();
       $rootScope.$digest();
 
       expect(menuElement.css('position')).toBe('fixed');
       expect(menuElement.css('top')).toBe('5px');
       expect(menuElement.css('left')).toBe('5px');
-    });
+    }));
 
     it('should not alter position if no event is passed to toggle', function() {
       ctrl.toggle(true);

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -285,4 +285,52 @@ describe('dropdownToggle', function() {
       expect($rootScope.toggleHandler).toHaveBeenCalledWith(false);
     });
   });
+
+  describe('toggle should use coordinates to position menu if available', function() {
+    var ctrl,
+      menuElement;
+    beforeEach(function() {
+      $rootScope.toggleHandler = jasmine.createSpy('toggleHandler');
+      element = $compile('' +
+        '<li class="dropdown">' +
+          '<a dropdown-toggle></a>' +
+          '<ul class="dropdown-menu" style="position: absolute">' +
+            '<li>Hello</li>' +
+          '</ul>' +
+        '</li>')($rootScope);
+      menuElement = element.find('ul');
+      ctrl = element.controller('dropdown');
+      expect(ctrl).toBeDefined();
+      $rootScope.$digest();
+      $document.find('body').append(element);
+    });
+
+    it('should not have been toggled initially', function() {
+      expect(menuElement.css('position')).toBe('absolute');
+    });
+
+    it('should set position to fixed if event is passed to toggle', function() {
+      ctrl.toggle(true, {pageX: 5, pageY: 5});
+      $rootScope.$digest();
+
+      expect(menuElement.css('position')).toBe('fixed');
+      expect(menuElement.css('top')).toBe('5px');
+      expect(menuElement.css('left')).toBe('5px');
+    });
+
+    it('should not alter position if no event is passed to toggle', function() {
+      ctrl.toggle(true);
+      $rootScope.$digest();
+
+      expect(menuElement.css('position')).toBe('absolute');
+    });
+
+    it('should unregister handler on $destroy', function() {
+      spyOn(ctrl, 'unregister').andCallThrough();
+      expect(ctrl.unregister).not.toHaveBeenCalled();
+
+      $rootScope.$destroy();
+      expect(ctrl.unregister).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
I have added a feature to dropdown, so it can be used as a context menu. Meaning it will show up at the specified coordinates. See demo.js and demo.html for details.

It is implemented as a dropdownMenu directive. So elements marked with dropdown-menu will register with the dropdown controller, and when dropdown is toggled, be called with the mouse event that triggered the dropdown.

I have also made a change to dropdown-toggle so it stops propagation, since this could e.g. trigger an accordion to toggle if the dropdown-toggle was placed inside an accordion header.