### PR TITLE
(typeahead) clean polluted dom

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -311,10 +311,13 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       originalScope.$on('$destroy', function(){
         $document.unbind('click', dismissClickHandler);
+        if (appendToBody) {
+          $popup.remove();
+        }
       });
 
       var $popup = $compile(popUpEl)(scope);
-      if ( appendToBody ) {
+      if (appendToBody) {
         $document.find('body').append($popup);
       } else {
         element.after($popup);


### PR DESCRIPTION
when `appendToBody` option is set to true and then scope is destroyed, DOM is still polluted with popup. This fix removes `$popup` from DOM, thus cleaning it.

Small style change besides it
