### PR TITLE
Replaced templateUrl param in typeaheadPopup Directive for external templates

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -361,10 +361,10 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         select:'&'
       },
       replace:true,
-      templateUrl:'template/typeahead/typeahead-popup.html',
+		templateUrl: function (element, attrs) {
+			return attrs.templateUrl || 'template/typeahead/typeahead-popup.html';
+	  },
       link:function (scope, element, attrs) {
-
-        scope.templateUrl = attrs.templateUrl;
 
         scope.isOpen = function () {
           return scope.matches.length > 0;


### PR DESCRIPTION
Replaced templateUrl param in typeaheadPopup Directive for support external templates in addition to the self contained template.

If you try to use the templateUrl attrib before this modification, you get an error if you don't have access to the original template on url 'template/typeahead/typeahead-popup.html'.

Now, you don't need the original template in the route if you provide an additional template.