### PR TITLE
Don't stop ESC propagation unless dropdown is open

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -567,7 +567,9 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       scope.keydown = function(evt) {
         if (evt.which === 27) {
           evt.preventDefault();
-          evt.stopPropagation();
+          if (scope.isOpen) {
+            evt.stopPropagation();
+          }
           scope.close();
         } else if (evt.which === 40 && !scope.isOpen) {
           scope.isOpen = true;

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1248,6 +1248,27 @@ describe('datepicker directive', function () {
           expect(dropdownEl).toBeHidden();
           expect(document.activeElement.tagName).toBe('INPUT');
         });
+        
+        it('stops the ESC key from propagating if the dropdown is open, but not when closed', function() {
+          expect(dropdownEl).not.toBeHidden();
+
+          dropdownEl.find('button').eq(0).focus();
+          expect(document.activeElement.tagName).toBe('BUTTON');
+          
+          var documentKey = -1;
+          var getKey = function(evt) { documentKey = evt.which; };
+          $document.bind('keydown', getKey);
+
+          triggerKeyDown(inputEl, 'esc');
+          $rootScope.$digest();
+          expect(dropdownEl).toBeHidden();
+          expect(documentKey).toBe(-1);
+          
+          triggerKeyDown(inputEl, 'esc');
+          expect(documentKey).toBe(27);
+          
+          $document.unbind('keydown', getKey);
+        });
       });
     });
 


### PR DESCRIPTION
In reference to issue #3096
If the escape key should have other functionality in the context of a form (for example, if datepicker is on a modal) it makes sense to prevent this from happening if escape is used to close the dropdown.  If the dropdown is closed, however, the event should be allowed to propagate.