### PR TITLE
modalClass option for $modal

### DIFF
--- a/src/modal/docs/readme.md
+++ b/src/modal/docs/readme.md
@@ -13,6 +13,7 @@ The `$modal` service has only one method: `open(options)` where available option
 * `keyboard` - indicates whether the dialog should be closable by hitting the ESC key, defaults to true
 * `backdropClass` - additional CSS class(es) to be added to a modal backdrop template
 * `windowClass` - additional CSS class(es) to be added to a modal window template
+* `modalClass` - additional CSS class(es) to be added to a modal-content template
 * `windowTemplateUrl` - a path to a template overriding modal's window template
 * `size` - optional size of modal window. Allowed values: `'sm'` (small) or  `'lg'` (large). Requires Bootstrap 3.1.0 or later
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -90,7 +90,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
       link: function (scope, element, attrs) {
         element.addClass(attrs.windowClass || '');
         scope.size = attrs.size;
-        scope.modalClass = attrs.modalClass;
+        scope.modalClass = attrs.modalClass || '';
 
         // moved from template to fix issue #2280
         element.on('click', function(evt) {
@@ -263,6 +263,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         angularDomEl.attr({
           'template-url': modal.windowTemplateUrl,
           'window-class': modal.windowClass,
+          'modal-Class': modal.modalClass,
           'size': modal.size,
           'index': openedWindows.length() - 1,
           'animate': 'animate'

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -263,7 +263,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         angularDomEl.attr({
           'template-url': modal.windowTemplateUrl,
           'window-class': modal.windowClass,
-          'modal-Class': modal.modalClass,
+          'modal-class': modal.modalClass,
           'size': modal.size,
           'index': openedWindows.length() - 1,
           'animate': 'animate'

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -90,6 +90,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
       link: function (scope, element, attrs) {
         element.addClass(attrs.windowClass || '');
         scope.size = attrs.size;
+        scope.modalClass = attrs.modalClass;
 
         // moved from template to fix issue #2280
         element.on('click', function(evt) {
@@ -394,6 +395,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
                 backdrop: modalOptions.backdrop,
                 keyboard: modalOptions.keyboard,
                 backdropClass: modalOptions.backdropClass,
+                modalClass: modalOptions.modalClass,
                 windowClass: modalOptions.windowClass,
                 windowTemplateUrl: modalOptions.windowTemplateUrl,
                 size: modalOptions.size

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -519,6 +519,18 @@ describe('$modal', function () {
         expect($document.find('div.modal')).toHaveClass('additional');
       });
     });
+      
+    describe('custom modal classes', function () {
+
+      it('should support additional modal class as string', function () {
+        open({
+          template: '<div>With custom modal class</div>',
+          modalClass: 'additional'
+        });
+
+        expect($document.find('div.modal-content')).toHaveClass('additional');
+      });
+    });
 
     describe('size', function () {
 

--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,3 +1,3 @@
 <div tabindex="-1" role="dialog" class="modal fade" ng-class="{in: animate}" ng-style="{'z-index': 1050 + index*10, display: 'block'}">
-    <div class="modal-dialog" ng-class="{'modal-sm': size == 'sm', 'modal-lg': size == 'lg'}"><div class="modal-content" modal-transclude></div></div>
+    <div class="modal-dialog {{ modalClass }}" ng-class="{'modal-sm': size == 'sm', 'modal-lg': size == 'lg'}"><div class="modal-content" modal-transclude></div></div>
 </div>

--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,3 +1,3 @@
 <div tabindex="-1" role="dialog" class="modal fade" ng-class="{in: animate}" ng-style="{'z-index': 1050 + index*10, display: 'block'}">
-    <div class="modal-dialog {{ modalClass }}" ng-class="{'modal-sm': size == 'sm', 'modal-lg': size == 'lg'}"><div class="modal-content" modal-transclude></div></div>
+    <div class="modal-dialog" ng-class="{'modal-sm': size == 'sm', 'modal-lg': size == 'lg'}"><div class="modal-content  {{ modalClass }}" modal-transclude></div></div>
 </div>


### PR DESCRIPTION
Adding ```modalClass``` as a new optional parameter for ```$modal``` service. The aim of this param is to specify additional CSS class(es) to be added to a modal-content template.

E.g. ```...modalClass: 'panel panel-danger'... ```, and a template
```
...
<div class="modal-header panel-heading">
    <h3 class="modal-title">Error!</h3>
</div>
...
```
makes the modal look "danger type".
