### PR TITLE
Fix if the openScope doesn´t exist anymore

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -38,9 +38,11 @@ angular.module('ui.bootstrap.dropdown', [])
         return;
     }
 
-    openScope.$apply(function() {
-      openScope.isOpen = false;
-    });
+    if ( openScope ) {
+      openScope.$apply(function() {
+        openScope.isOpen = false;
+      });
+    }
   };
 
   var escapeKeyBind = function( evt ) {


### PR DESCRIPTION
If the dropdown is not available in the DOM anymore but with the $document.bind the click event will be called it creates an error as you can´t $apply on a "null" element. This resolves the problem.