### PR TITLE
fix(timepicker): remove ng-mousewheel binding

### DIFF
--- a/template/timepicker/timepicker.html
+++ b/template/timepicker/timepicker.html
@@ -8,7 +8,7 @@
 		</tr>
 		<tr>
 			<td class="form-group" ng-class="{'has-error': invalidHours}">
-				<input style="width:50px;" type="text" ng-model="hours" ng-change="updateHours()" class="form-control text-center" ng-mousewheel="incrementHours()" ng-readonly="readonlyInput" maxlength="2">
+				<input style="width:50px;" type="text" ng-model="hours" ng-change="updateHours()" class="form-control text-center" ng-readonly="readonlyInput" maxlength="2">
 			</td>
 			<td>:</td>
 			<td class="form-group" ng-class="{'has-error': invalidMinutes}">


### PR DESCRIPTION
The timepicker template has an ng-mousewheel
binding on the hours input element and the
TimepickerController also binds the elemeent
to mouse wheel events.  Removed ng-mousewheel
binding from the template.