### PR TITLE
feat(typeahead): implement 'select on blur' option.

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -364,6 +364,32 @@ describe('typeahead tests', function () {
       expect(element).toBeClosed();
     });
 
+    it('should not select any match on blur without \'select-on-blur=true\' option', function () {
+
+      var element = prepareInputEl('<div><input ng-model="result" typeahead="item for item in source | filter:$viewValue"></div>');
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'b');
+      inputEl.blur(); // input loses focus
+
+      // no change
+      expect($scope.result).toEqual('b');
+      expect(inputEl.val()).toEqual('b');
+    });
+
+    it('should select a match on blur with \'select-on-blur=true\' option', function () {
+
+      var element = prepareInputEl('<div><input ng-model="result" typeahead="item for item in source | filter:$viewValue" typeahead-select-on-blur="true"></div>');
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'b');
+      inputEl.blur(); // input loses focus
+
+      // first element should be selected
+      expect($scope.result).toEqual('bar');
+      expect(inputEl.val()).toEqual('bar');
+    });
+
     it('should select match on click', function () {
 
       var element = prepareInputEl('<div><input ng-model="result" typeahead="item for item in source | filter:$viewValue"></div>');

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -56,7 +56,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       var onSelectCallback = $parse(attrs.typeaheadOnSelect);
 
       //should it select highlighted popup value when losing focus?
-      var isSelectOnBlur = angular.isDefined($attrs.typeaheadSelectOnBlur) ? originalScope.$eval(attrs.typeaheadSelectOnBlur) : false;
+      var isSelectOnBlur = angular.isDefined(attrs.typeaheadSelectOnBlur) ? originalScope.$eval(attrs.typeaheadSelectOnBlur) : false;
 
       var inputFormatter = attrs.typeaheadInputFormatter ? $parse(attrs.typeaheadInputFormatter) : undefined;
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -56,7 +56,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       var onSelectCallback = $parse(attrs.typeaheadOnSelect);
 
       //should it select highlighted popup value when losing focus?
-      var isSelectOnBlur = originalScope.$eval(attrs.typeaheadSelectOnBlur) == true;
+      var isSelectOnBlur = angular.isDefined($attrs.typeaheadSelectOnBlur) ? originalScope.$eval(attrs.typeaheadSelectOnBlur) : false;
 
       var inputFormatter = attrs.typeaheadInputFormatter ? $parse(attrs.typeaheadInputFormatter) : undefined;
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -55,6 +55,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //a callback executed when a match is selected
       var onSelectCallback = $parse(attrs.typeaheadOnSelect);
 
+      //should it select highlighted popup value when losing focus?
+      var isSelectOnBlur = originalScope.$eval(attrs.typeaheadSelectOnBlur) == true;
+
       var inputFormatter = attrs.typeaheadInputFormatter ? $parse(attrs.typeaheadInputFormatter) : undefined;
 
       var appendToBody =  attrs.typeaheadAppendToBody ? originalScope.$eval(attrs.typeaheadAppendToBody) : false;
@@ -311,6 +314,11 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       });
 
       element.bind('blur', function (evt) {
+        if (isSelectOnBlur && scope.activeIdx >= 0) {
+          scope.$apply(function () {
+            scope.select(scope.activeIdx);
+          });
+        }
         hasFocus = false;
       });
 


### PR DESCRIPTION
This PR adds an option 'select on blur' on typeahead. When enabled, this option selects the current highlighted value (in popup list) when the widget is losing focus. In short : clicking outside the widget is identical to hitting the 'tab' key.

By default, this option is disabled.