### PR TITLE
feat(typeahead): scroll list when traversing it using arrow keys

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -117,18 +117,17 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         } else {
           element.attr('aria-activedescendant', getMatchId(index));
         
-        setTimeout(function(){
-                var activeLiElem = document.getElementById(getMatchId(index));
-                if(activeLiElem){
-                    var activeAElem = activeLiElem.getElementsByTagName('A')[0];
-                    if(activeAElem){
-                       activeAElem.focus();
-                       element[0].focus();
-
-                    }
-                }
-            });
         
+          var activeLiElem = document.getElementById(getMatchId(index));
+          if(activeLiElem) {
+              var activeAElem = activeLiElem.getElementsByTagName('A')[0];
+              if(activeAElem) {
+                  setTimeout(function(){
+                      activeAElem.focus();
+                      element[0].focus();
+                  });
+              }
+          }
         }
       });
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -116,13 +116,19 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
           element.removeAttr('aria-activedescendant');
         } else {
           element.attr('aria-activedescendant', getMatchId(index));
-        var tempA = angular.element('#'+getMatchId(index)+' > a');
-            if(tempA){
-                 setTimeout(function(){
-                    tempA.focus();
-                    element.focus();
-                });
-            }
+        
+        setTimeout(function(){
+                var activeLiElem = document.getElementById(getMatchId(index));
+                if(activeLiElem){
+                    var activeAElem = activeLiElem.getElementsByTagName('A')[0];
+                    if(activeAElem){
+                       activeAElem.focus();
+                       element[0].focus();
+
+                    }
+                }
+            });
+        
         }
       });
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -116,6 +116,13 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
           element.removeAttr('aria-activedescendant');
         } else {
           element.attr('aria-activedescendant', getMatchId(index));
+        var tempA = angular.element('#'+getMatchId(index)+' > a');
+            if(tempA){
+                 setTimeout(function(){
+                    tempA.focus();
+                    element.focus();
+                });
+            }
         }
       });
 


### PR DESCRIPTION
Hi,
If you limit the visual area of dropdown-menu (by setting max-height:150px) and want to traverse the list using arrow keys, the highlighted value can go out side the visual area. List doesn't scroll up(if first value of list is selected) and down(if last value of list is selected) when up arrow key or down arrow key is pressed respectively.
Plunker with issue: http://plnkr.co/edit/zF2DMQXX9PdaEZJNfEgd?p=preview
enhancement: http://plnkr.co/edit/2d59mQcKVTIVdmad3vHg?p=preview