### PR TITLE
fix(modal): Modal backdrop does not fade out on close #3182

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -186,6 +186,9 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         //clean up the stack
         openedWindows.remove(modalInstance);
 
+        //start removing the backdrop with the modal
+        checkRemoveBackdrop();
+
         //remove window DOM element
         removeAfterAnimate(modalWindow.modalDomEl, modalWindow.modalScope, 300, function() {
           modalWindow.modalScope.$destroy();


### PR DESCRIPTION
We start removing the backdrop after the modal gets removed which results in backdrop being removed instantly after modal does its closing animation.

