### PR TITLE
Removed unnecessary string replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ html2js: {
     base: '.',
     module: 'ui-templates',
     rename: function (modulePath) {
-      var moduleName = modulePath.replace('app/views/partials/ui-bootstrap-tpls/', '').replace('.html', '');
-      return 'template' + '/' + moduleName + '.html';
+      var moduleName = modulePath.replace('app/views/partials/ui-bootstrap-tpls/', '');
+      return 'template/' + moduleName;
     }
   },
   main: {


### PR DESCRIPTION
If `.html` is removed from the end only to be added to the end, there's no reason to touch it. Also, `template` + `/` is the same as `template/`. 

I haven't tested this, but I see absolutely no reason why this code isn't the same functionally.
