### PR TITLE
feat(popover): added variation of popover with html unsave capabilities

### DIFF
--- a/src/popover/docs/demo.html
+++ b/src/popover/docs/demo.html
@@ -9,14 +9,14 @@
       <input type="text" ng-model="dynamicPopoverTitle" class="form-control">
     </div>
     <button popover="{{dynamicPopover}}" popover-title="{{dynamicPopoverTitle}}" class="btn btn-default">Dynamic Popover</button>
-    
+
     <hr />
     <h4>Positional</h4>
     <button popover-placement="top" popover="On the Top!" class="btn btn-default">Top</button>
     <button popover-placement="left" popover="On the Left!" class="btn btn-default">Left</button>
     <button popover-placement="right" popover="On the Right!" class="btn btn-default">Right</button>
     <button popover-placement="bottom" popover="On the Bottom!" class="btn btn-default">Bottom</button>
-    
+
     <hr />
     <h4>Triggers</h4>
     <p>
@@ -28,4 +28,8 @@
     <h4>Other</h4>
     <button Popover-animation="true" popover="I fade in and out!" class="btn btn-default">fading</button>
     <button popover="I have a title!" popover-title="The title." class="btn btn-default">title</button>
+
+    <hr />
+    <h4>With HTML as content</h4>
+    <button popover="I have some<br />multiline text." class="btn btn-default">With HTML</button>
 </div>

--- a/src/popover/docs/readme.md
+++ b/src/popover/docs/readme.md
@@ -1,6 +1,12 @@
 A lightweight, extensible directive for fancy popover creation. The popover
 directive supports multiple placements, optional transition animation, and more.
 
+There are two versions of the popover: `popover` and `popover-html-unsafe`. The
+former takes text only and will escape any HTML provided. The latter takes
+whatever HTML is provided and displays it in a popover; it called "unsafe"
+because the HTML is not sanitized. *The user is responsible for ensuring the
+content is safe to put into the DOM!*
+
 Like the Bootstrap jQuery plugin, the popover **requires** the tooltip
 module.
 

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -16,4 +16,17 @@ angular.module( 'ui.bootstrap.popover', [ 'ui.bootstrap.tooltip' ] )
 
 .directive( 'popover', [ '$tooltip', function ( $tooltip ) {
   return $tooltip( 'popover', 'popover', 'click' );
+}])
+
+.directive( 'popoverHtmlUnsavePopup', function () {
+  return {
+    restrict: 'EA',
+    replace: true,
+    scope: { title: '@', content: '@', placement: '@', animation: '&', isOpen: '&' },
+    templateUrl: 'template/popover/popover-html-unsave.html'
+  };
+})
+
+.directive( 'popoverHtmlUnsave', [ '$tooltip', function ( $tooltip ) {
+  return $tooltip( 'popoverHtmlUnsave', 'popover', 'click' );
 }]);

--- a/src/popover/test/popoverHtmlUnsave.spec.js
+++ b/src/popover/test/popoverHtmlUnsave.spec.js
@@ -1,0 +1,71 @@
+describe('popoverHtmlUnsave', function() {
+  var elm,
+      elmBody,
+      scope,
+      elmScope;
+
+  // load the popover code
+  beforeEach(module('ui.bootstrap.popover'));
+
+  // load the template
+  beforeEach(module('template/popover/popover-html-unsave.html'));
+
+  beforeEach(inject(function($rootScope, $compile) {
+    elmBody = angular.element(
+      '<div><span popover-html-unsave="popover<br />text">Selector Text</span></div>'
+    );
+
+    scope = $rootScope;
+    $compile(elmBody)(scope);
+    scope.$digest();
+    elm = elmBody.find('span');
+    elmScope = elm.scope();
+  }));
+
+  it('should not be open initially', inject(function() {
+    expect( elmScope.tt_isOpen ).toBe( false );
+
+    // We can only test *that* the popover-popup element wasn't created as the
+    // implementation is templated and replaced.
+    expect( elmBody.children().length ).toBe( 1 );
+  }));
+
+  it('should open on click', inject(function() {
+    elm.trigger( 'click' );
+    expect( elmScope.tt_isOpen ).toBe( true );
+
+    // We can only test *that* the popover-popup element was created as the
+    // implementation is templated and replaced.
+    expect( elmBody.children().length ).toBe( 2 );
+  }));
+
+  it('should close on second click', inject(function() {
+    elm.trigger( 'click' );
+    elm.trigger( 'click' );
+    expect( elmScope.tt_isOpen ).toBe( false );
+  }));
+
+  it('should not unbind event handlers created by other directives - issue 456', inject( function( $compile ) {
+
+    scope.click = function() {
+      scope.clicked = !scope.clicked;
+    };
+
+    elmBody = angular.element(
+      '<div><input popover-html-unsave="Hello<br />Popover!" ng-click="click()" popover-trigger="mouseenter"/></div>'
+    );
+    $compile(elmBody)(scope);
+    scope.$digest();
+
+    elm = elmBody.find('input');
+
+    elm.trigger( 'mouseenter' );
+    elm.trigger( 'mouseleave' );
+    expect(scope.clicked).toBeFalsy();
+
+    elm.click();
+    expect(scope.clicked).toBeTruthy();
+  }));
+});
+
+

--- a/template/popover/popover-html-unsave.html
+++ b/template/popover/popover-html-unsave.html
@@ -1,0 +1,7 @@
+<div class="popover {{placement}}" ng-class="{ in: isOpen(), fade: animation() }">
+  <div class="arrow"></div>
+  <div class="popover-inner">
+    <h3 class="popover-title" ng-bind="title" ng-show="title"></h3>
+    <div class="popover-content" bind-html-unsafe="content"></div>
+  </div>
+</div>


### PR DESCRIPTION
Hi,

Some people (including me) needed a popover, which is able to use html unsave content.
I implemented it in the same way, the tooltip-html-unsave was done.
Extended the documentation and also copied and adopted the test a bit. This could be better for sure, but it test the same functionality, like on the standard popover.

regards,
Andreas