### PR TITLE
Validating if markup options are really set in $scope

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -535,7 +535,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
 
       if ( attrs.datepickerOptions ) {
         var options = scope.$parent.$eval(attrs.datepickerOptions);
-        if(options.initDate) {
+        if(options && options.initDate) {
           scope.initDate = options.initDate;
           datepickerEl.attr( 'init-date', 'initDate' );
           delete options.initDate;


### PR DESCRIPTION
Validates if options are really set in $scope when <code> datepicker-options="options"  </code> is given in markup, but no <code> $scope.options </code> exists.

otherwise it will throw an error like:
<code>
TypeError: Cannot read property 'initDate' of undefined
    at link (http://localhost:3000/bower_components/angular-bootstrap/ui-bootstrap-tpls.js:1523:19)
    at http://localhost:3000/bower_components/angular/angular.js:8252:44
    at invokeLinkFn (http://localhost:3000/bower_components/angular/angular.js:8258:9)
</code>
....