### PR TITLE
fix(datepicker): `ng-model` value can be a timestamp

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -502,6 +502,11 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       }
 
       function parseDate(viewValue) {
+        if (angular.isNumber(viewValue)) {
+          // presumably timestamp to date object
+          viewValue = new Date(viewValue);
+        }
+
         if (!viewValue) {
           ngModel.$setValidity('date', true);
           return null;

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1506,8 +1506,15 @@ describe('datepicker directive', function () {
       it('should be invalid initially', function() {
         expect(inputEl.hasClass('ng-invalid')).toBeTruthy();
       });
+
       it('should be valid if model has been specified', function() {
         $rootScope.date = new Date();
+        $rootScope.$digest();
+        expect(inputEl.hasClass('ng-valid')).toBeTruthy();
+      });
+
+      it('should be valid if model value is a valid timestamp', function() {
+        $rootScope.date = Date.now();
         $rootScope.$digest();
         expect(inputEl.hasClass('ng-valid')).toBeTruthy();
       });


### PR DESCRIPTION
Accept a number of milliseconds since 01.01.1970 as a valid value
for `ng-model`

Closes #2345