### PR TITLE
fix(dropdown): update unit tests

### DIFF
--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -1,12 +1,13 @@
 describe('dropdownToggle', function() {
-  var $compile, $rootScope, $document, element;
+  var $compile, $rootScope, $document, dropdownConfig, element;
 
   beforeEach(module('ui.bootstrap.dropdown'));
 
-  beforeEach(inject(function(_$compile_, _$rootScope_, _$document_) {
+  beforeEach(inject(function(_$compile_, _$rootScope_, _$document_, _dropdownConfig_) {
     $compile = _$compile_;
     $rootScope = _$rootScope_;
     $document = _$document_;
+    dropdownConfig = _dropdownConfig_;
   }));
 
   afterEach(function() {
@@ -38,78 +39,78 @@ describe('dropdownToggle', function() {
     });
 
     it('should toggle on `a` click', function() {
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('should toggle when an option is clicked', function() {
       $document.find('body').append(element);
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
 
       var optionEl = element.find('ul > li').eq(0).find('a').eq(0);
       optionEl.click();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('should close on document click', function() {
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       $document.click();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('should close on escape key & focus toggle element', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
       triggerKeyDown($document, 27);
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
       expect(isFocused(element.find('a'))).toBe(true);
     });
 
     it('should not close on backspace key', function() {
       clickDropdownToggle();
       triggerKeyDown($document, 8);
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
     });
 
     it('should close on $location change', function() {
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       $rootScope.$broadcast('$locationChangeSuccess');
       $rootScope.$apply();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('should only allow one dropdown to be open at once', function() {
       var elm1 = dropdown();
       var elm2 = dropdown();
-      expect(elm1.hasClass('open')).toBe(false);
-      expect(elm2.hasClass('open')).toBe(false);
+      expect(elm1.hasClass(dropdownConfig.openClass)).toBe(false);
+      expect(elm2.hasClass(dropdownConfig.openClass)).toBe(false);
 
       clickDropdownToggle( elm1 );
-      expect(elm1.hasClass('open')).toBe(true);
-      expect(elm2.hasClass('open')).toBe(false);
+      expect(elm1.hasClass(dropdownConfig.openClass)).toBe(true);
+      expect(elm2.hasClass(dropdownConfig.openClass)).toBe(false);
 
       clickDropdownToggle( elm2 );
-      expect(elm1.hasClass('open')).toBe(false);
-      expect(elm2.hasClass('open')).toBe(true);
+      expect(elm1.hasClass(dropdownConfig.openClass)).toBe(false);
+      expect(elm2.hasClass(dropdownConfig.openClass)).toBe(true);
     });
 
     it('should not toggle if the element has `disabled` class', function() {
       var elm = $compile('<li dropdown><a class="disabled" dropdown-toggle></a><ul><li>Hello</li></ul></li>')($rootScope);
       clickDropdownToggle( elm );
-      expect(elm.hasClass('open')).toBe(false);
+      expect(elm.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('should not toggle if the element is disabled', function() {
       var elm = $compile('<li dropdown><button disabled="disabled" dropdown-toggle></button><ul><li>Hello</li></ul></li>')($rootScope);
       elm.find('button').click();
-      expect(elm.hasClass('open')).toBe(false);
+      expect(elm.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('should not toggle if the element has `ng-disabled` as true', function() {
@@ -117,12 +118,12 @@ describe('dropdownToggle', function() {
       var elm = $compile('<li dropdown><div ng-disabled="isdisabled" dropdown-toggle></div><ul><li>Hello</li></ul></li>')($rootScope);
       $rootScope.$digest();
       elm.find('div').click();
-      expect(elm.hasClass('open')).toBe(false);
+      expect(elm.hasClass(dropdownConfig.openClass)).toBe(false);
 
       $rootScope.isdisabled = false;
       $rootScope.$digest();
       elm.find('div').click();
-      expect(elm.hasClass('open')).toBe(true);
+      expect(elm.hasClass(dropdownConfig.openClass)).toBe(true);
     });
 
     it('should unbind events on scope destroy', function() {
@@ -132,13 +133,13 @@ describe('dropdownToggle', function() {
 
       var buttonEl = elm.find('button');
       buttonEl.click();
-      expect(elm.hasClass('open')).toBe(true);
+      expect(elm.hasClass(dropdownConfig.openClass)).toBe(true);
       buttonEl.click();
-      expect(elm.hasClass('open')).toBe(false);
+      expect(elm.hasClass(dropdownConfig.openClass)).toBe(false);
 
       $scope.$destroy();
       buttonEl.click();
-      expect(elm.hasClass('open')).toBe(false);
+      expect(elm.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     // issue 270
@@ -146,11 +147,11 @@ describe('dropdownToggle', function() {
       var checkboxEl = $compile('<input type="checkbox" ng-click="clicked = true" />')($rootScope);
       $rootScope.$digest();
 
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
       expect($rootScope.clicked).toBeFalsy();
 
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       expect($rootScope.clicked).toBeFalsy();
 
       checkboxEl.click();
@@ -172,13 +173,13 @@ describe('dropdownToggle', function() {
     // pr/issue 3274
     it('should not raise $digest:inprog if dismissed during a digest cycle', function () {
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
 
       $rootScope.$apply(function () {
         $document.click();
       });
 
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
   });
 
@@ -222,10 +223,10 @@ describe('dropdownToggle', function() {
     it('should close without errors on $location change', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       var optionEl = element.find('ul > li').eq(0).find('a').eq(0);
       optionEl.click();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
   });
 
@@ -237,13 +238,13 @@ describe('dropdownToggle', function() {
     });
 
     it('should be open initially', function() {
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
     });
 
     it('should toggle when `is-open` changes', function() {
       $rootScope.isopen = false;
       $rootScope.$digest();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
   });
 
@@ -255,7 +256,7 @@ describe('dropdownToggle', function() {
     });
 
     it('should be open initially', function() {
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
     });
 
     it('should change `is-open` binding when toggles', function() {
@@ -266,7 +267,7 @@ describe('dropdownToggle', function() {
     it('should toggle when `is-open` changes', function() {
       $rootScope.isopen = false;
       $rootScope.$digest();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('focus toggle element when opening', function() {
@@ -356,35 +357,35 @@ describe('dropdownToggle', function() {
     it('should close on document click if no auto-close is specified', function() {
       element = dropdown();
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       $document.click();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('should close on document click if empty auto-close is specified', function() {
       element = dropdown('');
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       $document.click();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('auto-close="disabled"', function() {
       element = dropdown('disabled');
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       $document.click();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
     });
 
     it('auto-close="outsideClick"', function() {
       element = dropdown('outsideClick');
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       element.find('ul li a').click();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       $document.click();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('control with is-open', function() {
@@ -392,22 +393,22 @@ describe('dropdownToggle', function() {
       element = $compile('<li dropdown is-open="isopen" auto-close="disabled"><a href dropdown-toggle></a><ul><li>Hello</li></ul></li>')($rootScope);
       $rootScope.$digest();
 
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       //should remain open
       $document.click();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       //now should close
       $rootScope.isopen = false;
       $rootScope.$digest();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('should close anyway if toggle is clicked', function() {
       element = dropdown('disabled');
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(true);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
       clickDropdownToggle();
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
     });
 
     it('should close anyway if esc is pressed', function() {
@@ -415,21 +416,21 @@ describe('dropdownToggle', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
       triggerKeyDown($document, 27);
-      expect(element.hasClass('open')).toBe(false);
+      expect(element.hasClass(dropdownConfig.openClass)).toBe(false);
       expect(isFocused(element.find('a'))).toBe(true);
     });
 
     it('should close anyway if another dropdown is opened', function() {
       var elm1 = dropdown('disabled');
       var elm2 = dropdown();
-      expect(elm1.hasClass('open')).toBe(false);
-      expect(elm2.hasClass('open')).toBe(false);
+      expect(elm1.hasClass(dropdownConfig.openClass)).toBe(false);
+      expect(elm2.hasClass(dropdownConfig.openClass)).toBe(false);
       clickDropdownToggle(elm1);
-      expect(elm1.hasClass('open')).toBe(true);
-      expect(elm2.hasClass('open')).toBe(false);
+      expect(elm1.hasClass(dropdownConfig.openClass)).toBe(true);
+      expect(elm2.hasClass(dropdownConfig.openClass)).toBe(false);
       clickDropdownToggle(elm2);
-      expect(elm1.hasClass('open')).toBe(false);
-      expect(elm2.hasClass('open')).toBe(true);
+      expect(elm1.hasClass(dropdownConfig.openClass)).toBe(false);
+      expect(elm2.hasClass(dropdownConfig.openClass)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Changing the value of dropdownConfig.openClass should not break the unit tests