### PR TITLE
fix(datepicker): child scope problem with isOpen

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -436,7 +436,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
     restrict: 'EA',
     require: 'ngModel',
     scope: {
-      isOpen: '=?',
+      popupState: '=?',
       currentText: '@',
       clearText: '@',
       closeText: '@',
@@ -448,6 +448,12 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
           appendToBody = angular.isDefined(attrs.datepickerAppendToBody) ? scope.$parent.$eval(attrs.datepickerAppendToBody) : datepickerPopupConfig.appendToBody;
 
       scope.showButtonBar = angular.isDefined(attrs.showButtonBar) ? scope.$parent.$eval(attrs.showButtonBar) : datepickerPopupConfig.showButtonBar;
+
+      if (!scope.popupState) {
+        scope.popupState = {
+          open: false
+        };
+      }
 
       scope.getText = function( key ) {
         return scope[key + 'Text'] || datepickerPopupConfig[key + 'Text'];
@@ -537,7 +543,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
         ngModel.$render();
 
         if ( closeOnDateSelection ) {
-          scope.isOpen = false;
+          scope.popupState.open = false;
           element[0].focus();
         }
       };
@@ -556,9 +562,9 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       };
 
       var documentClickBind = function(event) {
-        if (scope.isOpen && event.target !== element[0]) {
+        if (scope.popupState.open && event.target !== element[0]) {
           scope.$apply(function() {
-            scope.isOpen = false;
+            scope.popupState.open = false;
           });
         }
       };
@@ -571,17 +577,17 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       scope.keydown = function(evt) {
         if (evt.which === 27) {
           evt.preventDefault();
-          if (scope.isOpen) {
+          if (scope.popupState.open) {
             evt.stopPropagation();
           }
           scope.close();
-        } else if (evt.which === 40 && !scope.isOpen) {
-          scope.isOpen = true;
+        } else if (evt.which === 40 && !scope.popupState.open) {
+          scope.popupState.open = true;
         }
       };
 
-      scope.$watch('isOpen', function(value) {
-        if (value) {
+      scope.$watch('popupState', function(state) {
+        if (state && state.open) {
           scope.$broadcast('datepicker.focus');
           scope.position = appendToBody ? $position.offset(element) : $position.position(element);
           scope.position.top = scope.position.top + element.prop('offsetHeight');
@@ -606,7 +612,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
       };
 
       scope.close = function() {
-        scope.isOpen = false;
+        scope.popupState.open = false;
         element[0].focus();
       };
 

--- a/src/datepicker/docs/demo.html
+++ b/src/datepicker/docs/demo.html
@@ -10,7 +10,7 @@
     <div class="row">
         <div class="col-md-6">
             <p class="input-group">
-              <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="dt" is-open="opened" min-date="minDate" max-date="'2015-06-22'" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" close-text="Close" />
+              <input type="text" class="form-control" datepicker-popup="{{format}}" ng-model="dt" popup-state="popupState" min-date="minDate" max-date="'2015-06-22'" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" close-text="Close" />
               <span class="input-group-btn">
                 <button type="button" class="btn btn-default" ng-click="open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
               </span>

--- a/src/datepicker/docs/demo.js
+++ b/src/datepicker/docs/demo.js
@@ -1,4 +1,6 @@
 angular.module('ui.bootstrap.demo').controller('DatepickerDemoCtrl', function ($scope) {
+  $scope.popupState = {open: false};
+
   $scope.today = function() {
     $scope.dt = new Date();
   };
@@ -22,7 +24,7 @@ angular.module('ui.bootstrap.demo').controller('DatepickerDemoCtrl', function ($
     $event.preventDefault();
     $event.stopPropagation();
 
-    $scope.opened = true;
+    $scope.popupState.open = true;
   };
 
   $scope.dateOptions = {

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1101,7 +1101,7 @@ describe('datepicker directive', function () {
     describe('initially', function () {
       beforeEach(inject(function(_$document_, _$sniffer_) {
         $document = _$document_;
-        $rootScope.isopen = true;
+        $rootScope.popupState = {open: true};
         $rootScope.date = new Date('September 30, 2010 15:30:00');
         var wrapElement = $compile('<div><input ng-model="date" datepicker-popup><div>')($rootScope);
         $rootScope.$digest();
@@ -1121,9 +1121,9 @@ describe('datepicker directive', function () {
       beforeEach(inject(function(_$document_, _$sniffer_) {
         $document = _$document_;
         $sniffer = _$sniffer_;
-        $rootScope.isopen = true;
+        $rootScope.popupState = {open: true};
         $rootScope.date = new Date('September 30, 2010 15:30:00');
-        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup is-open="isopen"><div>')($rootScope);
+        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup popup-state="popupState"><div>')($rootScope);
         $rootScope.$digest();
         assignElements(wrapElement);
       }));
@@ -1248,13 +1248,13 @@ describe('datepicker directive', function () {
           expect(dropdownEl).toBeHidden();
           expect(document.activeElement.tagName).toBe('INPUT');
         });
-        
+
         it('stops the ESC key from propagating if the dropdown is open, but not when closed', function() {
           expect(dropdownEl).not.toBeHidden();
 
           dropdownEl.find('button').eq(0).focus();
           expect(document.activeElement.tagName).toBe('BUTTON');
-          
+
           var documentKey = -1;
           var getKey = function(evt) { documentKey = evt.which; };
           $document.bind('keydown', getKey);
@@ -1263,10 +1263,10 @@ describe('datepicker directive', function () {
           $rootScope.$digest();
           expect(dropdownEl).toBeHidden();
           expect(documentKey).toBe(-1);
-          
+
           triggerKeyDown(inputEl, 'esc');
           expect(documentKey).toBe(27);
-          
+
           $document.unbind('keydown', getKey);
         });
       });
@@ -1278,7 +1278,8 @@ describe('datepicker directive', function () {
         $rootScope.opts = {
           'show-weeks': false
         };
-        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup datepicker-options="opts" is-open="true"></div>')($rootScope);
+        $rootScope.popupState = {open: true};
+        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup datepicker-options="opts" popup-state="popupState"></div>')($rootScope);
         $rootScope.$digest();
         assignElements(wrapElement);
 
@@ -1295,8 +1296,8 @@ describe('datepicker directive', function () {
 
     describe('toggles programatically by `open` attribute', function () {
       beforeEach(inject(function() {
-        $rootScope.open = true;
-        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup is-open="open"><div>')($rootScope);
+        $rootScope.popupState = {open: true};
+        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup popup-state="popupState"><div>')($rootScope);
         $rootScope.$digest();
         assignElements(wrapElement);
       }));
@@ -1307,11 +1308,11 @@ describe('datepicker directive', function () {
 
       it('to close / open from scope variable', function() {
         expect(dropdownEl.css('display')).not.toBe('none');
-        $rootScope.open = false;
+        $rootScope.popupState = {open: false};
         $rootScope.$digest();
         expect(dropdownEl.css('display')).toBe('none');
 
-        $rootScope.open = true;
+        $rootScope.popupState = {open: true};
         $rootScope.$digest();
         expect(dropdownEl.css('display')).not.toBe('none');
       });
@@ -1388,7 +1389,8 @@ describe('datepicker directive', function () {
     describe('`close-on-date-selection` attribute', function () {
       beforeEach(inject(function() {
         $rootScope.close = false;
-        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup close-on-date-selection="close" is-open="true"><div>')($rootScope);
+        $rootScope.popupState = {open: true};
+        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup close-on-date-selection="close" popup-state="popupState"><div>')($rootScope);
         $rootScope.$digest();
         assignElements(wrapElement);
       }));
@@ -1409,8 +1411,8 @@ describe('datepicker directive', function () {
 
       describe('', function () {
         beforeEach(inject(function() {
-          $rootScope.isopen = true;
-          var wrapElement = $compile('<div><input ng-model="date" datepicker-popup is-open="isopen"><div>')($rootScope);
+          $rootScope.popupState = {open: true};
+          var wrapElement = $compile('<div><input ng-model="date" datepicker-popup popup-state="popupState"><div>')($rootScope);
           $rootScope.$digest();
           assignElements(wrapElement);
           assignButtonBar();

--- a/template/datepicker/popup.html
+++ b/template/datepicker/popup.html
@@ -1,4 +1,4 @@
-<ul class="dropdown-menu" ng-style="{display: (isOpen && 'block') || 'none', top: position.top+'px', left: position.left+'px'}" ng-keydown="keydown($event)">
+<ul class="dropdown-menu" ng-style="{display: (popupState.open && 'block') || 'none', top: position.top+'px', left: position.left+'px'}" ng-keydown="keydown($event)">
 	<li ng-transclude></li>
 	<li ng-if="showButtonBar" style="padding:10px 9px 2px">
 		<span class="btn-group pull-left">


### PR DESCRIPTION
Changed isOpen to and object, now called popupState.  Objects work in 2-way data binding when in a child scope.
Should fix issues with datapicker multiple open/close in ng-if, ng-repeat, etc.

fixes #3180 