### PR TITLE
Close bug on ng-show when minutes < 10

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -137,7 +137,7 @@ angular.module('ui.bootstrap.timepicker', [])
 
       if ( angular.isDefined(hours) ) {
         selected.setHours( hours );
-        refresh( 'h' );
+        refresh();
       } else {
         invalidate(true);
       }
@@ -156,7 +156,7 @@ angular.module('ui.bootstrap.timepicker', [])
 
       if ( angular.isDefined(minutes) ) {
         selected.setMinutes( minutes );
-        refresh( 'm' );
+        refresh();
       } else {
         invalidate(undefined, true);
       }
@@ -188,10 +188,10 @@ angular.module('ui.bootstrap.timepicker', [])
   };
 
   // Call internally when we know that model is valid.
-  function refresh( keyboardChange ) {
+  function refresh() {
     makeValid();
     ngModelCtrl.$setViewValue( new Date(selected) );
-    updateTemplate( keyboardChange );
+    updateTemplate();
   }
 
   function makeValid() {
@@ -200,15 +200,15 @@ angular.module('ui.bootstrap.timepicker', [])
     $scope.invalidMinutes = false;
   }
 
-  function updateTemplate( keyboardChange ) {
+  function updateTemplate() {
     var hours = selected.getHours(), minutes = selected.getMinutes();
 
     if ( $scope.showMeridian ) {
       hours = ( hours === 0 || hours === 12 ) ? 12 : hours % 12; // Convert 24 to 12 hour system
     }
 
-    $scope.hours = keyboardChange === 'h' ? hours : pad(hours);
-    $scope.minutes = keyboardChange === 'm' ? minutes : pad(minutes);
+    $scope.hours = pad(hours);
+    $scope.minutes = pad(minutes);
     $scope.meridian = selected.getHours() < 12 ? meridians[0] : meridians[1];
   }
 


### PR DESCRIPTION
When ng-hide/ng-show, timepicker's minutes loses it first 0 when exist. In this case timepicker becomes invalid.
When pad function is always used on updateTemplate, 0 doesn't disapear.
So, I also remove useless param on updateTemplate and refresh.

Regards.