### PR TITLE
Prevent collisions by using $apply over $digest

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -303,7 +303,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       var dismissClickHandler = function (evt) {
         if (element[0] !== evt.target) {
           resetMatches();
-          scope.$digest();
+          scope.$apply();
         }
       };
 


### PR DESCRIPTION
I was having a problem where the new elements added by an ng-repeat were
showing, but their bindings were applied a bit later, meaning that 
they'd show as "{{ something }}" for a moment first. I eventually traced
it back to this click event handler, and found that doing an $apply
instead of a $digest solved the problem.

I have been unable to recreate the problem in a minimal sample, since the setup in which things went wrong were quite complex and the problem also relies on the amount of work that is done, since unless there is a lot to do, the delay will be negligible. Either way, this is a change that shouldn't negatively impact the library, while it should prevent a problem, even if it is rare.