### PR TITLE
fix: Replacing timeout with interval for compatibility with Protractor

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -17,7 +17,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   maxDate: null
 })
 
-.controller('DatepickerController', ['$scope', '$attrs', '$parse', '$interpolate', '$timeout', '$log', 'dateFilter', 'datepickerConfig', function($scope, $attrs, $parse, $interpolate, $timeout, $log, dateFilter, datepickerConfig) {
+.controller('DatepickerController', ['$scope', '$attrs', '$parse', '$interpolate', '$interval', '$log', 'dateFilter', 'datepickerConfig', function($scope, $attrs, $parse, $interpolate, $interval, $log, dateFilter, datepickerConfig) {
   var self = this,
       ngModelCtrl = { $setViewValue: angular.noop }; // nullModelCtrl;
 
@@ -143,9 +143,9 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   $scope.keys = { 13:'enter', 32:'space', 33:'pageup', 34:'pagedown', 35:'end', 36:'home', 37:'left', 38:'up', 39:'right', 40:'down' };
 
   var focusElement = function() {
-    $timeout(function() {
+    $interval(function() {
       self.element[0].focus();
-    }, 0 , false);
+    }, 0, 1, false);
   };
 
   // Listen for focus requests from popup directive


### PR DESCRIPTION
In order to test an application that includes the datepicker using Protractor, $timeout has been replaced with $interval.  In the case of datepicker, this was a small, straightforward change.