### PR TITLE
feat: timepicker - fire 'blur' on parent element when fired on inputs

### DIFF
--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -1005,5 +1005,29 @@ describe('timepicker directive', function () {
     });
   });
 
+  describe('use with `ng-blur` directive', function() {
+    beforeEach(inject(function() {
+      $rootScope.changeHandler = jasmine.createSpy('changeHandler');
+      $rootScope.time = new Date();
+      element = $compile('<timepicker ng-model="time" ng-blur="changeHandler()"></timepicker>')($rootScope);
+      $rootScope.$digest();
+    }));
+
+    it('should not be called initially', function() {
+      expect($rootScope.changeHandler).not.toHaveBeenCalled();
+    });
+
+    it('should be called when hours / minutes buttons are unfocused', function() {
+      var btn1 = getHoursButton(true);
+      var btn2 = getMinutesButton(false);
+
+      doClick(btn1, 1);
+      doClick(btn2, 1);
+      doClick(btn1, 1);
+      $rootScope.$digest();
+      expect($rootScope.changeHandler.calls.count()).toBe(2);
+    });
+  });
+
 });
 

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -189,7 +189,7 @@ angular.module('ui.bootstrap.timepicker', [])
           $scope.hours = pad( $scope.hours );
         });
       }
-      parentEl.triggerEvent('blur', e);
+      parentEl.triggerHandler('blur', e);
     });
 
     $scope.updateMinutes = function() {
@@ -209,7 +209,7 @@ angular.module('ui.bootstrap.timepicker', [])
           $scope.minutes = pad( $scope.minutes );
         });
       }
-      parentEl.triggerEvent('blur', e);
+      parentEl.triggerHandler('blur', e);
     });
 
   };

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -16,7 +16,7 @@ angular.module('ui.bootstrap.timepicker', [])
       ngModelCtrl = { $setViewValue: angular.noop }, // nullModelCtrl
       meridians = angular.isDefined($attrs.meridians) ? $scope.$parent.$eval($attrs.meridians) : timepickerConfig.meridians || $locale.DATETIME_FORMATS.AMPMS;
 
-  this.init = function( ngModelCtrl_, inputs ) {
+  this.init = function( ngModelCtrl_, inputs, parentEl ) {
     ngModelCtrl = ngModelCtrl_;
     ngModelCtrl.$render = this.render;
 
@@ -38,7 +38,7 @@ angular.module('ui.bootstrap.timepicker', [])
     }
 
     $scope.readonlyInput = angular.isDefined($attrs.readonlyInput) ? $scope.$parent.$eval($attrs.readonlyInput) : timepickerConfig.readonlyInput;
-    this.setupInputEvents( hoursInputEl, minutesInputEl );
+    this.setupInputEvents( hoursInputEl, minutesInputEl, parentEl );
   };
 
   var hourStep = timepickerConfig.hourStep;
@@ -154,7 +154,7 @@ angular.module('ui.bootstrap.timepicker', [])
     });
   };
 
-  this.setupInputEvents = function( hoursInputEl, minutesInputEl ) {
+  this.setupInputEvents = function( hoursInputEl, minutesInputEl, parentEl ) {
     if ( $scope.readonlyInput ) {
       $scope.updateHours = angular.noop;
       $scope.updateMinutes = angular.noop;
@@ -189,6 +189,7 @@ angular.module('ui.bootstrap.timepicker', [])
           $scope.hours = pad( $scope.hours );
         });
       }
+      parentEl.triggerEvent('blur', e);
     });
 
     $scope.updateMinutes = function() {
@@ -208,6 +209,7 @@ angular.module('ui.bootstrap.timepicker', [])
           $scope.minutes = pad( $scope.minutes );
         });
       }
+      parentEl.triggerEvent('blur', e);
     });
 
   };
@@ -259,10 +261,10 @@ angular.module('ui.bootstrap.timepicker', [])
     selected.setHours( dt.getHours(), dt.getMinutes() );
     refresh();
   }
-  
+
   $scope.showSpinners = angular.isDefined($attrs.showSpinners) ?
     $scope.$parent.$eval($attrs.showSpinners) : timepickerConfig.showSpinners;
-  
+
   $scope.incrementHours = function() {
     addMinutes( hourStep * 60 );
   };
@@ -292,7 +294,7 @@ angular.module('ui.bootstrap.timepicker', [])
       var timepickerCtrl = ctrls[0], ngModelCtrl = ctrls[1];
 
       if ( ngModelCtrl ) {
-        timepickerCtrl.init( ngModelCtrl, element.find('input') );
+        timepickerCtrl.init( ngModelCtrl, element.find('input'), element );
       }
     }
   };


### PR DESCRIPTION
Having the ability to add an ng-blur directive directly on the `<timepicker>` element is very useful for validating without annoying the user. This allows this to happen by firing a blur event on the parent when either the hour or minute input is blurred.

I wasn't able to run the test. I sent an email to angular-ui@googlegroups.com , but I got a bounce notification.

Here's the email:

> Hi,
> 
> I'm trying to make a small change to the timepicker to allow blur events on the hour and minute inputs to be bubbled up to the top-level event, but I'm having trouble running the tests on Ubuntu 14.04 with both chromium-browser and google-chrome installed.
> 
> Grunt complains about not being able to open Chrome. [1]
> It appears to be looking for the right binaries according to [2], I put in a console.log at this point, so it didn't appear to be [related to this issue][3] I found.
>
> Any pointers?
>
> Thanks,
Ryan

[1]
```
$ grunt --force
Running "enforce" task

Running "ddescribe-iit:files" (ddescribe-iit) task

Running "jshint:files" (jshint) task
>> 66 files lint free.

Running "html2js:dist" (html2js) task
Successfully converted 29 html templates to js.

Running "test" task

Running "karma:continuous" (karma) task
INFO [karma]: Karma v0.12.36 server started at http://localhost:9876/
INFO [launcher]: Starting browser Chrome
ERROR [launcher]: Cannot start Chrome
	
INFO [launcher]: Trying to start Chrome again (1/2).
ERROR [launcher]: Cannot start Chrome
	
INFO [launcher]: Trying to start Chrome again (2/2).
ERROR [launcher]: Cannot start Chrome
	
ERROR [launcher]: Chrome failed 2 times (cannot start). Giving up.
Warning: Task "karma:continuous" failed. Used --force, continuing.

Running "build" task
File dist/ui-bootstrap-0.13.1-SNAPSHOT-csp.css created

Running "concat:dist" (concat) task
File dist/ui-bootstrap-0.13.1-SNAPSHOT.js created.

Running "concat:dist_tpls" (concat) task
File dist/ui-bootstrap-tpls-0.13.1-SNAPSHOT.js created.

Running "uglify:dist" (uglify) task
>> 1 file created.

Running "uglify:dist_tpls" (uglify) task
>> 1 file created.

Running "makeModuleMappingFile" task
File dist/assets/module-mapping.json created.

Running "makeRawFilesJs" task
File dist/assets/raw-files.json created.

Running "copy:demohtml" (copy) task
Copied 1 file

Running "copy:demoassets" (copy) task
Created 2 directories, copied 15 files

Done, but with warnings.
```

[2]
```
$ cat node_modules/karma-chrome-launcher/index.js | grep google-chrome
    linux: getBin(['chromium-browser', 'chromium', 'google-chrome', 'google-chrome-stable']),
    linux: 'google-chrome-canary',
```

[3]: https://github.com/yeoman/yeoman/issues/1031#issuecomment-18867693