### PR TITLE
make digest call safe for typeahead

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -78,6 +78,13 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         scope.$destroy();
       });
 
+      //safe digest will run only if digest-apply loop is not running already
+      var safeDigest = function {
+        if (!scope.$$phase) {
+          scope.$digest();
+        }
+      };
+
       // WAI-ARIA
       var popupId = 'typeahead-' + scope.$id + '-' + Math.floor(Math.random() * 10000);
       element.attr({
@@ -283,11 +290,11 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
         if (evt.which === 40) {
           scope.activeIdx = (scope.activeIdx + 1) % scope.matches.length;
-          scope.$digest();
+          safeDigest();
 
         } else if (evt.which === 38) {
           scope.activeIdx = (scope.activeIdx > 0 ? scope.activeIdx : scope.matches.length) - 1;
-          scope.$digest();
+          safeDigest();
 
         } else if (evt.which === 13 || evt.which === 9) {
           scope.$apply(function () {
@@ -298,7 +305,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
           evt.stopPropagation();
 
           resetMatches();
-          scope.$digest();
+          safeDigest();
         }
       });
 
@@ -310,7 +317,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       var dismissClickHandler = function (evt) {
         if (element[0] !== evt.target) {
           resetMatches();
-          scope.$digest();
+          safeDigest();
         }
       };
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -79,7 +79,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       });
 
       //safe digest will run only if digest-apply loop is not running already
-      var safeDigest = function {
+      var safeDigest = function() {
         if (!scope.$$phase) {
           scope.$digest();
         }


### PR DESCRIPTION
To prevent this error:

```
 Error: [$rootScope:inprog] $apply already in progress
http://errors.angularjs.org/1.3.8/$rootScope/inprog?p0=%24apply
    at REGEX_STRING_REGEXP (angular-1a24e868b68bd67ab39e8bf0a570f0e0.js?body=1:64)
    at beginPhase (angular-1a24e868b68bd67ab39e8bf0a570f0e0.js?body=1:14738)
    at Scope.$get.Scope.$digest (angular-1a24e868b68bd67ab39e8bf0a570f0e0.js?body=1:14180)
    at HTMLDocument.link.dismissClickHandler (angular-ui-bootstrap-tpls-f3cf4f62189f086934b79bbc8e869f2c.js?body=1:3777)
    at HTMLDocument.jQuery.event.dispatch (jquery-346a9251cf1c02f6e4dbd3bb8919f87d.js?body=1:4642)
    at HTMLDocument.jQuery.event.add.elemData.handle (jquery-346a9251cf1c02f6e4dbd3bb8919f87d.js?body=1:4310)
    at Object.jQuery.event.trigger (jquery-346a9251cf1c02f6e4dbd3bb8919f87d.js?body=1:4551)
    at HTMLAnchorElement.<anonymous> (jquery-346a9251cf1c02f6e4dbd3bb8919f87d.js?body=1:5261)
    at Function.jQuery.extend.each (jquery-346a9251cf1c02f6e4dbd3bb8919f87d.js?body=1:384)
    at jQuery.fn.jQuery.each (jquery-346a9251cf1c02f6e4dbd3bb8919f87d.js?body=1:137)angular-1a24e868b68bd67ab39e8bf0a570f0e0.js?body=1:11595 (anonymous function)angular-1a24e868b68bd67ab39e8bf0a570f0e0.js?body=1:8545 $getangular-1a24e868b68bd67ab39e8bf0a570f0e0.js?body=1:14485 $get.Scope.$applyangular-1a24e868b68bd67ab39e8bf0a570f0e0.js?body=1:22955 (anonymous function)jquery-346a9251cf1c02f6e4dbd3bb8919f87d.js?body=1:4642 jQuery.event.dispatchjquery-346a9251cf1c02f6e4dbd3bb8919f87d.js?body=1:4310 jQuery.event.add.elemData.handle
```

Signed-off-by: Yury Kaliada <fut.wrk@gmail.com>