### PR TITLE
added support for custom inner tag holding tooltip content

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -260,7 +260,16 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
              * Observe the relevant attributes.
              */
             attrs.$observe( type, function ( val ) {
-              ttScope.content = val;
+              if (val.charAt(0) == '@') {
+              	var tag = element.find(val.substring(1));
+              	if (tag) {
+              	  ttScope.content = tag.html();
+              	  tag.remove();
+              	}
+              }
+              if (!ttScope.content) {
+                ttScope.content = val;
+              }
 
               if (!val && ttScope.isOpen ) {
                 hide();


### PR DESCRIPTION
The idea is to provide support to something like

```
<span tooltip="@myTag">
  This is the span text<myTag>this is the tooltip text</myTag>which can be interpolated
</span>
```

I didn't write unit tests as I'm not sure this is something you might want to add: I find it mandatory because I want to allow CMS editors to manipulate the tooltip text via WYSIWYG editors.

I would add a default tag name `tooltip` to be used whenever the only provided value is the `@` char: convention over configuration....