### PR TITLE
Stringify pad return when value >= 10

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -88,7 +88,7 @@ angular.module('ui.bootstrap.timepicker', [])
   }
 
   function pad( value ) {
-    return ( angular.isDefined(value) && value.toString().length < 2 ) ? '0' + value : value;
+    return ( angular.isDefined(value) && value.toString().length < 2 ) ? '0' + value : value.toString();
   }
 
   // Respond on mousewheel spin


### PR DESCRIPTION
In some case, increment function indeeds become timepicker invalid because minutes are invalids.
Solution : stringify value in all case for always return string value when using pad function.