### PR TITLE
fix(popover): prevent wrong positioning from title

### DIFF
--- a/template/popover/popover-template.html
+++ b/template/popover/popover-template.html
@@ -5,7 +5,7 @@
   <div class="arrow"></div>
 
   <div class="popover-inner">
-      <h3 class="popover-title" ng-bind="title" ng-show="title"></h3>
+      <h3 class="popover-title" ng-bind="title" ng-if="title"></h3>
       <div class="popover-content"
         tooltip-template-transclude="content"
         tooltip-template-transclude-scope="originScope()"></div>

--- a/template/popover/popover.html
+++ b/template/popover/popover.html
@@ -5,7 +5,7 @@
   <div class="arrow"></div>
 
   <div class="popover-inner">
-      <h3 class="popover-title" ng-bind="title" ng-show="title"></h3>
+      <h3 class="popover-title" ng-bind="title" ng-if="title"></h3>
       <div class="popover-content" ng-bind="content"></div>
   </div>
 </div>


### PR DESCRIPTION
If the title is blank, ngAnimate attempts to animate ngShow so positionTooltip
gets called when the title box is still visible, about to be animated to
hidden. Hence, the positionTooltip receives a taller height. Avoid this by
using ngIf instead.

Unfortunately, I can't find a good way to test this.