### PR TITLE
feat(modal): pass reason when opened promise rejected

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -400,8 +400,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
 
             templateAndResolvePromise.then(function () {
               modalOpenedDeferred.resolve(true);
-            }, function () {
-              modalOpenedDeferred.reject(false);
+            }, function (reason) {
+              modalOpenedDeferred.reject(reason);
             });
 
             return modalInstance;

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -235,7 +235,7 @@ describe('$modal', function () {
           ok: function() {return $q.reject('ko');}
         }}
       );
-      expect(modal.opened).toBeRejectedWith(false);
+      expect(modal.opened).toBeRejectedWith('ko');
     });
 
   });


### PR DESCRIPTION
Pass rejected reason on opened promise rejected, like $routeChangeError event on ngRoute.
Give chance to handle error depends on rejected reason on opened promise.