### PR TITLE
feat(modal): add the ability to close / dismiss with multiple parameters

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -268,18 +268,26 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         body.addClass(OPENED_MODAL_CLASS);
       };
 
-      $modalStack.close = function (modalInstance, result) {
+      $modalStack.close = function (modalInstance) {
+        // Only one parameter is mandatory the modalInstance since the other one
+        // are recovered dynamically through arguments object
         var modalWindow = openedWindows.get(modalInstance);
         if (modalWindow) {
-          modalWindow.value.deferred.resolve(result);
+          // Here we slice after first element since it is the modalInstance
+          var args = Array.prototype.slice.call(arguments, 1);
+          modalWindow.value.deferred.resolve.apply(modalWindow.value.deferred, args);
           removeModalWindow(modalInstance);
         }
       };
 
-      $modalStack.dismiss = function (modalInstance, reason) {
+      $modalStack.dismiss = function (modalInstance) {
+        // Only one parameter is mandatory the modalInstance since the other one
+        // are recovered dynamically through arguments object
         var modalWindow = openedWindows.get(modalInstance);
         if (modalWindow) {
-          modalWindow.value.deferred.reject(reason);
+          // Here we slice after first element since it is the modalInstance
+          var args = Array.prototype.slice.call(arguments, 1);
+          modalWindow.value.deferred.reject.apply(modalWindow.value.deferred, args);
           removeModalWindow(modalInstance);
         }
       };
@@ -338,11 +346,17 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
             var modalInstance = {
               result: modalResultDeferred.promise,
               opened: modalOpenedDeferred.promise,
-              close: function (result) {
-                $modalStack.close(modalInstance, result);
+              close: function () {
+                // no parameters since we should be able to pass more than one parameter
+                var args = Array.prototype.slice.call(arguments);
+                args.unshift(modalInstance);
+                $modalStack.close.apply(this, args);
               },
-              dismiss: function (reason) {
-                $modalStack.dismiss(modalInstance, reason);
+              dismiss: function () {
+                // no parameters since we should be able to pass more than one parameter
+                var args = Array.prototype.slice.call(arguments);
+                args.unshift(modalInstance);
+                $modalStack.dismiss.apply(this, args);
               }
             };
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -214,12 +214,28 @@ describe('$modal', function () {
       expect(modal.result).toBeResolvedWith('closed ok');
     });
 
+    it('should resolve returned promise on close with multiple arguments', function () {
+      var modal = open({template: '<div>Content</div>'});
+      close(modal, 'closed ok', 'another parameter');
+
+      expect(modal.result).toBeResolvedWith('closed ok', 'another parameter');
+    });
+
+
     it('should reject returned promise on dismiss', function () {
 
       var modal = open({template: '<div>Content</div>'});
       dismiss(modal, 'esc');
 
       expect(modal.result).toBeRejectedWith('esc');
+    });
+
+    it('should reject returned promise on dismiss with multiple parameters', function () {
+
+      var modal = open({template: '<div>Content</div>'});
+      dismiss(modal, 'esc', 'another parameter');
+
+      expect(modal.result).toBeRejectedWith('esc', 'another parameter');
     });
 
     it('should expose a promise linked to the templateUrl / resolve promises', function () {


### PR DESCRIPTION
Add the ability to close ($close) or dismiss ($dismiss) a modal window with multiple parameters.

This PR has been made because for now if a user wants to pass down multiple parameters from the modal to the promise, it has to wrap the values in an object : 
```javascript
$modalInstance.close({
  param1: 'foo',
  param2: 'bar'
});
```

It would be more straightforward to do it like : 
```javascript
$modalInstance.close('foo', 'bar');
```