### PR TITLE
Make datepicker respect dateFormat inside ng-if

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -544,11 +544,13 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
         });
       });
 
-      // Outter change
-      ngModel.$render = function() {
-        var date = ngModel.$viewValue ? dateFilter(ngModel.$viewValue, dateFormat) : '';
-        element.val(date);
-        scope.date = parseDate( ngModel.$modelValue );
+      // Outer change
+      ngModel.$render = function () {
+        if (dateFormat) {
+          var date = ngModel.$viewValue ? dateFilter(ngModel.$viewValue, dateFormat) : '';
+          element.val(date);
+          scope.date = parseDate(ngModel.$modelValue);
+        }
       };
 
       var documentClickBind = function(event) {

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1083,6 +1083,25 @@ describe('datepicker directive', function () {
 
   });
 
+  describe('setting datepickerPopupConfig inside ng-if', function() {
+    var originalConfig = {};
+    beforeEach(inject(function (datepickerPopupConfig) {
+      angular.extend(originalConfig, datepickerPopupConfig);
+      datepickerPopupConfig.datepickerPopup = 'MM-dd-yyyy';
+
+      element = $compile('<div><div ng-if="true"><input ng-model="date" datepicker-popup></div></div>')($rootScope);
+      $rootScope.$digest();
+    }));
+    afterEach(inject(function (datepickerPopupConfig) {
+      // return it to the original state
+      angular.extend(datepickerPopupConfig, originalConfig);
+    }));
+
+    it('changes date format', function () {
+      expect(element.find('input').val()).toEqual('09-30-2010');
+    });
+  });
+
   describe('as popup', function () {
     var inputEl, dropdownEl, $document, $sniffer;
 


### PR DESCRIPTION
Makes the datepicker respect dateFormat inside ng-if.

It turns out this case didn't fail in angular 1.2 but is necessitated
(along with several other fixes) by angular 1.3 not having the
$viewValue still be a proper Date().  So this patch only covers a piece
of the puzzle.

Partially fixes #3124 