### PR TITLE
fix(modal): backspace with modal dialog should be disabled #3208

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -243,11 +243,18 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.transition'])
         var modal;
 
         if (evt.which === 27) {
+          closeOnKeydown('escape key press');
+        }
+        if (evt.which === 8) {
+          closeOnKeydown('backspace key press');
+        }
+
+        function closeOnKeydown(dismissMessage) {
           modal = openedWindows.top();
           if (modal && modal.value.keyboard) {
             evt.preventDefault();
-            $rootScope.$apply(function () {
-              $modalStack.dismiss(modal.key, 'escape key press');
+            $rootScope.$apply(function() {
+              $modalStack.dismiss(modal.key, dismissMessage);
             });
           }
         }

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -197,6 +197,18 @@ describe('$modal', function () {
       expect($document).toHaveModalsOpen(0);
     });
 
+    it('should support closing on BACKSPACE', function () {
+
+      var modal = open({template: '<div>Content</div>'});
+      expect($document).toHaveModalsOpen(1);
+
+      triggerKeyDown($document, 8);
+      $timeout.flush();
+      $rootScope.$digest();
+
+      expect($document).toHaveModalsOpen(0);
+    });
+
     it('should support closing on backdrop click', function () {
 
       var modal = open({template: '<div>Content</div>'});


### PR DESCRIPTION
Fixes #3208 

When the option "keyboard" is set to true (default), both ESC and BACKSPACE close the modal window.