### PR TITLE
Fix typeahead validity if model is set manually

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -630,6 +630,22 @@ describe('typeahead tests', function () {
       $(match).click();
       $scope.$digest();
     });
+
+    it('issue #3318 - should set model validity to true when set manually', function () {
+
+      var element = prepareInputEl(
+        '<div><form name="form">' +
+          '<input name="input" ng-model="result" typeahead="item for item in source | filter:$viewValue" typeahead-editable="false">' +
+        '</form></div>');
+
+      changeInputValueTo(element, 'not in matches');
+      $scope.$apply(function () {
+        $scope.result = 'manually set';
+      });
+
+      expect($scope.result).toEqual('manually set');
+      expect($scope.form.input.$valid).toBeTruthy();
+    });
   });
 
   describe('input formatting', function () {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -225,6 +225,13 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         var candidateViewValue, emptyViewValue;
         var locals = {};
 
+        // The validity may be set to false via $parsers (see above) if
+        // the model is restricted to selected values. If the model
+        // is set manually it is considered to be valid.
+        if (!isEditable) {
+          modelCtrl.$setValidity('editable', true);
+        }
+
         if (inputFormatter) {
 
           locals.$model = modelValue;


### PR DESCRIPTION
With this commit, the validity of a typeahead model is set to true if the model is set manually and the typehead directive is set to be non-editable.

Fixes #3318.

Thx to @jengeb for investigating the issue with me in a nightly hacking session. :smiley: 