### PR TITLE
feat(typeahead): Setting to show popup after blur

### DIFF
--- a/src/typeahead/docs/readme.md
+++ b/src/typeahead/docs/readme.md
@@ -55,3 +55,7 @@ The typeahead directives provide several attributes:
 * `typeahead-focus-first`
    _(Defaults: true)_ :
    Should the first match automatically be focused as you type?
+
+* `typeahead-show-after-blur`
+   _(Defaults: false)_ :
+   Should the popup appear even after the element loses focus?

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -579,6 +579,25 @@ describe('typeahead tests', function () {
       expect(element).toBeClosed();
     });
 
+    it('should show the popup after blur if show-after-blur is enabled', function () {
+
+      $scope.items = function(viewValue) {
+        return $timeout(function(){
+          return [viewValue];
+        });
+      };
+      var element = prepareInputEl('<div><input ng-model="result" typeahead="item for item in items($viewValue)" typeahead-show-after-blur="true"></div>');
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'match');
+      $scope.$digest();
+
+      inputEl.blur();
+      $timeout.flush();
+
+      expect(element).not.toBeClosed();
+    });
+
     it('should properly update loading callback if an element is not focused', function () {
 
       $scope.items = function(viewValue) {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -61,6 +61,8 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
 
       var focusFirst = originalScope.$eval(attrs.typeaheadFocusFirst) !== false;
 
+      var showAfterBlur = attrs.typeaheadShowAfterBlur ? originalScope.$eval(attrs.typeaheadShowAfterBlur) : false;
+
       //INTERNAL VARIABLES
 
       //model setter executed upon match selection
@@ -310,9 +312,11 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         }
       });
 
-      element.bind('blur', function (evt) {
-        hasFocus = false;
-      });
+      if (showAfterBlur === false) {
+        element.bind('blur', function (evt) {
+          hasFocus = false;
+        });
+      }
 
       // Keep reference to click handler to unbind it.
       var dismissClickHandler = function (evt) {


### PR DESCRIPTION
We have a typeahead query that in some cases takes a lot of time (20 seconds) due to a very slow backend ouside of our control. If the user does something while waiting, the input element loses focus and no popup is shown. This is frustrating for users.

This PR adds a `typeahead-show-after-blur` attribute that defaults to `false`.