### PR TITLE
Allow $modal resolve to accept plain values

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -324,6 +324,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
             angular.forEach(resolves, function (value) {
               if (angular.isFunction(value) || angular.isArray(value)) {
                 promisesArr.push($q.when($injector.invoke(value)));
+              } else {
+                promisesArr.push(value);
               }
             });
             return promisesArr;


### PR DESCRIPTION
Often I find myself writing code like:
$modal.open({...resolve: {object: function() { return obj; }...})
because the caller already knows what object should be.

This could potentially be condensed to:
$modal.open({...resolve: {object: obj; }...})
if resolve accepts plain values, in addition to functions and injectables.