### PR TITLE
feat(datepicker): Allow specifying next and previous button icon classes

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -15,7 +15,9 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   yearRange: 20,
   minDate: null,
   maxDate: null,
-  shortcutPropagation: false
+  shortcutPropagation: false,
+  nextIconClass: 'glyphicon glyphicon-chevron-right',
+  prevIconClass: 'glyphicon glyphicon-chevron-left'
 })
 
 .controller('DatepickerController', ['$scope', '$attrs', '$parse', '$interpolate', '$timeout', '$log', 'dateFilter', 'datepickerConfig', function($scope, $attrs, $parse, $interpolate, $timeout, $log, dateFilter, datepickerConfig) {
@@ -58,6 +60,9 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   } else {
     this.activeDate =  new Date();
   }
+
+  $scope.nextIconClass = $scope.nextIconClass || datepickerConfig.nextIconClass;
+  $scope.prevIconClass = $scope.prevIconClass || datepickerConfig.prevIconClass;
 
   $scope.isActive = function(dateObject) {
     if (self.compare(dateObject.date, self.activeDate) === 0) {

--- a/src/datepicker/docs/readme.md
+++ b/src/datepicker/docs/readme.md
@@ -85,6 +85,14 @@ All settings can be provided as attributes in the `datepicker` or globally confi
     _(Default: false)_ :
     An option to disable or enable shortcut's event propagation.
 
+ * `prev-icon-class`
+ 	_(Default: 'glyphicon glyphicon-chevron-left')
+ 	Icon to use for 'previous' button.
+
+ * `next-icon-class`
+ 	_(Default: 'glyphicon glyphicon-chevron-right')
+ 	Icon to use for 'next' button.
+
 
 ### Popup Settings ###
 

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1818,8 +1818,10 @@ describe('datepicker directive', function () {
   });
 
   describe('with empty initial state', function () {
-    beforeEach(inject(function() {
+    beforeEach(inject(function(datepickerConfig) {
       $rootScope.date = null;
+      $rootScope.nextIconClass = datepickerConfig.nextIconClass;
+      $rootScope.prevIconClass = datepickerConfig.prevIconClass;
       element = $compile('<datepicker ng-model="date"></datepicker>')($rootScope);
       $rootScope.$digest();
     }));
@@ -1830,6 +1832,17 @@ describe('datepicker directive', function () {
 
     it('is shows rows with days', function() {
       expect(element.find('tbody').find('tr').length).toBeGreaterThan(3);
+    });
+
+    it('has next and previous icons', function () {
+
+      expect($rootScope.nextIconClass).toEqual('glyphicon glyphicon-chevron-right');
+      expect($rootScope.prevIconClass).toEqual('glyphicon glyphicon-chevron-left');
+
+      var nextIconClassSelector = $rootScope.nextIconClass.split(' ').map(function (c) { return '.' + c; }).join('');
+      var prevIconClassSelector = $rootScope.prevIconClass.split(' ').map(function (c) { return '.' + c; }).join('');
+      expect(element.find('thead').find(nextIconClassSelector).length).toBe(1);
+      expect(element.find('thead').find(prevIconClassSelector).length).toBe(1);
     });
 
     it('sets default 00:00:00 time for selected date', function() {

--- a/template/datepicker/day.html
+++ b/template/datepicker/day.html
@@ -1,9 +1,9 @@
 <table role="grid" aria-labelledby="{{uniqueId}}-title" aria-activedescendant="{{activeDateId}}">
   <thead>
     <tr>
-      <th><button type="button" class="btn btn-default btn-sm pull-left" ng-click="move(-1)" tabindex="-1"><i class="glyphicon glyphicon-chevron-left"></i></button></th>
+      <th><button type="button" class="btn btn-default btn-sm pull-left" ng-click="move(-1)" tabindex="-1"><i ng-class="prevIconClass"></i></button></th>
       <th colspan="{{5 + showWeeks}}"><button id="{{uniqueId}}-title" role="heading" aria-live="assertive" aria-atomic="true" type="button" class="btn btn-default btn-sm" ng-click="toggleMode()" ng-disabled="datepickerMode === maxMode" tabindex="-1" style="width:100%;"><strong>{{title}}</strong></button></th>
-      <th><button type="button" class="btn btn-default btn-sm pull-right" ng-click="move(1)" tabindex="-1"><i class="glyphicon glyphicon-chevron-right"></i></button></th>
+      <th><button type="button" class="btn btn-default btn-sm pull-right" ng-click="move(1)" tabindex="-1"><i ng-class="nextIconClass"></i></button></th>
     </tr>
     <tr>
       <th ng-show="showWeeks" class="text-center"></th>

--- a/template/datepicker/month.html
+++ b/template/datepicker/month.html
@@ -1,9 +1,9 @@
 <table role="grid" aria-labelledby="{{uniqueId}}-title" aria-activedescendant="{{activeDateId}}">
   <thead>
     <tr>
-      <th><button type="button" class="btn btn-default btn-sm pull-left" ng-click="move(-1)" tabindex="-1"><i class="glyphicon glyphicon-chevron-left"></i></button></th>
+      <th><button type="button" class="btn btn-default btn-sm pull-left" ng-click="move(-1)" tabindex="-1"><i ng-class="prevIconClass"></i></button></th>
       <th><button id="{{uniqueId}}-title" role="heading" aria-live="assertive" aria-atomic="true" type="button" class="btn btn-default btn-sm" ng-click="toggleMode()" ng-disabled="datepickerMode === maxMode" tabindex="-1" style="width:100%;"><strong>{{title}}</strong></button></th>
-      <th><button type="button" class="btn btn-default btn-sm pull-right" ng-click="move(1)" tabindex="-1"><i class="glyphicon glyphicon-chevron-right"></i></button></th>
+      <th><button type="button" class="btn btn-default btn-sm pull-right" ng-click="move(1)" tabindex="-1"><i ng-class="nextIconClass"></i></button></th>
     </tr>
   </thead>
   <tbody>

--- a/template/datepicker/year.html
+++ b/template/datepicker/year.html
@@ -1,9 +1,9 @@
 <table role="grid" aria-labelledby="{{uniqueId}}-title" aria-activedescendant="{{activeDateId}}">
   <thead>
     <tr>
-      <th><button type="button" class="btn btn-default btn-sm pull-left" ng-click="move(-1)" tabindex="-1"><i class="glyphicon glyphicon-chevron-left"></i></button></th>
+      <th><button type="button" class="btn btn-default btn-sm pull-left" ng-click="move(-1)" tabindex="-1"><i ng-class="prevIconClass"></i></button></th>
       <th colspan="3"><button id="{{uniqueId}}-title" role="heading" aria-live="assertive" aria-atomic="true" type="button" class="btn btn-default btn-sm" ng-click="toggleMode()" ng-disabled="datepickerMode === maxMode" tabindex="-1" style="width:100%;"><strong>{{title}}</strong></button></th>
-      <th><button type="button" class="btn btn-default btn-sm pull-right" ng-click="move(1)" tabindex="-1"><i class="glyphicon glyphicon-chevron-right"></i></button></th>
+      <th><button type="button" class="btn btn-default btn-sm pull-right" ng-click="move(1)" tabindex="-1"><i ng-class="nextIconClass"></i></button></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
I'm a fan of Font-Awesome over Glyphicons, so I use Font-Awesome everywhere else in one of the apps I work on but found it detrimental to the user (many of whom are mobile) to download an extra set of icons and CSS when they'd only be used in a few components (datepicker and timepicker).

I'm wondering if this is a feature that would be interesting to anyone else. I realize I could do the same thing by providing different templates, but I'd prefer not to have to maintain a seperate set of datepicker templates for a simple class difference.

*Note: I've got a similar patch lined up for Timepicker too, but I wanted to get feedback on this implementation first and clean it up as needed, then redo the timepicker patch similarly.*