### PR TITLE
feat(tabs): disallow deselect of tab in onDeselect

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -14,14 +14,25 @@ angular.module('ui.bootstrap.tabs', [])
       tabs = ctrl.tabs = $scope.tabs = [];
 
   ctrl.select = function(selectedTab) {
+	var allow=true;
+	var prevSelected;
     angular.forEach(tabs, function(tab) {
       if (tab.active && tab !== selectedTab) {
+		prevSelected = tab;
         tab.active = false;
-        tab.onDeselect();
+        var result = tab.onDeselect();
+        if (typeof result != 'undefined') {
+			allow = result;
+		}
       }
     });
-    selectedTab.active = true;
-    selectedTab.onSelect();
+    if ( allow ) {
+		selectedTab.active = true;
+		selectedTab.onSelect();
+    } else {
+		prevSelected.active= true;
+		selectedTab.active=false;
+	}
   };
 
   ctrl.addTab = function addTab(tab) {

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -14,25 +14,25 @@ angular.module('ui.bootstrap.tabs', [])
       tabs = ctrl.tabs = $scope.tabs = [];
 
   ctrl.select = function(selectedTab) {
-	var allow=true;
-	var prevSelected;
+    var allow=true;
+    var prevSelected;
     angular.forEach(tabs, function(tab) {
       if (tab.active && tab !== selectedTab) {
-		prevSelected = tab;
+        prevSelected = tab;
         tab.active = false;
         var result = tab.onDeselect();
         if (typeof result != 'undefined') {
-			allow = result;
-		}
+          allow = result;
+        }
       }
     });
     if ( allow ) {
-		selectedTab.active = true;
-		selectedTab.onSelect();
+      selectedTab.active = true;
+      selectedTab.onSelect();
     } else {
-		prevSelected.active= true;
-		selectedTab.active=false;
-	}
+      prevSelected.active= true;
+      selectedTab.active=false;
+    }
   };
 
   ctrl.addTab = function addTab(tab) {

--- a/src/tabs/test/tabs.spec.js
+++ b/src/tabs/test/tabs.spec.js
@@ -190,6 +190,59 @@ describe('tabs', function() {
           expect(execOrder).toEqual([ 'deselect2', 'select1' ]);
     });
   });
+  
+  describe('tab deselect returns false disables navigation',function() {
+
+    beforeEach(inject(function($compile, $rootScope) {
+      scope = $rootScope.$new();
+
+      function makeTab(active) {
+        return {
+          active: !!active,
+          select: jasmine.createSpy('Select'),
+          deselect: jasmine.createSpy('Deselect')
+        };
+      }
+      
+      scope.deselectTab = function(allow){
+        return allow ;
+      };
+      
+      scope.tabs = [
+        makeTab(true), makeTab()
+      ];
+      
+      elm = $compile([
+        '<tabset>',
+        '  <tab active="tabs[0].active" deselect="deselectTab(false)">',
+        '  </tab>',
+        '  <tab active="tabs[1].active" >',
+        '  </tab>',
+        '</tabset>'
+      ].join('\n'))(scope);
+      scope.$apply();
+    }));
+
+    function expectTabActive(activeTab) {
+      var _titles = titles();
+      angular.forEach(scope.tabs, function(tab, i) {
+        if (activeTab === tab) {
+          expect(tab.active).toBe(true,'active tab');
+          expect(_titles.eq(i)).toHaveClass('active','_titles active class');
+          expect(contents().eq(i)).toHaveClass('active', 'contents active class');
+        } else {
+          expect(tab.active).toBe(false, 'inactive');
+          expect(_titles.eq(i)).not.toHaveClass('active','inactive class');
+        }
+      });
+    }
+
+    it('should call deselect, then stay on current tab when deselect returns false', function() {
+          // Select second tab
+          titles().eq(1).find('a').click();
+          expectTabActive(scope.tabs[0]);
+    });
+   });
 
   describe('ng-repeat', function() {
 

--- a/src/tabs/test/tabs.spec.js
+++ b/src/tabs/test/tabs.spec.js
@@ -191,7 +191,7 @@ describe('tabs', function() {
     });
   });
   
-  describe('tab deselect returns false disables navigation',function() {
+  describe('tab deselect',function() {
 
     beforeEach(inject(function($compile, $rootScope) {
       scope = $rootScope.$new();
@@ -205,13 +205,11 @@ describe('tabs', function() {
       }
       
       scope.deselectTab = function(allow){
-        return allow ;
+        return allow;
       };
-      
       scope.tabs = [
         makeTab(true), makeTab()
       ];
-      
       elm = $compile([
         '<tabset>',
         '  <tab active="tabs[0].active" deselect="deselectTab(false)">',


### PR DESCRIPTION
Replaces pull request 3088

We had the need to disallow changing tabs according to business rules. This pull request implements the functionality where the return value (true/false) of onDeselect() determines if switching tabs is allowed or not.

