### PR TITLE
Add wrap option to carousel

### DIFF
--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -25,7 +25,7 @@ angular.module('ui.bootstrap.carousel', [])
     var nextIndex = self.indexOfSlide(nextSlide);
     //Decide direction if it's not given
     if (direction === undefined) {
-      direction = nextIndex > $scope.getCurrentIndex() ? 'next' : 'prev';
+      direction = nextIndex > self.getCurrentIndex() ? 'next' : 'prev';
     }
     if (nextSlide && nextSlide !== self.currentSlide) {
       goNext();
@@ -67,7 +67,7 @@ angular.module('ui.bootstrap.carousel', [])
     }
   }
 
-  $scope.getCurrentIndex = function() {
+  self.getCurrentIndex = function() {
     if (self.currentSlide && angular.isDefined(self.currentSlide.index)) {
       return +self.currentSlide.index;
     }
@@ -85,7 +85,7 @@ angular.module('ui.bootstrap.carousel', [])
         $scope.nextActive = true;
         return;
       }
-      else if ($scope.getCurrentIndex() + 1 < slides.length)
+      else if (self.getCurrentIndex() + 1 < slides.length)
       {
         $scope.nextActive = true;
         return;
@@ -106,7 +106,7 @@ angular.module('ui.bootstrap.carousel', [])
         $scope.prevActive = true;
         return;
       }
-      else if ($scope.getCurrentIndex() - 1 >= 0)
+      else if (self.getCurrentIndex() - 1 >= 0)
       {
         $scope.prevActive = true;
         return;
@@ -130,7 +130,7 @@ angular.module('ui.bootstrap.carousel', [])
     // if wrap is not active stops the next action     
     if ($scope.nextActive)
     {
-      var newIndex = ($scope.getCurrentIndex() + 1) % slides.length;
+      var newIndex = (self.getCurrentIndex() + 1) % slides.length;
 
       //Prevent this user-triggered transition from occurring if there is already one in progress
       if (!$scope.$currentTransition) {
@@ -143,7 +143,7 @@ angular.module('ui.bootstrap.carousel', [])
     // if wrap is not active stops the next action     
     if ($scope.prevActive)
     {
-      var newIndex = $scope.getCurrentIndex() - 1 < 0 ? slides.length - 1 : $scope.getCurrentIndex() - 1;
+      var newIndex = self.getCurrentIndex() - 1 < 0 ? slides.length - 1 : self.getCurrentIndex() - 1;
 
       //Prevent this user-triggered transition from occurring if there is already one in progress
       if (!$scope.$currentTransition) {
@@ -155,6 +155,13 @@ angular.module('ui.bootstrap.carousel', [])
   $scope.isActive = function(slide) {
      return self.currentSlide === slide;
   };
+
+  $scope.$watch('wrap', updateWrapStatus);
+
+  function updateWrapStatus() {
+    $scope.wrapValue = angular.isUndefined($scope.wrap)?true:$scope.wrap;  
+    self.updateCarouselControls();    
+  }
 
   $scope.$watch('interval', restartTimer);
   $scope.$on('$destroy', resetTimer);

--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -252,7 +252,7 @@ angular.module('ui.bootstrap.carousel', [])
  * @param {number=} interval The time, in milliseconds, that it will take the carousel to go to the next slide.
  * @param {boolean=} noTransition Whether to disable transitions on the carousel.
  * @param {boolean=} noPause Whether to disable pausing on the carousel (by default, the carousel interval pauses on hover).
- * €param {boolean=} wrap Whether the carousel should cycle continuously or have hard stops
+ * @param {boolean=} wrap Whether the carousel should cycle continuously or have hard stops
  *
  * @example
 <example module="ui.bootstrap">

--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -13,9 +13,9 @@ angular.module('ui.bootstrap.carousel', [])
     currentIndex = -1,
     currentInterval, isPlaying;
   self.currentSlide = null;
-
+  
   // setting wrap as false if undefined
-  $scope.wrap = angular.isUndefined($scope.wrap)?true:$scope.wrap;
+  $scope.wrapValue = angular.isUndefined($scope.wrap)?true:$scope.wrap;  
   $scope.nextActive = true;
   $scope.prevActive = true;
 
@@ -29,8 +29,9 @@ angular.module('ui.bootstrap.carousel', [])
     }
     if (nextSlide && nextSlide !== self.currentSlide) {
       goNext();
+      self.updateCarouselControls();
     }
-    self.updateCarouselControls();
+    
     function goNext() {
       // Scope has been destroyed, stop here.
       if (destroyed) { return; }
@@ -79,12 +80,12 @@ angular.module('ui.bootstrap.carousel', [])
     // otherwise -> false    
     if (slides.length !== 0)
     {
-      if ($scope.wrap)
+      if ($scope.wrapValue)
       {
         $scope.nextActive = true;
         return;
       }
-      else if (!$scope.wrap && ($scope.getCurrentIndex() + 1 < slides.length))
+      else if ($scope.getCurrentIndex() + 1 < slides.length)
       {
         $scope.nextActive = true;
         return;
@@ -100,12 +101,12 @@ angular.module('ui.bootstrap.carousel', [])
     // otherwise -> false
     if (slides.length !== 0)
     {
-      if ($scope.wrap)
+      if ($scope.wrapValue)
       {
         $scope.prevActive = true;
         return;
       }
-      else if (!$scope.wrap && ($scope.getCurrentIndex() - 1 >= 0))
+      else if ($scope.getCurrentIndex() - 1 >= 0)
       {
         $scope.prevActive = true;
         return;
@@ -126,8 +127,7 @@ angular.module('ui.bootstrap.carousel', [])
   };
 
   $scope.next = function() {
-    // if wrap is not active stops the next action 
-    
+    // if wrap is not active stops the next action     
     if ($scope.nextActive)
     {
       var newIndex = ($scope.getCurrentIndex() + 1) % slides.length;

--- a/src/carousel/docs/README.md
+++ b/src/carousel/docs/README.md
@@ -3,3 +3,5 @@ Carousel creates a carousel similar to bootstrap's image carousel.
 The carousel also offers support for touchscreen devices in the form of swiping. To enable swiping, load the `ngTouch` module as a dependency.
 
 Use a `<carousel>` element with `<slide>` elements inside it.  It will automatically cycle through the slides at a given rate, and a current-index variable will be kept in sync with the currently visible slide.
+
+Use the attribute `wrap` set to `false` (the default value is true) to had hard stops to the carousel. 

--- a/src/carousel/docs/demo.html
+++ b/src/carousel/docs/demo.html
@@ -1,6 +1,6 @@
 <div ng-controller="CarouselDemoCtrl">
   <div style="height: 305px">
-    <carousel interval="myInterval">
+    <carousel interval="myInterval" wrap="myWrap">
       <slide ng-repeat="slide in slides" active="slide.active">
         <img ng-src="{{slide.image}}" style="margin:auto;">
         <div class="carousel-caption">
@@ -17,6 +17,13 @@
     <div class="col-md-6">
       Interval, in milliseconds: <input type="number" class="form-control" ng-model="myInterval">
       <br />Enter a negative number or 0 to stop the interval.
+    </div>  
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <label class="checkbox">
+        Wrap (cycle continuously) <input type="checkbox" ng-model="myWrap">
+      </label>
     </div>
   </div>
 </div>

--- a/src/carousel/docs/demo.js
+++ b/src/carousel/docs/demo.js
@@ -1,5 +1,6 @@
 angular.module('ui.bootstrap.demo').controller('CarouselDemoCtrl', function ($scope) {
   $scope.myInterval = 5000;
+  $scope.myWrap = true;
   var slides = $scope.slides = [];
   $scope.addSlide = function() {
     var newWidth = 600 + slides.length + 1;

--- a/src/carousel/test/carousel.spec.js
+++ b/src/carousel/test/carousel.spec.js
@@ -32,7 +32,7 @@ describe('carousel', function() {
         {active:false,content:'three'}
       ];
       elm = $compile(
-        '<carousel interval="interval" no-transition="true" no-pause="nopause">' +
+        '<carousel interval="interval" no-transition="true" no-pause="nopause" wrap="true">' +
           '<slide ng-repeat="slide in slides" active="slide.active">' +
             '{{slide.content}}' +
           '</slide>' +
@@ -77,7 +77,7 @@ describe('carousel', function() {
       scope.slides=[{active:false,content:'one'}];
       scope.$apply();
       elm = $compile(
-          '<carousel interval="interval" no-transition="true">' +
+          '<carousel interval="interval" no-transition="true" wrap="true">' +
             '<slide ng-repeat="slide in slides" active="slide.active">' +
               '{{slide.content}}' +
             '</slide>' +
@@ -276,7 +276,7 @@ describe('carousel', function() {
           {active:false,content:'three', id:3}
         ];
         elm = $compile(
-          '<carousel interval="interval" no-transition="true" no-pause="nopause">' +
+          '<carousel interval="interval" no-transition="true" no-pause="nopause" wrap="true">' +
             '<slide ng-repeat="slide in slides | orderBy: \'id\' " active="slide.active" index="$index">' +
               '{{slide.content}}' +
             '</slide>' +

--- a/src/carousel/test/carousel.spec.js
+++ b/src/carousel/test/carousel.spec.js
@@ -254,7 +254,7 @@ describe('carousel', function() {
       testSlideActive(1);
     });
 
-    it('should stop navigation when wrap false', function () {
+    it('should stop navigation when wrap is false', function () {
       scope.slides = [
         {active:false,content:'one'},
         {active:false,content:'two'},
@@ -283,7 +283,7 @@ describe('carousel', function() {
       testSlideActive(2);
     });    
 
-    it('should hide navigation when wrap false', function () {
+    it('should hide navigation when wrap is false', function () {
       scope.slides = [
         {active:false,content:'one'},
         {active:false,content:'two'},

--- a/src/carousel/test/carousel.spec.js
+++ b/src/carousel/test/carousel.spec.js
@@ -32,7 +32,7 @@ describe('carousel', function() {
         {active:false,content:'three'}
       ];
       elm = $compile(
-        '<carousel interval="interval" no-transition="true" no-pause="nopause" wrap="true">' +
+        '<carousel interval="interval" no-transition="true" no-pause="nopause">' +
           '<slide ng-repeat="slide in slides" active="slide.active">' +
             '{{slide.content}}' +
           '</slide>' +
@@ -77,7 +77,7 @@ describe('carousel', function() {
       scope.slides=[{active:false,content:'one'}];
       scope.$apply();
       elm = $compile(
-          '<carousel interval="interval" no-transition="true" wrap="true">' +
+          '<carousel interval="interval" no-transition="true">' +
             '<slide ng-repeat="slide in slides" active="slide.active">' +
               '{{slide.content}}' +
             '</slide>' +
@@ -254,6 +254,68 @@ describe('carousel', function() {
       testSlideActive(1);
     });
 
+    it('should stop navigation when wrap false', function () {
+      scope.slides = [
+        {active:false,content:'one'},
+        {active:false,content:'two'},
+        {active:false,content:'three'}
+      ];
+      elm = $compile(
+        '<carousel interval="interval" wrap="false">' +
+          '<slide ng-repeat="slide in slides" active="slide.active">' +
+            '{{slide.content}}' +
+          '</slide>' +
+        '</carousel>'
+      )(scope);
+      scope.$apply();
+
+      var navPrev = elm.find('a.left');
+      var navNext = elm.find('a.right');
+
+      testSlideActive(0);
+      navPrev.click();
+      testSlideActive(0);
+      navNext.click();
+      testSlideActive(1);
+      navNext.click();
+      testSlideActive(2);
+      navNext.click();
+      testSlideActive(2);
+    });    
+
+    it('should hide navigation when wrap false', function () {
+      scope.slides = [
+        {active:false,content:'one'},
+        {active:false,content:'two'},
+        {active:false,content:'three'}
+      ];
+      elm = $compile(
+        '<carousel interval="interval" wrap="false">' +
+          '<slide ng-repeat="slide in slides" active="slide.active">' +
+            '{{slide.content}}' +
+          '</slide>' +
+        '</carousel>'
+      )(scope);
+      scope.$apply();
+
+      var navPrev = elm.find('a.left');
+      var navNext = elm.find('a.right');
+
+      testSlideActive(0);
+      expect(navPrev.hasClass('ng-hide')).toBe(true);
+      expect(navNext.hasClass('ng-hide')).toBe(false);
+      navNext.click();
+      expect(navPrev.hasClass('ng-hide')).toBe(false);
+      expect(navNext.hasClass('ng-hide')).toBe(false);      
+      testSlideActive(1);
+      expect(navPrev.hasClass('ng-hide')).toBe(false);
+      expect(navNext.hasClass('ng-hide')).toBe(false);            
+      navNext.click();
+      testSlideActive(2);
+      expect(navPrev.hasClass('ng-hide')).toBe(false);
+      expect(navNext.hasClass('ng-hide')).toBe(true); 
+    });     
+
     it('issue 1414 - should not continue running timers after scope is destroyed', function() {
       testSlideActive(0);
       $interval.flush(scope.interval);
@@ -276,7 +338,7 @@ describe('carousel', function() {
           {active:false,content:'three', id:3}
         ];
         elm = $compile(
-          '<carousel interval="interval" no-transition="true" no-pause="nopause" wrap="true">' +
+          '<carousel interval="interval" no-transition="true" no-pause="nopause">' +
             '<slide ng-repeat="slide in slides | orderBy: \'id\' " active="slide.active" index="$index">' +
               '{{slide.content}}' +
             '</slide>' +

--- a/template/carousel/carousel.html
+++ b/template/carousel/carousel.html
@@ -3,6 +3,6 @@
         <li ng-repeat="slide in slides | orderBy:'index' track by $index" ng-class="{active: isActive(slide)}" ng-click="select(slide)"></li>
     </ol>
     <div class="carousel-inner" ng-transclude></div>
-    <a class="left carousel-control" ng-click="prev()" ng-show="slides.length > 1"><span class="glyphicon glyphicon-chevron-left"></span></a>
-    <a class="right carousel-control" ng-click="next()" ng-show="slides.length > 1"><span class="glyphicon glyphicon-chevron-right"></span></a>
+    <a class="left carousel-control" ng-click="prev()" ng-show="prevActive && slides.length > 0"><span class="glyphicon glyphicon-chevron-left"></span></a>
+    <a class="right carousel-control" ng-click="next()" ng-show="nextActive && slides.length > 0"><span class="glyphicon glyphicon-chevron-right"></span></a>
 </div>


### PR DESCRIPTION
Sometimes applications require carousels that does not cycle continuously (having hard stops). This use case is already supported by the javascript [Bootstrap](http://getbootstrap.com/javascript/#carousel) library and is controlled using the wrap attribute. I implemented this feature in our carousel using plain angular.js by adding support for the wrap attribute in the carousel directive as in the following example:

```html
    <carousel interval="myInterval" wrap="myWrap">
      <slide ng-repeat="slide in slides" active="slide.active">
        <img ng-src="{{slide.image}}" style="margin:auto;">
        <div class="carousel-caption">
          <h4>Slide {{$index}}</h4>
          <p>{{slide.text}}</p>
        </div>
      </slide>
    </carousel>
```

I've updated the tests, documentation and demo. The following images exemplify the final result with wrap="false" for the first, middle and last slides of a carousel.

![first](https://cloud.githubusercontent.com/assets/1120442/7103313/dd969c80-e098-11e4-8e65-9c60eb8b99da.png)
![middle](https://cloud.githubusercontent.com/assets/1120442/7103315/dd9c7cc2-e098-11e4-8018-9b1746702ed8.png)
![last](https://cloud.githubusercontent.com/assets/1120442/7103314/dd99f22c-e098-11e4-8935-2155e934d8e4.png)