### PR TITLE
fix(modal): controllerAs not checked

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -377,7 +377,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
                 });
 
                 ctrlInstance = $controller(modalOptions.controller, ctrlLocals);
-                if (modalOptions.controller) {
+                if (modalOptions.controllerAs) {
                   modalScope[modalOptions.controllerAs] = ctrlInstance;
                 }
               }


### PR DESCRIPTION
This causes the controller to be added to the scope as the property "undefined"!

I blame 79105368b37316c9035345a6b2255d52ed5703c6.
