### PR TITLE
showSpinners directive to toggle timepicker spinners

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -7,7 +7,8 @@ angular.module('ui.bootstrap.timepicker', [])
   meridians: null,
   readonlyInput: false,
   mousewheel: true,
-  arrowkeys: true
+  arrowkeys: true,
+  showSpinners: true
 })
 
 .controller('TimepickerController', ['$scope', '$attrs', '$parse', '$log', '$locale', 'timepickerConfig', function($scope, $attrs, $parse, $log, $locale, timepickerConfig) {
@@ -258,7 +259,9 @@ angular.module('ui.bootstrap.timepicker', [])
     selected.setHours( dt.getHours(), dt.getMinutes() );
     refresh();
   }
-
+  
+  $scope.showSpinners = angular.isDefined($attrs.showSpinners) ? $scope.$parent.$eval($attrs.showSpinners) : timepickerConfig.showSpinners;
+  
   $scope.incrementHours = function() {
     addMinutes( hourStep * 60 );
   };

--- a/template/timepicker/timepicker.html
+++ b/template/timepicker/timepicker.html
@@ -1,6 +1,6 @@
 <table>
 	<tbody>
-		<tr class="text-center" ng-show="showSpinners">
+		<tr class="text-center" ng-show="::showSpinners">
 			<td><a ng-click="incrementHours()" class="btn btn-link"><span class="glyphicon glyphicon-chevron-up"></span></a></td>
 			<td>&nbsp;</td>
 			<td><a ng-click="incrementMinutes()" class="btn btn-link"><span class="glyphicon glyphicon-chevron-up"></span></a></td>
@@ -16,7 +16,7 @@
 			</td>
 			<td ng-show="showMeridian"><button type="button" class="btn btn-default text-center" ng-click="toggleMeridian()">{{meridian}}</button></td>
 		</tr>
-		<tr class="text-center" ng-show="showSpinners">
+		<tr class="text-center" ng-show="::showSpinners">
 			<td><a ng-click="decrementHours()" class="btn btn-link"><span class="glyphicon glyphicon-chevron-down"></span></a></td>
 			<td>&nbsp;</td>
 			<td><a ng-click="decrementMinutes()" class="btn btn-link"><span class="glyphicon glyphicon-chevron-down"></span></a></td>

--- a/template/timepicker/timepicker.html
+++ b/template/timepicker/timepicker.html
@@ -1,6 +1,6 @@
 <table>
 	<tbody>
-		<tr class="text-center">
+		<tr class="text-center" ng-show="showSpinners">
 			<td><a ng-click="incrementHours()" class="btn btn-link"><span class="glyphicon glyphicon-chevron-up"></span></a></td>
 			<td>&nbsp;</td>
 			<td><a ng-click="incrementMinutes()" class="btn btn-link"><span class="glyphicon glyphicon-chevron-up"></span></a></td>
@@ -16,7 +16,7 @@
 			</td>
 			<td ng-show="showMeridian"><button type="button" class="btn btn-default text-center" ng-click="toggleMeridian()">{{meridian}}</button></td>
 		</tr>
-		<tr class="text-center">
+		<tr class="text-center" ng-show="showSpinners">
 			<td><a ng-click="decrementHours()" class="btn btn-link"><span class="glyphicon glyphicon-chevron-down"></span></a></td>
 			<td>&nbsp;</td>
 			<td><a ng-click="decrementMinutes()" class="btn btn-link"><span class="glyphicon glyphicon-chevron-down"></span></a></td>


### PR DESCRIPTION
Directive for togglings spinners in order to vertically align a timepicker to other form controls in multi column forms.

**Example:**
![explanation](https://cloud.githubusercontent.com/assets/1556950/7993515/f3d4a690-0adc-11e5-995a-de7a6ddc9b0b.png)

Incorporates **one-time binding** for this directive, as per suggested by @wesleycho (#3758)