### PR TITLE
fix(dateparser): ignore invalid baseDate

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -125,7 +125,7 @@ angular.module('ui.bootstrap.dateparser', [])
 
     if ( results && results.length ) {
       var fields, dt;
-      if (baseDate) {
+      if (baseDate && !isNaN(baseDate)) {
         fields = {
           year: baseDate.getFullYear(),
           month: baseDate.getMonth(),

--- a/src/dateparser/test/dateparser.spec.js
+++ b/src/dateparser/test/dateparser.spec.js
@@ -173,4 +173,8 @@ describe('date parser', function () {
   it('should not parse if no format is specified', function() {
     expect(dateParser.parse('21.08.1951', '')).toBe('21.08.1951');
   });
+
+  it('should ignore invalid baseDate', function() {
+    expect(dateParser.parse('21.08.1951', 'dd.MM.yyyy', new Date('invalid'))).toEqual(new Date(1951, 7, 21));
+  });
 });


### PR DESCRIPTION
Fix issue where the datepicker model value being set to an invalid date will cause all future calls to dateParser.parse() to return an invalid date. The "fields" object just below my change would get all its properties set to NaN, and the resulting date would therefore still contain NaN values, and would therefore be invalid.

This caused an issue where if you use a input[type=text] field for the datepicker, if you enter an invalid date, and then correct it to a valid date (by typing it, not by using the datepicker), the value would never flip back to valid.

See http://plnkr.co/hndJHbOgtPP9eWG9A31v to reproduce easily.

1. Enter a letter into the end of the date field to make the value invalid. The "Selected date is:" display at the top will show a blank value.

2. Delete the letter you entered to make the field valid again. The "Selected date is:" display at the top will continue to show a blank value, and the value you entered will not be parsed.