### PR TITLE
fix(dateparser): Throw on invalid date format string.

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -95,6 +95,10 @@ angular.module('ui.bootstrap.dateparser', [])
           format[i] = '$';
         }
         format = format.join('');
+        var dupe=format.indexOf(code[0]);
+        if (dupe>-1){
+          throw new Error('Invalid date format string.');
+        }
 
         map.push({ index: index, apply: data.apply });
       }

--- a/src/dateparser/test/dateparser.spec.js
+++ b/src/dateparser/test/dateparser.spec.js
@@ -173,4 +173,12 @@ describe('date parser', function () {
   it('should not parse if no format is specified', function() {
     expect(dateParser.parse('21.08.1951', '')).toBe('21.08.1951');
   });
+
+  it('should not parse if invalid format is specified', function() {
+    expect(function(){dateParser.parse('20.12.20190', 'dd.MM.yyyyy');}).toThrow(new Error('Invalid date format string.'));
+  });
+
+  it('should not parse if invalid value is specified', function() {
+    expect(dateParser.parse('20.12.20190', 'dd.MM.yyyy')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
This PR replaces #3544.  The dateParser will throw an exception for an invalid format string as suggested.