### PR TITLE
fix(modal): fix closing modal with click backdrop in ie8

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -93,7 +93,7 @@ angular.module('ui.bootstrap.modal', [])
 
         scope.close = function (evt) {
           var modal = $modalStack.getTop();
-          if (modal && modal.value.backdrop && modal.value.backdrop != 'static' && (evt.target === evt.currentTarget)) {
+          if (modal && modal.value.backdrop && modal.value.backdrop != 'static' && (evt.target === element[0])) {
             evt.preventDefault();
             evt.stopPropagation();
             $modalStack.dismiss(modal.key, 'backdrop click');


### PR DESCRIPTION
Closing modal directive by clicking on backdrop doesn't work in IE8, since it uses `event.currentTarget` which IE8 doesn't support.

I know that this project does not officially support IE8, but my project consumes this directive and needs to support IE8. 