### PR TITLE
Use `ng-if` to hide inactive tabs

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -95,6 +95,7 @@ angular.module('ui.bootstrap.tabs', [])
     link: function(scope, element, attrs) {
       scope.vertical = angular.isDefined(attrs.vertical) ? scope.$parent.$eval(attrs.vertical) : false;
       scope.justified = angular.isDefined(attrs.justified) ? scope.$parent.$eval(attrs.justified) : false;
+      scope.hideTabs = angular.isDefined(attrs.hideTabs) ? scope.$parent.$eval(attrs.hideTabs) : false;
     }
   };
 })

--- a/template/tabs/tabset.html
+++ b/template/tabs/tabset.html
@@ -2,7 +2,8 @@
   <ul class="nav nav-{{type || 'tabs'}}" ng-class="{'nav-stacked': vertical, 'nav-justified': justified}" ng-transclude></ul>
   <div class="tab-content">
     <div class="tab-pane" 
-         ng-repeat="tab in tabs" 
+         ng-repeat="tab in tabs"
+         ng-if="tab.active"
          ng-class="{active: tab.active}"
          tab-content-transclude="tab">
     </div>

--- a/template/tabs/tabset.html
+++ b/template/tabs/tabset.html
@@ -3,7 +3,7 @@
   <div class="tab-content">
     <div class="tab-pane" 
          ng-repeat="tab in tabs"
-         ng-if="tab.active"
+         ng-if="tab.active || !hideTabs"
          ng-class="{active: tab.active}"
          tab-content-transclude="tab">
     </div>


### PR DESCRIPTION
Hi there. By using `ng-if` the scope for the tab is destroyed when hidden. If there are a lot of large tabs then this can significantly reduce the length of a $digest cycle. Feel free to close the PR I just thought I'd mention this since I found it gave large performance improvements for my app.

It's also easy for people to add this to their app without forking or modifying the code by simply placing the following code above their application code:

```
angular.module("template/tabs/tabset.html", []).run(["$templateCache", function($templateCache) {
  $templateCache.put("template/tabs/tabset.html",
    "\n" +
    "<div class=\"tabbable\">\n" +
    "  <ul class=\"nav {{type && 'nav-' + type}}\" ng-class=\"{'nav-stacked': vertical, 'nav-justified': justified}\" ng-transclude></ul>\n" +
    "  <div class=\"tab-content\">\n" +
    "    <div class=\"tab-pane\" \n" +
    "         ng-repeat=\"tab in tabs\" \n" +
    "         ng-if=\"tab.active\" \n" +
    "         ng-class=\"{active: tab.active}\"\n" +
    "         tab-content-transclude=\"tab\">\n" +
    "    </div>\n" +
    "  </div>\n" +
    "</div>\n" +
    "");
}])
```

Note that in some cases this could change the behavior of your code and it's not surprising some of the tests failed. If you did want to in some way merge this change you'd probably rather have it as a configurable option or advise in the docs the ability to override the templateCache.