### PR TITLE
bug #2506 Datepicker displays wrong week numbers

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -259,7 +259,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
         if ( scope.showWeeks ) {
           scope.weekNumbers = [];
-          var weekNumber = getISO8601WeekNumber( scope.rows[0][0].date ),
+          // use date at middle of the row (3) instead of 0 to avoid problems when first day is Sunday
+          var weekNumber = getISO8601WeekNumber( scope.rows[0][3].date ), 
               numWeeks = scope.rows.length;
           while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {}
         }

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -259,10 +259,11 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
         if ( scope.showWeeks ) {
           scope.weekNumbers = [];
-          // use date at middle of the row (3) instead of 0 to avoid problems when first day is Sunday
-          var weekNumber = getISO8601WeekNumber(scope.rows[0][3].date);
           var numWeeks = scope.rows.length;
-          while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {}
+          for (var r = 0; r < numWeeks; r++) {
+            // use date at middle of the row (3) instead of 0 to avoid problems when first day is Sunday
+            scope.weekNumbers.push(getISO8601WeekNumber(scope.rows[r][3].date));
+          }
         }
       };
 

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -260,8 +260,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
         if ( scope.showWeeks ) {
           scope.weekNumbers = [];
           // use date at middle of the row (3) instead of 0 to avoid problems when first day is Sunday
-          var weekNumber = getISO8601WeekNumber( scope.rows[0][3].date ), 
-              numWeeks = scope.rows.length;
+          var weekNumber = getISO8601WeekNumber(scope.rows[0][3].date);
+          var numWeeks = scope.rows.length;
           while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {}
         }
       };

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -135,7 +135,7 @@ describe('datepicker directive', function () {
     });
 
     it('renders the week numbers based on ISO 8601', function() {
-      expect(getWeeks()).toEqual(['34', '35', '36', '37', '38', '39']);
+      expect(getWeeks()).toEqual(['35','36','37','38','39','40']);
     });
 
     it('value is correct', function() {


### PR DESCRIPTION
The datepicker displays wrong week numbers if the starting-day is 0 (Sunday),
because it uses the first day of the row to determine the weeknumber of the corresponding row.
According to ISO 8601 the week starts on Monday and ends on Sunday.
Consequently the datapicker will display e.g. for the week Sun Aug 17 - Sat Aug 23 the number of the week that ended on Sun Aug 17 and not the week that starts on Mon Aug 18.
Using the date at middle of the row will display the correct week number regardless of whether the week display starts with a Sunday or a Monday.

[@chrisirhc edit: FIxes #2506]