### PR TITLE
Made accordion heading tab-able for IE9-10

### DIFF
--- a/template/accordion/accordion-group.html
+++ b/template/accordion/accordion-group.html
@@ -1,7 +1,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title">
-      <a href class="accordion-toggle" ng-click="toggleOpen()" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
+      <a href tabindex="0" class="accordion-toggle" ng-click="toggleOpen()" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
     </h4>
   </div>
   <div class="panel-collapse" collapse="!isOpen">


### PR DESCRIPTION
Having an empty href tag works with modern browsers but not with IE9 or IE10. Adding tabindex="0" makes the accordion heading tab-able without mixing up the tab order.