### PR TITLE
fix(datepicker): format values received from external model changes

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -546,9 +546,10 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
 
       // Outter change
       ngModel.$render = function() {
-        var date = ngModel.$viewValue ? dateFilter(ngModel.$viewValue, dateFormat) : '';
-        element.val(date);
-        scope.date = parseDate( ngModel.$modelValue );
+        var date = ngModel.$viewValue ? parseDate(ngModel.$viewValue) : null;
+        var display = date ? dateFilter(date, dateFormat) : '';
+        element.val(display);
+        scope.date = date;
       };
 
       var documentClickBind = function(event) {


### PR DESCRIPTION
When `ngModel.$render` receives a value updated externally (that is, not as a response to a datepicker event, but some other model update) it does not actually apply configured formatting of any kind. It is assumed that the value is a string, but if it is an instance of `Date` then it is implicitly cast to a string and the element's value is set to that. This fix corrects the behavior by parsing it and applying local filters before assigning the element's value.