### PR TITLE
On destroy must remove popup appended to body

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -311,6 +311,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       originalScope.$on('$destroy', function(){
         $document.unbind('click', dismissClickHandler);
+        if ( appendToBody ) {
+          $popup.remove();
+        }
       });
 
       var $popup = $compile(popUpEl)(scope);


### PR DESCRIPTION
Typeahead leaks popup DOMs when they are appended to body.
