### PR TITLE
Dependency of ngAnimate for animations and transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Do you want to see directives in action? Visit http://angular-ui.github.io/boots
 # Installation
 
 Installation is easy as UI Bootstrap has minimal dependencies - only the AngularJS and Twitter Bootstrap's CSS are required.
+Note: Since version 0.13.0, Ui Bootstrap depends on [ng-animate module](https://docs.angularjs.org/api/ngAnimate) for transitions and animations (ie accordion directive, carroussel). Include it in your angular if you want enable these features.
 
 #### Install with Bower
 ```sh


### PR DESCRIPTION
After upgrading to version 0.13.0, I could not understand why animations were off.

Just add a little word about dependency of ngAnimate module in order to enable animations and transitions. 

