### PR TITLE
fix(accordion): noop header link to avoid page refresh with nested buttons

### DIFF
--- a/template/accordion/accordion-group.html
+++ b/template/accordion/accordion-group.html
@@ -1,7 +1,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title">
-      <a href class="accordion-toggle" ng-click="toggleOpen()" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
+      <a href="javascript:void(0)" class="accordion-toggle" ng-click="toggleOpen()" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
     </h4>
   </div>
   <div class="panel-collapse" collapse="!isOpen">


### PR DESCRIPTION
When nesting buttons in the header, and calling `$event.stopPropagation()` in their click handlers would cause a page refresh, because the default empty URL would be executed. By changing this into a noop, the page refresh is prevented. #3299