### PR TITLE
Typo: 'rendered' changed to <code>rendered</code>

### DIFF
--- a/index.html
+++ b/index.html
@@ -1391,7 +1391,7 @@ Creating custom modals is straightforward: create a partial view, its controller
 <li><code>dismiss(reason)</code> - a method that can be used to dismiss a modal, passing a reason</li>
 <li><code>result</code> - a promise that is resolved when a modal is closed and rejected when a modal is dismissed</li>
 <li><code>opened</code> - a promise that is resolved when a modal gets opened after downloading content's template and resolving all variables</li>
-<li>'rendered' - a promise that is resolved when a modal is rendered. </li>
+<li><code>rendered</code> - a promise that is resolved when a modal is rendered. </li>
 </ul>
 
 <p>In addition the scope associated with modal's content is augmented with 2 methods:</p>


### PR DESCRIPTION
Found a typo while browsing through the docs. 