### PR TITLE
fix(datepicker): MinMaxInputValidation

### DIFF
--- a/src/datepicker/docs/demo.html
+++ b/src/datepicker/docs/demo.html
@@ -31,7 +31,7 @@
 
         <div class="col-md-6">
             <p class="input-group">
-              <input type="date" class="form-control" datepicker-popup ng-model="dt" is-open="opened" min-date="minDate" max-date="'2015-06-22'" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" close-text="Close" />
+              <input type="date" class="form-control" datepicker-popup ng-model="pickerDate.dt" is-open="opened" min-date="minDate" max-date="'2015-06-22'" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" close-text="Close" />
               <span class="input-group-btn">
                 <button type="button" class="btn btn-default" ng-click="open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
               </span>

--- a/src/datepicker/docs/demo.js
+++ b/src/datepicker/docs/demo.js
@@ -1,11 +1,11 @@
 angular.module('ui.bootstrap.demo').controller('DatepickerDemoCtrl', function ($scope) {
   $scope.today = function() {
-    $scope.dt = new Date();
+    $scope.pickerDate.dt = new Date();
   };
   $scope.today();
 
   $scope.clear = function () {
-    $scope.dt = null;
+    $scope.pickerDate.dt = null;
   };
 
   // Disable weekend selection


### PR DESCRIPTION
This PR is designed to fix #1688 and replaces my earlier PR #3020.
Enable min and max validation on datepicker popup input.  Revised to only use one formatter and one parser per reviewer suggestions.  Also, modified demo app to avoid scoping issues when binding to primitives.  (See https://github.com/angular/angular.js/wiki/Understanding-Scopes)
