### PR TITLE
Allowing (optional) dynamic max in progress bar

### DIFF
--- a/src/progressbar/progressbar.js
+++ b/src/progressbar/progressbar.js
@@ -54,6 +54,7 @@ angular.module('ui.bootstrap.progressbar', [])
         require: '^progress',
         scope: {
             value: '=',
+            max: '=',
             type: '@'
         },
         templateUrl: 'template/progressbar/bar.html',
@@ -71,6 +72,7 @@ angular.module('ui.bootstrap.progressbar', [])
         controller: 'ProgressController',
         scope: {
             value: '=',
+            max: '=',
             type: '@'
         },
         templateUrl: 'template/progressbar/progressbar.html',

--- a/src/progressbar/progressbar.js
+++ b/src/progressbar/progressbar.js
@@ -10,7 +10,7 @@ angular.module('ui.bootstrap.progressbar', [])
         animate = angular.isDefined($attrs.animate) ? $scope.$parent.$eval($attrs.animate) : progressConfig.animate;
 
     this.bars = [];
-    $scope.max = angular.isDefined($attrs.max) ? $scope.$parent.$eval($attrs.max) : progressConfig.max;
+    $scope.max = angular.isDefined($scope.max) ? $scope.max : progressConfig.max;
 
     this.addBar = function(bar, element) {
         if ( !animate ) {
@@ -54,7 +54,7 @@ angular.module('ui.bootstrap.progressbar', [])
         require: '^progress',
         scope: {
             value: '=',
-            max: '=',
+            max: '=?',
             type: '@'
         },
         templateUrl: 'template/progressbar/bar.html',
@@ -72,7 +72,7 @@ angular.module('ui.bootstrap.progressbar', [])
         controller: 'ProgressController',
         scope: {
             value: '=',
-            max: '=',
+            max: '=?',
             type: '@'
         },
         templateUrl: 'template/progressbar/progressbar.html',

--- a/src/progressbar/test/progressbar.spec.js
+++ b/src/progressbar/test/progressbar.spec.js
@@ -116,6 +116,13 @@ describe('progressbar directive', function () {
     it('transcludes "bar" text', function() {
       expect(getBar(0).text()).toBe('22/200');
     });
+    
+    it('adjust the valuemax when it changes', function() {
+      expect(getBar(0).attr('aria-valuemax')).toBe('200');
+      $rootScope.max = 300;
+      $rootScope.$digest();
+      expect(getBar(0).attr('aria-valuemax')).toBe('300');
+    })
   });
 
   describe('"type" attribute', function () {

--- a/src/progressbar/test/progressbar.spec.js
+++ b/src/progressbar/test/progressbar.spec.js
@@ -122,7 +122,7 @@ describe('progressbar directive', function () {
       $rootScope.max = 300;
       $rootScope.$digest();
       expect(getBar(0).attr('aria-valuemax')).toBe('300');
-    })
+    });
   });
 
   describe('"type" attribute', function () {

--- a/src/progressbar/test/progressbar.spec.js
+++ b/src/progressbar/test/progressbar.spec.js
@@ -117,7 +117,7 @@ describe('progressbar directive', function () {
       expect(getBar(0).text()).toBe('22/200');
     });
     
-    it('adjust the valuemax when it changes', function() {
+    it('adjusts the valuemax when it changes', function() {
       expect(getBar(0).attr('aria-valuemax')).toBe('200');
       $rootScope.max = 300;
       $rootScope.$digest();


### PR DESCRIPTION
If max's value was changed after the progress bar was created, the value of max in the progress bar was not updated.
This update will allow the user to dynamically change the max value and update the progress bar correctly.
Max is treated as an optional variable and is being initialized using the default value (100) if not provided.