### PR TITLE
feat(modal): Adds `defaultContainer` to `$modalProvider`

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -159,8 +159,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
 
       function removeModalWindow(modalInstance) {
 
-        var body = $document.find('body').eq(0);
         var modalWindow = openedWindows.get(modalInstance).value;
+        var container = modalWindow.appendTo;
 
         //clean up the stack
         openedWindows.remove(modalInstance);
@@ -168,7 +168,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         //remove window DOM element
         removeAfterAnimate(modalWindow.modalDomEl, modalWindow.modalScope, 300, function() {
           modalWindow.modalScope.$destroy();
-          body.toggleClass(OPENED_MODAL_CLASS, openedWindows.length() > 0);
+          container.toggleClass(OPENED_MODAL_CLASS, openedWindows.length() > 0);
           checkRemoveBackdrop();
         });
       }
@@ -238,10 +238,11 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
           deferred: modal.deferred,
           modalScope: modal.scope,
           backdrop: modal.backdrop,
-          keyboard: modal.keyboard
+          keyboard: modal.keyboard,
+          appendTo: modal.appendTo
         });
 
-        var body = $document.find('body').eq(0),
+        var container = modal.appendTo,
             currBackdropIndex = backdropIndex();
 
         if (currBackdropIndex >= 0 && !backdropDomEl) {
@@ -250,7 +251,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
           var angularBackgroundDomEl = angular.element('<div modal-backdrop></div>');
           angularBackgroundDomEl.attr('backdrop-class', modal.backdropClass);
           backdropDomEl = $compile(angularBackgroundDomEl)(backdropScope);
-          body.append(backdropDomEl);
+          container.append(backdropDomEl);
         }
 
         var angularDomEl = angular.element('<div modal-window></div>');
@@ -264,8 +265,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
 
         var modalDomEl = $compile(angularDomEl)(modal.scope);
         openedWindows.top().value.modalDomEl = modalDomEl;
-        body.append(modalDomEl);
-        body.addClass(OPENED_MODAL_CLASS);
+        container.append(modalDomEl);
+        container.addClass(OPENED_MODAL_CLASS);
       };
 
       $modalStack.close = function (modalInstance, result) {
@@ -306,6 +307,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         backdrop: true, //can be also false or 'static'
         keyboard: true
       },
+      appendTo: angular.element(document).find('body').eq(0),
       $get: ['$injector', '$rootScope', '$q', '$http', '$templateCache', '$controller', '$modalStack',
         function ($injector, $rootScope, $q, $http, $templateCache, $controller, $modalStack) {
 
@@ -391,6 +393,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
                 backdropClass: modalOptions.backdropClass,
                 windowClass: modalOptions.windowClass,
                 windowTemplateUrl: modalOptions.windowTemplateUrl,
+                appendTo: $modalProvider.appendTo,
                 size: modalOptions.size
               });
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -160,7 +160,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
       function removeModalWindow(modalInstance) {
 
         var modalWindow = openedWindows.get(modalInstance).value;
-        var container = modalWindow.appendTo;
+        var container = modalWindow.container;
 
         //clean up the stack
         openedWindows.remove(modalInstance);
@@ -239,10 +239,10 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
           modalScope: modal.scope,
           backdrop: modal.backdrop,
           keyboard: modal.keyboard,
-          appendTo: modal.appendTo
+          container: modal.container
         });
 
-        var container = modal.appendTo,
+        var container = modal.container,
             currBackdropIndex = backdropIndex();
 
         if (currBackdropIndex >= 0 && !backdropDomEl) {
@@ -307,7 +307,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         backdrop: true, //can be also false or 'static'
         keyboard: true
       },
-      appendTo: angular.element(document).find('body').eq(0),
+      defaultContainer: angular.element(document).find('body').eq(0),
       $get: ['$injector', '$rootScope', '$q', '$http', '$templateCache', '$controller', '$modalStack',
         function ($injector, $rootScope, $q, $http, $templateCache, $controller, $modalStack) {
 
@@ -393,7 +393,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
                 backdropClass: modalOptions.backdropClass,
                 windowClass: modalOptions.windowClass,
                 windowTemplateUrl: modalOptions.windowTemplateUrl,
-                appendTo: $modalProvider.appendTo,
+                container: $modalProvider.defaultContainer,
                 size: modalOptions.size
               });
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -267,9 +267,9 @@ describe('$modal', function () {
     });
   });
 
-  describe('default appendTo can be changed in a provider', function () {
+  describe('defaultContainer can be changed in a provider', function () {
     it('should allow overriding default appendTo in a provider', function () {
-      var container = $modalProvider.appendTo = angular.element('<div>');
+      var container = $modalProvider.defaultContainer = angular.element('<div>');
 
       var modal = open({template: '<div>Content</div>'});
       expect(container).toHaveClass('modal-open');

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -77,13 +77,17 @@ describe('$modal', function () {
 
       toHaveModalsOpen: function(noOfModals) {
 
-        var modalDomEls = this.actual.find('body > div.modal');
+        var modalDomEls = this.actual === $document ?
+          this.actual.find('body > div.modal') :
+          angular.element(this.actual).children('div.modal');
         return modalDomEls.length === noOfModals;
       },
 
       toHaveBackdrop: function() {
 
-        var backdropDomEls = this.actual.find('body > div.modal-backdrop');
+        var backdropDomEls = this.actual === $document ?
+          this.actual.find('body > div.modal-backdrop') :
+          angular.element(this.actual).children('div.modal-backdrop');
         this.message = function() {
           return 'Expected "' + angular.mock.dump(backdropDomEls) + '" to be a backdrop element".';
         };
@@ -260,6 +264,24 @@ describe('$modal', function () {
 
       expect($document).toHaveModalOpenWithContent('Content', 'div');
       expect($document).not.toHaveBackdrop();
+    });
+  });
+
+  describe('default appendTo can be changed in a provider', function () {
+    it('should allow overriding default appendTo in a provider', function () {
+      var container = $modalProvider.appendTo = angular.element('<div>');
+
+      var modal = open({template: '<div>Content</div>'});
+      expect(container).toHaveClass('modal-open');
+      expect(container).toHaveModalsOpen(1);
+      expect(container).toHaveBackdrop();
+
+      dismiss(modal);
+      waitForBackdropAnimation();
+
+      expect(container).not.toHaveClass('modal-open');
+      expect(container).toHaveModalsOpen(0);
+      expect(container).not.toHaveBackdrop();
     });
   });
 


### PR DESCRIPTION
Includes basic tests, with adjustments to `toHaveModalsOpen` and `toHaveBackdrop`.

Fixes: #2688