### PR TITLE
fix(modal): fix for conflicts with ngTouch module on mobile devices

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -91,6 +91,11 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         element.addClass(attrs.windowClass || '');
         scope.size = attrs.size;
 
+        // moved from template to fix issue #2280
+        element.on('click', function(evt) {
+          scope.close(evt);
+        });
+
         $timeout(function () {
           // trigger CSS transitions
           scope.animate = true;

--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,3 +1,3 @@
-<div tabindex="-1" role="dialog" class="modal fade" ng-class="{in: animate}" ng-style="{'z-index': 1050 + index*10, display: 'block'}" ng-click="close($event)">
+<div tabindex="-1" role="dialog" class="modal fade" ng-class="{in: animate}" ng-style="{'z-index': 1050 + index*10, display: 'block'}">
     <div class="modal-dialog" ng-class="{'modal-sm': size == 'sm', 'modal-lg': size == 'lg'}"><div class="modal-content" modal-transclude></div></div>
 </div>


### PR DESCRIPTION
This change attempts to fix issue #2280 

ng-click directive has been removed from modal template and click event moved to the modal-window directive code, so the click event keeps firing and modal window closes when clicking on the backdrop. Not sure if there's a better place to put this event but the fix seems to be working.