### PR TITLE
Add IE8 compatibility for tab directive

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -36,7 +36,14 @@ angular.module('ui.bootstrap.tabs', [])
   };
 
   ctrl.removeTab = function removeTab(tab) {
-    var index = tabs.indexOf(tab);
+	for (var index = 0, len = tabs.length; i < len; i++) {
+		if(tabs[index] === tab)
+		{
+			--index;
+			break;
+		}
+	};
+
     //Select a new tab if the tab to be removed is selected and not destroyed
     if (tab.active && tabs.length > 1 && !destroyed) {
       //If this is the last tab, select the previous tab. else, the next tab.


### PR DESCRIPTION
In the line 39 of the file tabs.js there are an incompatibility with IE8:

var index = tabs.indexOf(tab);

because the method indexOf isn't in the Array prototype, just in the String prototype.
