### PR TITLE
fix(datepicker): time zone bug

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -134,7 +134,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   // console.log(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours());
   // can result in "2013 11 31 23" because of the bug.
   this.fixTimeZone = function(date) {
-    date.setHours(date.getHours() === 23 ? date.getHours() + 2 : 0);
+    var hours = date.getHours();
+    date.setHours(hours === 23 ? hours + 2 : 0);
   };
 
   $scope.select = function( date ) {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -127,6 +127,16 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     return arrays;
   };
 
+  // Fix a hard-reprodusible bug with timezones
+  // The bug depends on OS, browser, current timezone and current date
+  // i.e.
+  // var date = new Date(2014, 0, 1);
+  // console.log(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours());
+  // can result in "2013 11 31 23" because of the bug.
+  this.fixTimeZone = function(date) {
+    date.setHours(date.getHours() > 12 ? date.getHours() + 2 : 0);
+  };
+
   $scope.select = function( date ) {
     if ( $scope.datepickerMode === self.minMode ) {
       var dt = ngModelCtrl.$viewValue ? new Date( ngModelCtrl.$viewValue ) : new Date(0, 0, 0, 0, 0, 0, 0);
@@ -237,10 +247,11 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       }
 
       function getDates(startDate, n) {
-        var dates = new Array(n), current = new Date(startDate), i = 0;
-        current.setHours(12); // Prevent repeated dates because of timezone bug
+        var dates = new Array(n), current = new Date(startDate), i = 0, date;
         while ( i < n ) {
-          dates[i++] = new Date(current);
+          date = new Date(current);
+          ctrl.fixTimeZone(date);
+          dates[i++] = date;
           current.setDate( current.getDate() + 1 );
         }
         return dates;
@@ -339,10 +350,13 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
       ctrl._refreshView = function() {
         var months = new Array(12),
-            year = ctrl.activeDate.getFullYear();
+            year = ctrl.activeDate.getFullYear(),
+            date;
 
         for ( var i = 0; i < 12; i++ ) {
-          months[i] = angular.extend(ctrl.createDateObject(new Date(year, i, 1), ctrl.formatMonth), {
+          date = new Date(year, i, 1);
+          ctrl.fixTimeZone(date);
+          months[i] = angular.extend(ctrl.createDateObject(date, ctrl.formatMonth), {
             uid: scope.uniqueId + '-' + i
           });
         }
@@ -399,10 +413,12 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       }
 
       ctrl._refreshView = function() {
-        var years = new Array(range);
+        var years = new Array(range), date;
 
         for ( var i = 0, start = getStartingYear(ctrl.activeDate.getFullYear()); i < range; i++ ) {
-          years[i] = angular.extend(ctrl.createDateObject(new Date(start + i, 0, 1), ctrl.formatYear), {
+          date = new Date(start + i, 0, 1);
+          ctrl.fixTimeZone(date);
+          years[i] = angular.extend(ctrl.createDateObject(date, ctrl.formatYear), {
             uid: scope.uniqueId + '-' + i
           });
         }

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -134,7 +134,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   // console.log(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours());
   // can result in "2013 11 31 23" because of the bug.
   this.fixTimeZone = function(date) {
-    date.setHours(date.getHours() > 12 ? date.getHours() + 2 : 0);
+    date.setHours(date.getHours() === 23 ? date.getHours() + 2 : 0);
   };
 
   $scope.select = function( date ) {

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -271,6 +271,33 @@ describe('datepicker directive', function () {
       expect(getTitle()).toBe('January 2014');
     });
 
+    // issue #3079
+    describe('time zone bug', function () {
+
+      it('should deal with time zone bug', function() {
+        var ctrl = element.controller('datepicker'),
+            date = new Date('January 1, 2014');
+        spyOn(date, 'getHours').andReturn(23);
+        spyOn(date, 'setHours').andReturn();
+
+        ctrl.fixTimeZone(date);
+
+        expect(date.setHours).toHaveBeenCalledWith(25);
+      });
+
+      it('should not change hours if time zone bug does not occur', function() {
+        var ctrl = element.controller('datepicker'),
+            date = new Date('January 1, 2014');
+        spyOn(date, 'getHours').andReturn(0);
+        spyOn(date, 'setHours').andReturn();
+
+        ctrl.fixTimeZone(date);
+
+        expect(date.setHours).toHaveBeenCalledWith(0);
+      });
+
+    });
+
     describe('when `model` changes', function () {
       function testCalendar() {
         expect(getTitle()).toBe('November 2005');


### PR DESCRIPTION
This bug is quite difficult to reproduce because it depends on OS, OS updates, browser, current timezone and even current date.
As I understand, it's connected with daylight savings.
The bug was discussed here: #1098.
The problem with repeated days seems to be fixed here: 7f4b40eb8bc57f03bd306330a6ad227790c33f27 (line 145) . But the problem with repeated months and years still exists.

Some screenshots:
1. OS: Windows 7; current day: December 10, 2014; current time zone: +6 GMT; browser: Firefox 36.0.4
*Wrong January:*
![winmonth](https://cloud.githubusercontent.com/assets/10140049/6815338/578f9534-d2aa-11e4-8349-fea255f0dfdc.png)
*Wrong 2014:*
![winyear](https://cloud.githubusercontent.com/assets/10140049/6815341/5c45d2b4-d2aa-11e4-970b-ac1af4279891.png)
2. OS: Debian Jessie / Ubuntu 14.04; current day: December 10, 2014 / March 24, 2015; current time zone: +3 GMT / +6 GMT; browser: Firefox 31.5.0, 33.0, 34.0.
*Wrong April:*
![linuxmonth](https://cloud.githubusercontent.com/assets/10140049/6815386/e1836392-d2aa-11e4-8619-d898858edc23.png)

You can see the reason of the bug in this piece of code:
```javascript
var date = new Date(2014, 0, 1);
console.log(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours());
```
The expected result is *"2014 0 1 0"*, but in some cases it will be *"2013 11 31 23"*.

One more example. I printed the dates which is used to display months in monthpicker:
```javascript
// February: correct
{
	"date":"Date {Wed Feb 01 1984 00:00:00 GMT+0600 (OMST)}",
	"label":"February",
        . . .
}
// March: correct
{
	"date":"Date {Thu Mar 01 1984 00:00:00 GMT+0600 (OMST)}",
	"label":"March",
        . . .
}
// April: error, 1 hour is missing
{
	"date":"Date {Sat Mar 31 1984 23:00:00 GMT+0600 (OMST)}",
	"label":"March",
        . . .
}
// May: correct
{
	"date":"Date {Tue May 01 1984 00:00:00 GMT+0700 (OMSST)}",
	"label":"May",
        . . .
}
```

Discussions of this bug can be found on the Internet. Some of them:
http://stackoverflow.com/questions/5859959/dst-problem-storing-date-in-javascript-date-object
https://code.google.com/p/chromium/issues/detail?id=417640

I've implemented a possible workaround. We should determine whether a date is created with the bug. If the bug arises then we just add 2 hours to the date (adding one hour has no effect in this case). It should guarantee the correct handling of all the bug cases.

Fixes #3079