### PR TITLE
fix(accordion): Using angular.noop instead

### DIFF
--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -104,7 +104,7 @@ angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse'])
       // Pass the heading to the accordion-group controller
       // so that it can be transcluded into the right place in the template
       // [The second parameter to transclude causes the elements to be cloned so that they work in ng-repeat]
-      accordionGroupCtrl.setHeading(transclude(scope, function() {}));
+      accordionGroupCtrl.setHeading(transclude(scope, angular.noop));
     }
   };
 })


### PR DESCRIPTION
This is a rather small change, I would be more than happy to go a quick grep for other instances but should be a fairly small change. 

According to Angular docs, etc this seems to be the desired way to handle a noop function.

https://docs.angularjs.org/api/ng/function/angular.noop