### PR TITLE
Fix 2331

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -44,7 +44,18 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
   $scope.datepickerMode = $scope.datepickerMode || datepickerConfig.datepickerMode;
   $scope.uniqueId = 'datepicker-' + $scope.$id + '-' + Math.floor(Math.random() * 10000);
-  this.activeDate = angular.isDefined($attrs.initDate) ? $scope.$parent.$eval($attrs.initDate) : new Date();
+
+  if(angular.isDefined($attrs.initDate)) {
+    this.activeDate = $scope.$parent.$eval($attrs.initDate) || new Date();
+    $scope.$parent.$watch($attrs.initDate, function(initDate){
+      if(initDate && (ngModelCtrl.$isEmpty(ngModelCtrl.$modelValue) || ngModelCtrl.$invalid)){
+        self.activeDate = initDate;
+        self.refreshView();
+      }
+    });
+  } else {
+    this.activeDate =  new Date();
+  }
 
   $scope.isActive = function(dateObject) {
     if (self.compare(dateObject.date, self.activeDate) === 0) {
@@ -484,7 +495,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       }
 
       scope.watchData = {};
-      angular.forEach(['minDate', 'maxDate', 'datepickerMode'], function( key ) {
+      angular.forEach(['minDate', 'maxDate', 'datepickerMode', 'initDate'], function( key ) {
         if ( attrs[key] ) {
           var getAttribute = $parse(attrs[key]);
           scope.$parent.$watch(getAttribute, function(value){

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -472,7 +472,13 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       // datepicker element
       var datepickerEl = angular.element(popupEl.children()[0]);
       if ( attrs.datepickerOptions ) {
-        angular.forEach(scope.$parent.$eval(attrs.datepickerOptions), function( value, option ) {
+        var options = scope.$parent.$eval(attrs.datepickerOptions);
+        if(options.initDate) {
+          scope.initDate = options.initDate;
+          datepickerEl.attr( 'init-date', 'initDate' );
+          delete options.initDate;
+        }
+        angular.forEach(options, function( value, option ) {
           datepickerEl.attr( cameltoDash(option), value );
         });
       }

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1341,7 +1341,7 @@ describe('datepicker directive', function () {
           var wrapElement = $compile('<div><input ng-model="date" datepicker-popup init-date="initDate" is-open="true"></div>')($rootScope);
           $rootScope.$digest();
           assignElements(wrapElement);
-          $rootScope.date = new Date('April 1, 1982')
+          $rootScope.date = new Date('April 1, 1982');
           $rootScope.initDate = new Date('December 20, 1981');
           $rootScope.$digest();
         });

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1252,23 +1252,46 @@ describe('datepicker directive', function () {
     });
 
     describe('attribute `datepickerOptions`', function () {
-      var weekHeader, weekElement;
-      beforeEach(function() {
-        $rootScope.opts = {
-          'show-weeks': false
-        };
-        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup datepicker-options="opts" is-open="true"></div>')($rootScope);
-        $rootScope.$digest();
-        assignElements(wrapElement);
 
-        weekHeader = getLabelsRow().find('th').eq(0);
-        weekElement = element.find('tbody').find('tr').eq(1).find('td').eq(0);
+      describe('show-weeks', function(){
+        var weekHeader, weekElement;
+        beforeEach(function() {
+          $rootScope.opts = {
+            'show-weeks': false
+          };
+          var wrapElement = $compile('<div><input ng-model="date" datepicker-popup datepicker-options="opts" is-open="true"></div>')($rootScope);
+          $rootScope.$digest();
+          assignElements(wrapElement);
+
+          weekHeader = getLabelsRow().find('th').eq(0);
+          weekElement = element.find('tbody').find('tr').eq(1).find('td').eq(0);
+        });
+
+        it('hides week numbers based on variable', function() {
+          expect(weekHeader.text()).toEqual('');
+          expect(weekHeader).toBeHidden();
+          expect(weekElement).toBeHidden();
+        });
       });
 
-      it('hides week numbers based on variable', function() {
-        expect(weekHeader.text()).toEqual('');
-        expect(weekHeader).toBeHidden();
-        expect(weekElement).toBeHidden();
+      describe('init-date', function(){
+        beforeEach(function() {
+          $rootScope.date = null;
+          $rootScope.opts = {
+            'initDate': new Date('November 9, 1980')
+          };
+          var wrapElement = $compile('<div><input ng-model="date" datepicker-popup datepicker-options="opts" is-open="true"></div>')($rootScope);
+          $rootScope.$digest();
+          assignElements(wrapElement);
+        });
+
+        it('does not alter the model', function() {
+          expect($rootScope.date).toBe(null);
+        });
+
+        it('shows the correct title', function() {
+          expect(getTitle()).toBe('November 1980');
+        });
       });
     });
 

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1351,7 +1351,7 @@ describe('datepicker directive', function () {
         });
 
         it('shows the correct title', function() {
-          expect(getTitle()).toBe('April 1944');
+          expect(getTitle()).toBe('April 1982');
         });
       });
     });

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1295,6 +1295,67 @@ describe('datepicker directive', function () {
       });
     });
 
+    describe('attribute `init-date`', function(){
+      beforeEach(function() {
+        $rootScope.date = null;
+        $rootScope.initDate = new Date('November 9, 1980');
+      });
+
+      describe('when initially set', function(){
+        beforeEach(function() {
+          var wrapElement = $compile('<div><input ng-model="date" datepicker-popup init-date="initDate" is-open="true"></div>')($rootScope);
+          $rootScope.$digest();
+          assignElements(wrapElement);
+        });
+
+        it('does not alter the model', function() {
+          expect($rootScope.date).toBe(null);
+        });
+
+        it('shows the correct title', function() {
+          expect(getTitle()).toBe('November 1980');
+        });
+      });
+
+      describe('when modified before date selected.', function(){
+        beforeEach(function() {
+          var wrapElement = $compile('<div><input ng-model="date" datepicker-popup init-date="initDate" is-open="true"></div>')($rootScope);
+          $rootScope.$digest();
+          assignElements(wrapElement);
+
+          $rootScope.initDate = new Date('December 20, 1981');
+          $rootScope.$digest();
+        });
+
+        it('does not alter the model', function() {
+          expect($rootScope.date).toBe(null);
+        });
+
+        it('shows the correct title', function() {
+          expect(getTitle()).toBe('December 1981');
+        });
+      });
+
+      describe('when modified after date selected.', function(){
+        beforeEach(function() {
+          var wrapElement = $compile('<div><input ng-model="date" datepicker-popup init-date="initDate" is-open="true"></div>')($rootScope);
+          $rootScope.$digest();
+          assignElements(wrapElement);
+          $rootScope.date = new Date('April 1, 1982')
+          $rootScope.initDate = new Date('December 20, 1981');
+          $rootScope.$digest();
+        });
+
+        it('does not alter the model', function() {
+          expect($rootScope.date).toEqual(new Date('April 1, 1982'));
+        });
+
+        it('shows the correct title', function() {
+          expect(getTitle()).toBe('April 1944');
+        });
+      });
+    });
+
     describe('toggles programatically by `open` attribute', function () {
       beforeEach(inject(function() {
         $rootScope.open = true;


### PR DESCRIPTION
This fixes the various issues reported under issue #2331.  Specifically it resolves the following issues and provides passing tests to cover each:

* initDate property when present on datepicker-options was not being handled correctly by the datepicker dropdown.
* init-date attribute worked when used on a datepicker but not a datepicker dropdown.  It now works the same on both.
* init-date attribute was only evaluated when the datepicker dropdown was initialized.  It is now watched and will impact the date displayed in the dropdown up until the point were a date is selected or the model is assigned a date programatically.

Please let me know if you have any questions, comments or concerns.
