### PR TITLE
traverse parent scopes to evaluate the expression given in init-date

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -30,7 +30,7 @@ angular.module('ui.bootstrap.dateparser', [])
       apply: function(value) { this.month = value - 1; }
     },
     'M': {
-      regex: '[1-9]|1[0-2]',
+      regex: '1[0-2]|0[1-9]|[1-9]',
       apply: function(value) { this.month = value - 1; }
     },
     'dd': {
@@ -38,7 +38,7 @@ angular.module('ui.bootstrap.dateparser', [])
       apply: function(value) { this.date = +value; }
     },
     'd': {
-      regex: '[1-2]?[0-9]{1}|3[0-1]{1}',
+      regex: '0[1-9]|[12][0-9]|3[01]|[1-9]',
       apply: function(value) { this.date = +value; }
     },
     'EEEE': {

--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -38,7 +38,7 @@ angular.module('ui.bootstrap.dateparser', [])
       apply: function(value) { this.date = +value; }
     },
     'd': {
-      regex: '[1-2]?[0-9]{1}|3[0-1]{1}',
+      regex: '0[1-9]|[12][0-9]|3[01]|[1-9]',
       apply: function(value) { this.date = +value; }
     },
     'EEEE': {

--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -38,7 +38,7 @@ angular.module('ui.bootstrap.dateparser', [])
       apply: function(value) { this.date = +value; }
     },
     'd': {
-      regex: '0[1-9]|[12][0-9]|3[01]|[1-9]',
+      regex: '[1-2]?[0-9]{1}|3[0-1]{1}',
       apply: function(value) { this.date = +value; }
     },
     'EEEE': {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -44,8 +44,24 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
   $scope.datepickerMode = $scope.datepickerMode || datepickerConfig.datepickerMode;
   $scope.uniqueId = 'datepicker-' + $scope.$id + '-' + Math.floor(Math.random() * 10000);
-  this.activeDate = angular.isDefined($attrs.initDate) ? $scope.$parent.$eval($attrs.initDate) : new Date();
+  
+  var traverseParentScopes = function traverser (expression, scope){
+    var result = scope.$parent.$eval(expression);
+    if(typeof(result) !== 'undefined'){
+      self.activeDate = result;
+    }else if(scope.$parent !== null){
+      traverser(expression, scope.$parent);
+    }
+  };
 
+  if(angular.isDefined($attrs.initDate)){
+    traverseParentScopes($attrs.initDate, $scope);
+  }
+
+  if(!this.activeDate){
+    this.activeDate = new Date();
+  }
+    
   $scope.isActive = function(dateObject) {
     if (self.compare(dateObject.date, self.activeDate) === 0) {
       $scope.activeDateId = dateObject.uid;


### PR DESCRIPTION
If init-date is set and contains a valid angular expression, parent scopes are evaluated for this expression. First $parent may not contain the expression thus this method traverses all parents for the given expression. 