### PR TITLE
fix(tooltip): allow string literal templates

### DIFF
--- a/src/tooltip/test/tooltip-template.spec.js
+++ b/src/tooltip/test/tooltip-template.spec.js
@@ -75,5 +75,22 @@ describe('tooltip template', function() {
     expect( elmBody.children().length ).toBe( 1 );
   }));
 
+  it('should open when templateUrl is specified as a string literal rather than an expression - issue 3852', inject(function($compile) {
+    elmBody = angular.element(
+      '<div><span tooltip-template="myUrl">Selector Text</span></div>'
+    );
+    $compile(elmBody)(scope);
+    scope.$digest();
+    elm = elmBody.find('span');
+    elmScope = elm.scope();
+    tooltipScope = elmScope.$$childTail;
+
+    
+    elm.trigger( 'mouseenter' );
+
+    expect( tooltipScope.isOpen ).toBe( true );
+    expect( elmBody.children().length ).toBe( 2 );
+  }));
+
 });
 

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -65,7 +65,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
    * Returns the actual instance of the $tooltip service.
    * TODO support multiple triggers
    */
-  this.$get = [ '$window', '$compile', '$timeout', '$document', '$position', '$interpolate', function ( $window, $compile, $timeout, $document, $position, $interpolate ) {
+  this.$get = [ '$window', '$compile', '$timeout', '$document', '$position', '$interpolate', '$templateCache', function ( $window, $compile, $timeout, $document, $position, $interpolate, $templateCache ) {
     return function $tooltip ( type, prefix, defaultTriggerShow, options ) {
       options = angular.extend( {}, defaultOptions, globalOptions, options );
 
@@ -278,7 +278,9 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
             }
 
             ttScope.contentExp = function () {
-              return scope.$eval(attrs[type]);
+              if (scope.$eval(attrs[type])) return scope.$eval(attrs[type]);
+              if ($templateCache.get(attrs[type])) return attrs[type];
+              return false;
             };
 
             /**

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -278,8 +278,14 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
             }
 
             ttScope.contentExp = function () {
-              if (scope.$eval(attrs[type])) return scope.$eval(attrs[type]);
-              if ($templateCache.get(attrs[type])) return attrs[type];
+              if (scope.$eval(attrs[type])) {
+                return scope.$eval(attrs[type]);
+              }
+              
+              if ($templateCache.get(attrs[type])) {
+                return attrs[type];
+              }
+
               return false;
             };
 


### PR DESCRIPTION
Can now pass a string literal with the templateUrl to tooltip-template and popover-template,
rather than just an expression / scope variable. This is a potential solution to my issue here: https://github.com/angular-ui/bootstrap/issues/3852