### PR TITLE
fix(Modal): Use attribute observe and add a render promise.

### DIFF
--- a/src/modal/docs/readme.md
+++ b/src/modal/docs/readme.md
@@ -22,6 +22,7 @@ The `open` method returns a modal instance, an object with the following propert
 * `dismiss(reason)` - a method that can be used to dismiss a modal, passing a reason
 * `result` - a promise that is resolved when a modal is closed and rejected when a modal is dismissed
 * `opened` - a promise that is resolved when a modal gets opened after downloading content's template and resolving all variables
+* 'rendered' - a promise that is resolved when a modal is rendered. 
 
 In addition the scope associated with modal's content is augmented with 2 methods:
 

--- a/src/modal/test/modalWindow.spec.js
+++ b/src/modal/test/modalWindow.spec.js
@@ -10,14 +10,16 @@ describe('modal window', function () {
   }));
 
   it('should not use transclusion scope for modals content - issue 2110', function () {
-    $compile('<div modal-window><span ng-init="foo=true"></span></div>')($rootScope);
+    $rootScope.animate = false;
+    $compile('<div modal-window animate="animate"><span ng-init="foo=true"></span></div>')($rootScope);
     $rootScope.$digest();
 
     expect($rootScope.foo).toBeTruthy();
   });
 
   it('should support custom CSS classes as string', function () {
-    var windowEl = $compile('<div modal-window window-class="test foo">content</div>')($rootScope);
+    $rootScope.animate = false;
+    var windowEl = $compile('<div modal-window animate="animate" window-class="test foo">content</div>')($rootScope);
     $rootScope.$digest();
 
     expect(windowEl).toHaveClass('test');

--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,3 +1,3 @@
-<div tabindex="-1" role="dialog" class="modal fade" ng-class="{in: animate}" ng-style="{'z-index': 1050 + index*10, display: 'block'}" ng-click="close($event)">
+<div modal-render="{{$isRendered}}" tabindex="-1" role="dialog" class="modal fade" ng-class="{in: animate}" ng-style="{'z-index': 1050 + index*10, display: 'block'}" ng-click="close($event)">
     <div class="modal-dialog" ng-class="{'modal-sm': size == 'sm', 'modal-lg': size == 'lg'}"><div class="modal-content" modal-transclude></div></div>
 </div>


### PR DESCRIPTION
There are two issues with Modal.
1) Modal Directive relays on timeout service to set the animation and focus. The better alternate is to use attribute service's observe method. It is more consistent then $timeout.

2) As of now, there is no way of knowing whether the modal is rendered or DOM ready. Opened promise is pretty useless as it will only notify that template and resolves are resolves successfully or rejected. To solve this, we can have one more promise called 'rendered' which will be settled when modal is rendered. 

Pros:
- User can manipulate DOM (if needed) when rendered promise is settled.
- Avoid any race conditions in the scenarios where the modal content dependents on the dimension of the container. Like setting the maximum height of the modal content element on the basis of modal dialog height etc. 

Short Coming:
- We should reject rendered promise if rendering takes more than allotted time.   