### PR TITLE
Issue #3307 fix - DatePeeker weeks

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -262,7 +262,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
           var weekNumber = getISO8601WeekNumber( scope.rows[0][6].date ),
               numWeeks = scope.rows.length;
           while( scope.weekNumbers.push(weekNumber++) < numWeeks && weekNumber < 53) {}
-          weekNumber = 1;  
+          weekNumber = 1;
           while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {}
         }
       };

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -259,7 +259,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
         if ( scope.showWeeks ) {
           scope.weekNumbers = [];
-          var weekNumber = getISO8601WeekNumber( scope.rows[0][0].date ),
+          var weekNumber = getISO8601WeekNumber( scope.rows[0][6].date ),
               numWeeks = scope.rows.length;
           while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {}
         }

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -261,6 +261,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
           scope.weekNumbers = [];
           var weekNumber = getISO8601WeekNumber( scope.rows[0][6].date ),
               numWeeks = scope.rows.length;
+          while( scope.weekNumbers.push(weekNumber++) < numWeeks && weekNumber < 53) {}
+          weekNumber = 1;  
           while( scope.weekNumbers.push(weekNumber++) < numWeeks ) {}
         }
       };

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -135,7 +135,7 @@ describe('datepicker directive', function () {
     });
 
     it('renders the week numbers based on ISO 8601', function() {
-      expect(getWeeks()).toEqual(['34', '35', '36', '37', '38', '39']);
+      expect(getWeeks()).toEqual(['35', '36', '37', '38', '39', '40']);
     });
 
     it('value is correct', function() {


### PR DESCRIPTION
Issue #3307 fix - DatePeeker weeks - wrong date sent to "getISO8601WeekNumber" method. 
Should be the last week's day, and not the first (otherwise on start of a new year it will send a date of one of last year's days, and will get end of last year's weeks)
For example: 
The fist week of January 2015 starts at Thursday. The date sent to "getISO8601WeekNumber" was of the first day of the week (28.12.2014), returning the weeks of last year's December!

- There was an issue in unit tests as well: Sep 2010 weeks are 35-40, not 34-39, see http://www.epochconverter.com/date-and-time/weeknumbers-by-year.php?year=2010