### PR TITLE
Allowing dynamic max value

### DIFF
--- a/src/progressbar/progressbar.js
+++ b/src/progressbar/progressbar.js
@@ -54,6 +54,7 @@ angular.module('ui.bootstrap.progressbar', [])
         require: '^progress',
         scope: {
             value: '=',
+            max: '=',
             type: '@'
         },
         templateUrl: 'template/progressbar/bar.html',
@@ -71,6 +72,7 @@ angular.module('ui.bootstrap.progressbar', [])
         controller: 'ProgressController',
         scope: {
             value: '=',
+            max: '=',
             type: '@'
         },
         templateUrl: 'template/progressbar/progressbar.html',


### PR DESCRIPTION
If max was changed after the progress bar was created, the value of max in the progress bar was not updated.
This update will allow the user to dynamically change the max value and update the progress bar correctly.