### PR TITLE
reset week counter when crossing the new year.

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -262,7 +262,9 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
           var weekNumber = getISO8601WeekNumber( scope.rows[0][0].date ),
               numWeeks = scope.rows.length;
           while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {
-            if (weekNumber === 52) weekNumber = 1;
+            if (weekNumber === 52) { 
+              weekNumber = 1; 
+            }
           }
         }
       };

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -262,8 +262,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
           var weekNumber = getISO8601WeekNumber( scope.rows[0][0].date ),
               numWeeks = scope.rows.length;
           while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {
-            if (weekNumber === 52) {
-              weekNumber = 1;
+            if (weekNumber === 53) {
+              weekNumber = 2;
             }
           }
         }

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -262,8 +262,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
           var weekNumber = getISO8601WeekNumber( scope.rows[0][0].date ),
               numWeeks = scope.rows.length;
           while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {
-            if (weekNumber === 52) { 
-              weekNumber = 1; 
+            if (weekNumber === 52) {
+              weekNumber = 1;
             }
           }
         }

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -261,7 +261,9 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
           scope.weekNumbers = [];
           var weekNumber = getISO8601WeekNumber( scope.rows[0][0].date ),
               numWeeks = scope.rows.length;
-          while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {}
+          while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {
+            if (weekNumber === 52) weekNumber = 1;
+          }
         }
       };
 


### PR DESCRIPTION
Currently January counts weeks as 52, 53, 54, 55, 56 but should count 52, 1, 2, 3, 4. This simple fix should make the counting correct.