### PR TITLE
feat(typeahead): Typeahead Custom Popup Template support

### DIFF
--- a/src/typeahead/docs/demo.html
+++ b/src/typeahead/docs/demo.html
@@ -4,6 +4,17 @@
       <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
   </a>
 </script>
+<script type="text/ng-template" id="customPopupTemplate.html">
+  <div>
+
+    <ul class="dropdown-menu" ng-show="isOpen()" ng-style="{top: position.top+'px', left: position.left+'px'}" style="display: block;" role="listbox" aria-hidden="{{!isOpen()}}">
+      <li><label>Custom Popup</label></li>
+      <li ng-repeat="match in matches | limitTo:10 track by $index" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index)" role="option" id="{{match.id}}">
+        <div typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>
+      </li>
+    </ul>
+  </div>
+</script>
 <div class='container-fluid' ng-controller="TypeaheadCtrl">
 
     <h4>Static arrays</h4>
@@ -18,4 +29,8 @@
     <h4>Custom templates for results</h4>
     <pre>Model: {{customSelected | json}}</pre>
     <input type="text" ng-model="customSelected" placeholder="Custom template" typeahead="state as state.name for state in statesWithFlags | filter:{name:$viewValue}" typeahead-template-url="customTemplate.html" class="form-control">
+
+    <h4>Custom templates for popup</h4>
+    <pre>Model: {{customSelected | json}}</pre>
+    <input type="text" ng-model="customSelected" placeholder="Custom template" typeahead="state as state.name for state in statesWithFlags | filter:{name:$viewValue}" typeahead-template-url="customTemplate.html" typeahead-popup-template-url="customPopupTemplate.html" class="form-control">
 </div>

--- a/src/typeahead/docs/readme.md
+++ b/src/typeahead/docs/readme.md
@@ -48,6 +48,10 @@ The typeahead directives provide several attributes:
    :
    Set custom item template
 
+* `typeahead-popup-template-url` <i class="glyphicon glyphicon-eye-open"></i>
+   :
+   Set custom popup template
+
 * `typeahead-wait-ms` <i class="glyphicon glyphicon-eye-open"></i>
    _(Defaults: 0)_ :
    Minimal wait time after last character typed before typeahead kicks-in

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -101,6 +101,11 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         popUpEl.attr('template-url', attrs.typeaheadTemplateUrl);
       }
 
+      //custom popup template
+      if (angular.isDefined(attrs.typeaheadPopupTemplateUrl)) {
+        popUpEl.attr('popup-template-url', attrs.typeaheadPopupTemplateUrl);
+      }
+
       var resetMatches = function() {
         scope.matches = [];
         scope.activeIdx = -1;
@@ -172,7 +177,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //we need to propagate user's query so we can higlight matches
       scope.query = undefined;
 
-      //Declare the timeout promise var outside the function scope so that stacked calls can be cancelled later 
+      //Declare the timeout promise var outside the function scope so that stacked calls can be cancelled later
       var timeoutPromise;
 
       var scheduleSearchWithTimeout = function(inputValue) {
@@ -334,7 +339,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
 }])
 
-  .directive('typeaheadPopup', function () {
+  .directive('typeaheadPopup', function ($http, $templateCache, $compile, $parse) {
     return {
       restrict:'EA',
       scope:{
@@ -345,8 +350,12 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         select:'&'
       },
       replace:true,
-      templateUrl:'template/typeahead/typeahead-popup.html',
       link:function (scope, element, attrs) {
+
+        var tplUrl = attrs.popupTemplateUrl || 'template/typeahead/typeahead-popup.html';
+        $http.get(tplUrl, {cache: $templateCache}).success(function(tplContent){
+           element.replaceWith($compile(tplContent.trim())(scope));
+        });
 
         scope.templateUrl = attrs.templateUrl;
 


### PR DESCRIPTION
Provides support for custom popup template for `typeahead` directive.  Introduces new `typeahead-popup-template-url` attribute to `typeahead` directive.