### PR TITLE
Add page-label attribute to pagination directive

### DIFF
--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -97,6 +97,7 @@ angular.module('ui.bootstrap.pagination', [])
       }
 
       // Setup configuration parameters
+      var pageLabel = angular.isDefined(attrs.pageLabel) ? function(idx) { return scope.$parent.$eval(attrs.pageLabel, {$page: idx}); } : function(idx) { return idx; };
       var maxSize = angular.isDefined(attrs.maxSize) ? scope.$parent.$eval(attrs.maxSize) : paginationConfig.maxSize,
           rotate = angular.isDefined(attrs.rotate) ? scope.$parent.$eval(attrs.rotate) : paginationConfig.rotate;
       scope.boundaryLinks = angular.isDefined(attrs.boundaryLinks) ? scope.$parent.$eval(attrs.boundaryLinks) : paginationConfig.boundaryLinks;
@@ -150,7 +151,7 @@ angular.module('ui.bootstrap.pagination', [])
 
         // Add page number links
         for (var number = startPage; number <= endPage; number++) {
-          var page = makePage(number, number, number === currentPage);
+          var page = makePage(number, pageLabel(number), number === currentPage);
           pages.push(page);
         }
 

--- a/src/pagination/test/pagination.spec.js
+++ b/src/pagination/test/pagination.spec.js
@@ -574,7 +574,7 @@ describe('pagination directive', function () {
 
   describe('override configuration from attributes', function () {
     beforeEach(function() {
-      element = $compile('<pagination boundary-links="true" first-text="<<" previous-text="<" next-text=">" last-text=">>" total-items="total" ng-model="currentPage"></pagination>')($rootScope);
+      element = $compile('<pagination page-label="\'test_\'+$page" boundary-links="true" first-text="<<" previous-text="<" next-text=">" last-text=">>" total-items="total" ng-model="currentPage"></pagination>')($rootScope);
       $rootScope.$digest();
     });
 
@@ -588,6 +588,12 @@ describe('pagination directive', function () {
       expect(getPaginationEl(-2).text()).toBe('>');
       expect(getPaginationEl(-1).text()).toBe('>>');
     });
-  });
 
+    it('has the label of the page as text in each page item', function() {
+      for (var i = 1; i <= 5; i++) {
+        // +1 because the first element is a <
+        expect(getPaginationEl(i+1).text()).toEqual('test_'+i);
+      }
+    });
+  });
 });


### PR DESCRIPTION
The page-label attribute is an expression that returns a label given a page index (in the scope local $page).

This is a fix for issue #2532 