### PR TITLE
feat(accordion): optimize accordion to lazy load content

### DIFF
--- a/src/accordion/docs/demo.html
+++ b/src/accordion/docs/demo.html
@@ -26,5 +26,10 @@
         </accordion-heading>
         This is just some content to illustrate fancy headings.
     </accordion-group>
+    <accordion-group heading="Lazy Loaded Body Content">
+        <accordion-body>
+            Use the accordion-body directive to transclude content <i>after</i> the accordion is opened.
+        </accordion-body>
+    </accordion-group>
   </accordion>
 </div>

--- a/template/accordion/accordion-group.html
+++ b/template/accordion/accordion-group.html
@@ -4,7 +4,7 @@
       <a class="accordion-toggle" ng-click="toggleOpen()" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
     </h4>
   </div>
-  <div class="panel-collapse" collapse="!isOpen">
+  <div class="panel-collapse" collapse="!isExpanded">
 	  <div class="panel-body" ng-transclude></div>
   </div>
 </div>


### PR DESCRIPTION
I've noticed accordions slowing down the UI when containing a large number of directives. There have been some solutions to this problem, for example:

http://crashthatch.tumblr.com/post/68378038141/lazy-angular-bootstrap-accordions

One of the problems with this approach however, is that it loses the animation, in addition to making your code unnecessarily complicated.

I've added a new directive in this pull request, called accordionBody, that when wrapping content, will lazily load the content on clicking the group link, in addition it will wait for the content to load before expanding a collapsed accordion group.