### PR TITLE
allow for leading zeros #3008

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -32,7 +32,7 @@ angular.module('ui.bootstrap.dateparser', [])
       apply: function(value) { this.month = value - 1; }
     },
     'M': {
-      regex: '[1-9]|1[0-2]',
+      regex: '1[0-2]|0[1-9]|[1-9]',
       apply: function(value) { this.month = value - 1; }
     },
     'dd': {
@@ -40,7 +40,7 @@ angular.module('ui.bootstrap.dateparser', [])
       apply: function(value) { this.date = +value; }
     },
     'd': {
-      regex: '[1-2]?[0-9]{1}|3[0-1]{1}',
+      regex: '0[1-9]|[12][0-9]|3[01]|[1-9]',
       apply: function(value) { this.date = +value; }
     },
     'EEEE': {


### PR DESCRIPTION
Allow leading zeros for day and month for format d and M
Use case:
Format d.M.y should allow for entering dates like 02.05.12 and like 2.5.12
This format is very common.

In addition, the regex for 'M' is incorrect. The order of the alternation should be changed.