### PR TITLE
fix(typeahead): resolves property length of undefined error #2999

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -453,7 +453,7 @@ describe('typeahead tests', function () {
       changeInputValueTo(element, 'c');
       expect(element).toBeClosed();
 
-      deferred.resolve(['good1', 'stuff']);
+      deferred.resolve(['good', 'stuff']);
       $scope.$digest();
       expect(element).toBeOpenWithActive(2, 0);
     });

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -453,7 +453,7 @@ describe('typeahead tests', function () {
       changeInputValueTo(element, 'c');
       expect(element).toBeClosed();
 
-      deferred.resolve(['good', 'stuff']);
+      deferred.resolve(['good1', 'stuff']);
       $scope.$digest();
       expect(element).toBeOpenWithActive(2, 0);
     });
@@ -465,6 +465,14 @@ describe('typeahead tests', function () {
       deferred.reject('fail');
       $scope.$digest();
       expect(element).toBeClosed();
+    });
+
+    it('PR #3178, resolves #2999 - should not return property "length" of undefined for matches', function () {
+      changeInputValueTo(element, 'c');
+      expect(element).toBeClosed();
+
+      expect(deferred.resolve()).toEqual(undefined);
+      $scope.$digest();
     });
 
   });
@@ -741,7 +749,7 @@ describe('typeahead tests', function () {
     };
     var element = prepareInputEl('<div><input ng-model="result" ng-keydown="keyDownEvent = $event" typeahead="item for item in source | filter:$viewValue" typeahead-on-select="onSelect($item, $model, $label)" typeahead-focus-first="false"></div>');
     changeInputValueTo(element, 'b');
-    
+
     // enter key should not be captured when nothing is focused
     triggerKeyDown(element, 13);
     expect($scope.keyDownEvent.isDefaultPrevented()).toBeFalsy();

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -131,7 +131,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
           //but we are interested only in responses that correspond to the current view value
           var onCurrentRequest = (inputValue === modelCtrl.$viewValue);
           if (onCurrentRequest && hasFocus) {
-            if (matches.length > 0) {
+            if (matches && matches.length > 0) {
 
               scope.activeIdx = focusFirst ? 0 : -1;
               scope.matches.length = 0;
@@ -172,7 +172,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //we need to propagate user's query so we can higlight matches
       scope.query = undefined;
 
-      //Declare the timeout promise var outside the function scope so that stacked calls can be cancelled later 
+      //Declare the timeout promise var outside the function scope so that stacked calls can be cancelled later
       var timeoutPromise;
 
       var scheduleSearchWithTimeout = function(inputValue) {


### PR DESCRIPTION
An error is thrown that matches.length is not defined. So we check if matches is truthy first.