### PR TITLE
Allow Accordion Groups to be open by default

### DIFF
--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -73,7 +73,7 @@ angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse'])
     },
     link: function(scope, element, attrs, accordionCtrl) {
 
-      //allow accordion-groups to be open by default
+      //allow accordion-groups to be open by default, e.g <accordion-group heading="Heading" open-by-default="true">This content will be shown by default.</accordion-group>
       if (attrs.openByDefault) {
         scope.isOpen = true;
       }

--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -72,6 +72,12 @@ angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse'])
       };
     },
     link: function(scope, element, attrs, accordionCtrl) {
+
+      //allow accordion-groups to be open by default
+      if (attrs.openByDefault) {
+        scope.isOpen = true;
+      }
+
       accordionCtrl.addGroup(scope);
 
       scope.$watch('isOpen', function(value) {


### PR DESCRIPTION
Added a cute & necessary lil feature that allows <accordion-group> tags to have an open-by-default option, which lets them be open by default.

`<accordion-group open-by-default="true">
You'll see this!
</accordion-group>`