### PR TITLE
fix(dateparser): Throws on invalid date format string.

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -220,6 +220,10 @@ angular.module('ui.bootstrap.dateparser', [])
           format[i] = '$';
         }
         format = format.join('');
+        var dupe = format.indexOf(data.key[0]);
+        if (dupe > -1 && !(format.slice(dupe, dupe + 3) === 'ss\\')) {
+          throw new Error('Invalid date format string.');
+        }
 
         map.push({
           index: index,

--- a/src/dateparser/test/dateparser.spec.js
+++ b/src/dateparser/test/dateparser.spec.js
@@ -391,6 +391,15 @@ describe('date parser', function() {
     expect(dateParser.init).toHaveBeenCalled();
   }));
 
+  it('should not parse if invalid format is specified', function () {
+    expect(function () {
+      dateParser.parse('20.12.20190', 'dd.MM.yyyyy');
+    }).toThrow(new Error('Invalid date format string.'));
+  });
+
+  it('should not parse if invalid value is specified', function () {
+    expect(dateParser.parse('20.12.20190', 'dd.MM.yyyy')).toBeUndefined();
+  });
 
   describe('timezone functions', function() {
     describe('toTimezone', function() {


### PR DESCRIPTION
This PR replaces #3568. The dateParser will throw an exception for an invalid format string. In addition to fixing some code formatting issues, this PR also handles parsing dates from the datepicker with a datetime-local type.
