### PR TITLE
onMove event

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -127,6 +127,9 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
         month = self.activeDate.getMonth() + direction * (self.step.months || 0);
     self.activeDate.setFullYear(year, month, 1);
     self.refreshView();
+	if ($attrs.onMove) {
+		$scope.$parent.$eval($attrs.onMove);
+	}
   };
 
   $scope.toggleMode = function( direction ) {


### PR DESCRIPTION
Event for detect move month in ui.bootstrap.datepicker. 
Example: 
`<datepicker ng-model="dt" on-move="scopeFn()" show-weeks="true" class="well well-sm"></datepicker>`
