### PR TITLE
datepicker popup removes angularjs basicText formatter from ngModel.$formatters

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -523,7 +523,16 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
         }
       }
       ngModel.$parsers.unshift(parseDate);
-
+      // get rid of the default angularjs text formatter that messes with the view value.
+      for (var i = 0; i < ngModel.$formatters.length; i++) {
+          var now = new Date();
+          var fmtFn = ngModel.$formatters[i];
+          var isDefault = fmtFn(now) === now.toString();
+          if (isDefault) {
+              ngModel.$formatters.splice(i, 1);
+              break;
+          }
+      }
       // Inner change
       scope.dateSelection = function(dt) {
         if (angular.isDefined(dt)) {


### PR DESCRIPTION
fixes #2899 and #2069 in angular 1.3.x.

As it seems there is a default formatter in there put by the framework that converts a javascript Date object to a string using the toString() method in order to render the value to the view. I have managed to get around it by inspecting the formatters and just removing the default if found.