### PR TITLE
Inner tag holding tooltip content

### DIFF
--- a/src/tooltip/test/tooltip2.spec.js
+++ b/src/tooltip/test/tooltip2.spec.js
@@ -133,4 +133,26 @@ describe('tooltip directive', function () {
     expect(fragment).not.toHaveOpenTooltips();
   });
 
+  it('should retrieve content from default inner tag', function () {
+    var fragment = compileTooltip('<span tooltip="@">Trigger here<tooltip>Tooltip text</tooltip></span>');
+
+    var tt = fragment.find('span');
+    tt.trigger( 'mouseenter' );
+    expect( tt.text() ).toBe( 'Trigger here' );
+
+    var tooltipScope = tt.scope().$$childTail;
+    expect( tooltipScope.content ).toBe( 'Tooltip text' );
+  });
+
+  it('should retrieve content from named inner tag', function () {
+    var fragment = compileTooltip('<span tooltip="@myTag">Trigger here<myTag>Tooltip text</myTag></span>');
+
+    var tt = fragment.find('span');
+    tt.trigger( 'mouseenter' );
+    expect( tt.text() ).toBe( 'Trigger here' );
+
+    var tooltipScope = tt.scope().$$childTail;
+    expect( tooltipScope.content ).toBe( 'Tooltip text' );
+  });
+
 });

--- a/src/tooltip/test/tooltip2.spec.js
+++ b/src/tooltip/test/tooltip2.spec.js
@@ -155,4 +155,48 @@ describe('tooltip directive', function () {
     expect( tooltipScope.content ).toBe( 'Tooltip text' );
   });
 
+  it('should retrieve content from default interpolated inner tag', function () {
+    var fragment = compileTooltip('<span tooltip="@">Trigger here<tooltip>Tooltip text</tooltip>!!!</span>');
+
+    var tt = fragment.find('span');
+    tt.trigger( 'mouseenter' );
+    expect( tt.text() ).toBe( 'Trigger here!!!' );
+
+    var tooltipScope = tt.scope().$$childTail;
+    expect( tooltipScope.content ).toBe( 'Tooltip text' );
+  });
+
+  it('should retrieve content from attribute if non matching inner tag', function () {
+    var fragment = compileTooltip('<span tooltip="@">Trigger here <b>Tooltip text</b></span>');
+
+    var tt = fragment.find('span');
+    tt.trigger( 'mouseenter' );
+    expect( tt.text() ).toBe( 'Trigger here Tooltip text' );
+
+    var tooltipScope = tt.scope().$$childTail;
+    expect( tooltipScope.content ).toBe( '@' );
+  });
+
+  it('should retrieve content from attribute if non matching inner tag', function () {
+    var fragment = compileTooltip('<span tooltip="@myTag">Trigger here <b>Tooltip text</b></span>');
+
+    var tt = fragment.find('span');
+    tt.trigger( 'mouseenter' );
+    expect( tt.text() ).toBe( 'Trigger here Tooltip text' );
+
+    var tooltipScope = tt.scope().$$childTail;
+    expect( tooltipScope.content ).toBe( '@myTag' );
+  });
+
+  it('should retrieve content from attribute if no inner tag', function () {
+    var fragment = compileTooltip('<span tooltip="@tooltip">Trigger here</span>');
+
+    var tt = fragment.find('span');
+    tt.trigger( 'mouseenter' );
+    expect( tt.text() ).toBe( 'Trigger here' );
+
+    var tooltipScope = tt.scope().$$childTail;
+    expect( tooltipScope.content ).toBe( '@tooltip' );
+  });
+
 });

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -265,11 +265,10 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
                 if (tag) {
                   ttScope.content = tag.html();
                   tag.remove();
+                  return;
                 }
               }
-              if (!ttScope.content) {
-                ttScope.content = val;
-              }
+              ttScope.content = val;
 
               if (!val && ttScope.isOpen ) {
                 hide();

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -260,7 +260,16 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
              * Observe the relevant attributes.
              */
             attrs.$observe( type, function ( val ) {
-              ttScope.content = val;
+              if (val.charAt(0) == '@') {
+              	var tag = element.find(val.substring(1));
+              	if (tag) {
+              	  ttScope.content = tag.html();
+              	  tag.remove();
+              	}
+              }
+              if (!ttScope.content) {
+                ttScope.content = val;
+              }
 
               if (!val && ttScope.isOpen ) {
                 hide();

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -261,11 +261,11 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
              */
             attrs.$observe( type, function ( val ) {
               if (val.charAt(0) == '@') {
-              	var tag = element.find(val.length > 1 ? val.substring(1) : 'tooltip');
-              	if (tag) {
-              	  ttScope.content = tag.html();
-              	  tag.remove();
-              	}
+                var tag = element.find(val.length > 1 ? val.substring(1) : 'tooltip');
+                if (tag) {
+                  ttScope.content = tag.html();
+                  tag.remove();
+                }
               }
               if (!ttScope.content) {
                 ttScope.content = val;

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -261,7 +261,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
              */
             attrs.$observe( type, function ( val ) {
               if (val.charAt(0) == '@') {
-              	var tag = element.find(val.substring(1));
+              	var tag = element.find(val.length > 1 ? val.substring(1) : 'tooltip');
               	if (tag) {
               	  ttScope.content = tag.html();
               	  tag.remove();

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -260,7 +260,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
              * Observe the relevant attributes.
              */
             attrs.$observe( type, function ( val ) {
-              if (val && val.charAt(0) == '@') {
+              if (val && val.length >= 1 && val.charAt(0) == '@') {
                 var tag = element.find(val.length > 1 ? val.substring(1) : 'tooltip');
                 if (tag) {
                   ttScope.content = tag.html();

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -260,7 +260,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
              * Observe the relevant attributes.
              */
             attrs.$observe( type, function ( val ) {
-              if (val.charAt(0) == '@') {
+              if (val && val.charAt(0) == '@') {
                 var tag = element.find(val.length > 1 ? val.substring(1) : 'tooltip');
                 if (tag) {
                   ttScope.content = tag.html();

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -262,7 +262,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
             attrs.$observe( type, function ( val ) {
               if (val && val.length >= 1 && val.charAt(0) == '@') {
                 var tag = element.find(val.length > 1 ? val.substring(1) : 'tooltip');
-                if (tag) {
+                if (tag.length == 1) {
                   ttScope.content = tag.html();
                   tag.remove();
                   return;


### PR DESCRIPTION
The idea is to provide support to something like

```
<span tooltip="@myTag">
  This is the span text<myTag>this is the tooltip text</myTag>which can be interpolated
</span>
```

I didn't write unit tests as I'm not sure this is something you might want to add: I find it mandatory because I want to allow CMS editors to manipulate the tooltip text via WYSIWYG editors.

I added a default tag name `tooltip` to be used whenever the only provided value is the `@` char: convention over configuration....