### PR TITLE
feat(timepicker): have up/down arrow keys control time selection

### DIFF
--- a/src/timepicker/docs/readme.md
+++ b/src/timepicker/docs/readme.md
@@ -29,5 +29,9 @@ All settings can be provided as attributes in the `<timepicker>` or globally con
  	 Whether user can type inside the hours & minutes input.
 
  * `mousewheel`
- 	_(Defaults: true)_ :
- 	 Whether user can scroll inside the hours & minutes input to increase or decrease it's values.
+    _(Defaults: true)_ :
+     Whether user can scroll inside the hours & minutes input to increase or decrease it's values.
+
+ * `arrowkeys`
+    _(Defaults: true)_ :
+     Whether user can use up/down arrowkeys inside the hours & minutes input to increase or decrease it's values.

--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -71,6 +71,25 @@ describe('timepicker directive', function () {
     return e;
   }
 
+  function keydown(key) {
+    var e = $.Event('keydown');
+    switch(key) {
+      case 'left':
+        e.which = 37;
+        break;
+      case 'up':
+        e.which = 38;
+        break;
+      case 'right':
+        e.which = 39;
+        break;
+      case 'down':
+        e.which = 40;
+        break;
+    }
+    return e;
+  }
+
   it('contains three row & three input elements', function() {
     expect(element.find('tr').length).toBe(3);
     expect(element.find('input').length).toBe(2);
@@ -371,6 +390,70 @@ describe('timepicker directive', function () {
     expect(getModelState()).toEqual([15, 40]);
 
     hoursEl.trigger( downMouseWheelEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['02', '40', 'PM']);
+    expect(getModelState()).toEqual([14, 40]);
+  });
+
+  it('responds properly on "keydown" events', function() {
+    var inputs = element.find('input');
+    var hoursEl = inputs.eq(0), minutesEl = inputs.eq(1);
+    var upKeydownEvent = keydown('up');
+    var downKeydownEvent = keydown('down');
+    var leftKeydownEvent = keydown('left');
+
+    expect(getTimeState()).toEqual(['02', '40', 'PM']);
+    expect(getModelState()).toEqual([14, 40]);
+
+    // UP
+    hoursEl.trigger( upKeydownEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['03', '40', 'PM']);
+    expect(getModelState()).toEqual([15, 40]);
+
+    hoursEl.trigger( upKeydownEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['04', '40', 'PM']);
+    expect(getModelState()).toEqual([16, 40]);
+
+    minutesEl.trigger( upKeydownEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['04', '41', 'PM']);
+    expect(getModelState()).toEqual([16, 41]);
+
+    minutesEl.trigger( upKeydownEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['04', '42', 'PM']);
+    expect(getModelState()).toEqual([16, 42]);
+
+    // DOWN
+    minutesEl.trigger( downKeydownEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['04', '41', 'PM']);
+    expect(getModelState()).toEqual([16, 41]);
+
+    minutesEl.trigger( downKeydownEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['04', '40', 'PM']);
+    expect(getModelState()).toEqual([16, 40]);
+
+    hoursEl.trigger( downKeydownEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['03', '40', 'PM']);
+    expect(getModelState()).toEqual([15, 40]);
+
+    hoursEl.trigger( downKeydownEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['02', '40', 'PM']);
+    expect(getModelState()).toEqual([14, 40]);
+
+    // Other keydown
+    hoursEl.trigger( leftKeydownEvent );
+    $rootScope.$digest();
+    expect(getTimeState()).toEqual(['02', '40', 'PM']);
+    expect(getModelState()).toEqual([14, 40]);
+
+    minutesEl.trigger( leftKeydownEvent );
     $rootScope.$digest();
     expect(getTimeState()).toEqual(['02', '40', 'PM']);
     expect(getModelState()).toEqual([14, 40]);

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -6,7 +6,8 @@ angular.module('ui.bootstrap.timepicker', [])
   showMeridian: true,
   meridians: null,
   readonlyInput: false,
-  mousewheel: true
+  mousewheel: true,
+  arrowkeys: true
 })
 
 .controller('TimepickerController', ['$scope', '$attrs', '$parse', '$log', '$locale', 'timepickerConfig', function($scope, $attrs, $parse, $log, $locale, timepickerConfig) {
@@ -24,6 +25,11 @@ angular.module('ui.bootstrap.timepicker', [])
     var mousewheel = angular.isDefined($attrs.mousewheel) ? $scope.$parent.$eval($attrs.mousewheel) : timepickerConfig.mousewheel;
     if ( mousewheel ) {
       this.setupMousewheelEvents( hoursInputEl, minutesInputEl );
+    }
+
+    var arrowkeys = angular.isDefined($attrs.arrowkeys) ? $scope.$parent.$eval($attrs.arrowkeys) : timepickerConfig.arrowkeys;
+    if (arrowkeys) {
+      this.setupArrowkeyEvents( hoursInputEl, minutesInputEl );
     }
 
     $scope.readonlyInput = angular.isDefined($attrs.readonlyInput) ? $scope.$parent.$eval($attrs.readonlyInput) : timepickerConfig.readonlyInput;
@@ -112,6 +118,39 @@ angular.module('ui.bootstrap.timepicker', [])
       e.preventDefault();
     });
 
+  };
+
+  // Respond on up/down arrowkeys
+  this.setupArrowkeyEvents = function( hoursInputEl, minutesInputEl ) {
+    hoursInputEl.bind('keydown', function(e) {
+      if ( e.which === 38 ) { // up
+        $scope.$apply(function() {
+          $scope.incrementHours();
+        });
+        e.preventDefault();
+      }
+      else if ( e.which === 40 ) { // down
+        $scope.$apply(function() {
+          $scope.decrementHours();
+        });
+        e.preventDefault();
+      }
+    });
+
+    minutesInputEl.bind('keydown', function(e) {
+      if ( e.which === 38 ) { // up
+        $scope.$apply(function() {
+          $scope.incrementMinutes();
+        });
+        e.preventDefault();
+      }
+      else if ( e.which === 40 ) { // down
+        $scope.$apply(function() {
+          $scope.decrementMinutes();
+        });
+        e.preventDefault();
+      }
+    });
   };
 
   this.setupInputEvents = function( hoursInputEl, minutesInputEl ) {

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -27,7 +27,7 @@ angular.module('ui.bootstrap.timepicker', [])
       this.setupMousewheelEvents( hoursInputEl, minutesInputEl );
     }
 
-    var arrowkeys = angular.isDefined($attrs.arrowkeys) ? $scope.$parent.$eval($attrs.arrowkeys) : timepickerConfig.arrowkeys;
+    var arrowkeys = angular.isDefined($attrs.arrowkeys) ? $scope.$eval($attrs.arrowkeys) : timepickerConfig.arrowkeys;
     if (arrowkeys) {
       this.setupArrowkeyEvents( hoursInputEl, minutesInputEl );
     }

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -124,31 +124,27 @@ angular.module('ui.bootstrap.timepicker', [])
   this.setupArrowkeyEvents = function( hoursInputEl, minutesInputEl ) {
     hoursInputEl.bind('keydown', function(e) {
       if ( e.which === 38 ) { // up
-        $scope.$apply(function() {
-          $scope.incrementHours();
-        });
         e.preventDefault();
+        $scope.incrementHours();
+        $scope.$apply();
       }
       else if ( e.which === 40 ) { // down
-        $scope.$apply(function() {
-          $scope.decrementHours();
-        });
         e.preventDefault();
+        $scope.decrementHours();
+        $scope.$apply();
       }
     });
 
     minutesInputEl.bind('keydown', function(e) {
       if ( e.which === 38 ) { // up
-        $scope.$apply(function() {
-          $scope.incrementMinutes();
-        });
         e.preventDefault();
+        $scope.incrementMinutes();
+        $scope.$apply();
       }
       else if ( e.which === 40 ) { // down
-        $scope.$apply(function() {
-          $scope.decrementMinutes();
-        });
         e.preventDefault();
+        $scope.decrementMinutes();
+        $scope.$apply();
       }
     });
   };

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -27,7 +27,7 @@ angular.module('ui.bootstrap.timepicker', [])
       this.setupMousewheelEvents( hoursInputEl, minutesInputEl );
     }
 
-    var arrowkeys = angular.isDefined($attrs.arrowkeys) ? $scope.$eval($attrs.arrowkeys) : timepickerConfig.arrowkeys;
+    var arrowkeys = angular.isDefined($attrs.arrowkeys) ? $scope.$parent.$eval($attrs.arrowkeys) : timepickerConfig.arrowkeys;
     if (arrowkeys) {
       this.setupArrowkeyEvents( hoursInputEl, minutesInputEl );
     }


### PR DESCRIPTION
Similar to #2316, but:
* has tests/docs.
* properly consumes up/down events with `preventDefault`.