### PR TITLE
Make accordion work with inline js CSP directive

### DIFF
--- a/template/accordion/accordion-group.html
+++ b/template/accordion/accordion-group.html
@@ -1,7 +1,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title">
-      <a href="javascript:void(0)" tabindex="0" class="accordion-toggle" ng-click="toggleOpen()" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
+      <a href="#" tabindex="0" class="accordion-toggle" ng-click="$event.preventDefault(); toggleOpen()" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
     </h4>
   </div>
   <div class="panel-collapse collapse" collapse="!isOpen">

--- a/template/typeahead/typeahead-match.html
+++ b/template/typeahead/typeahead-match.html
@@ -1,1 +1,1 @@
-<a href="javascript:void(0)" tabindex="-1" bind-html-unsafe="match.label | typeaheadHighlight:query"></a>
+<a href="#" ng-click="$event.preventDefault();" tabindex="-1" bind-html-unsafe="match.label | typeaheadHighlight:query"></a>


### PR DESCRIPTION
This PR fixes issue https://github.com/angular-ui/bootstrap/issues/3904 where CSP errors are triggered as the code href="javascript:void(0)" violates the inline js content security policy. This also preserves the original intent of adding an empty href attribute to enable accessibility while preventing a page refresh.