### PR TITLE
fix(datepicker): Don't parse the date twice

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -650,7 +650,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
 
       // Detect changes in the view from the text box
       ngModel.$viewChangeListeners.push(function () {
-        scope.date = dateParser.parse(ngModel.$viewValue, dateFormat, scope.date) || new Date(ngModel.$viewValue);
+        scope.date = ngModel.$modelValue;
       });
 
       var documentClickBind = function(event) {


### PR DESCRIPTION
Fixes #3644, #3617 

Potentially fixes #3643 as well, but I haven't tested that one yet.

Unit tests are missing, as I'm at a loss how to test these issues with karma. I'd appreciate some pointers in this regard. If it's fine to add protractor tests, I'd be happy to do so.