### PR TITLE
wrap ngModelCtrl.$modelValue with scope.$eval

### DIFF
--- a/src/buttons/buttons.js
+++ b/src/buttons/buttons.js
@@ -19,7 +19,7 @@ angular.module('ui.bootstrap.buttons', [])
 
       //model -> UI
       ngModelCtrl.$render = function () {
-        element.toggleClass(buttonsCtrl.activeClass, angular.equals(ngModelCtrl.$modelValue, scope.$eval(attrs.btnRadio)));
+        element.toggleClass(buttonsCtrl.activeClass, angular.equals(scope.$eval(ngModelCtrl.$modelValue), scope.$eval(attrs.btnRadio)));
       };
 
       //ui->model
@@ -59,7 +59,7 @@ angular.module('ui.bootstrap.buttons', [])
 
       //model -> UI
       ngModelCtrl.$render = function () {
-        element.toggleClass(buttonsCtrl.activeClass, angular.equals(ngModelCtrl.$modelValue, getTrueValue()));
+        element.toggleClass(buttonsCtrl.activeClass, angular.equals(scope.$eval(ngModelCtrl.$modelValue), getTrueValue()));
       };
 
       //ui->model

--- a/src/buttons/buttons.js
+++ b/src/buttons/buttons.js
@@ -19,7 +19,9 @@ angular.module('ui.bootstrap.buttons', [])
 
       //model -> UI
       ngModelCtrl.$render = function () {
-        element.toggleClass(buttonsCtrl.activeClass, angular.equals(scope.$eval(ngModelCtrl.$modelValue), scope.$eval(attrs.btnRadio)));
+        var modelValue = ngModelCtrl.$modelValue; 
+			  modelValue = typeof modelValue === 'string' ? (modelValue.toLowerCase() === 'true' ? true : (modelValue.toLowerCase() === 'false' ? false : modelValue)) : modelValue;
+			  element.toggleClass(buttonsCtrl.activeClass, angular.equals(modelValue, scope.$eval(attrs.btnRadio)));
       };
 
       //ui->model
@@ -59,7 +61,9 @@ angular.module('ui.bootstrap.buttons', [])
 
       //model -> UI
       ngModelCtrl.$render = function () {
-        element.toggleClass(buttonsCtrl.activeClass, angular.equals(scope.$eval(ngModelCtrl.$modelValue), getTrueValue()));
+        var modelValue = ngModelCtrl.$modelValue; 
+			  modelValue = typeof modelValue === 'string' ? (modelValue.toLowerCase() === 'true' ? true : (modelValue.toLowerCase() === 'false' ? false : modelValue)) : modelValue;
+        element.toggleClass(buttonsCtrl.activeClass, angular.equals(modelValue, getTrueValue()));
       };
 
       //ui->model


### PR DESCRIPTION
Hello,
 at the rows 22 and 62, I had add "scope.$eval(-----)" to wrap ngModelCtrl.$modelValue because sometimes my ngModelCtrl.$modelValue has the string "true" instead true value... and the check box in first not work as expect.
Thank to all!