### PR TITLE
fix(tooltip): Fix for issue #3167

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -266,6 +266,12 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
                 hide();
               }
             });
+            
+            attrs.$observe( 'disabled', function ( val ) {
+              if (val && ttScope.isOpen ) {
+                hide();
+              }
+            });
 
             attrs.$observe( prefix+'Title', function ( val ) {
               ttScope.title = val;


### PR DESCRIPTION
Tooltip on button doesn't hide if button is disabled on click. Fix for issue #3167
