### PR TITLE
initDate bug

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -248,6 +248,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       }
 
       ctrl._refreshView = function() {
+		ctrl.activeDate = ctrl.activeDate? new Date(ctrl.activeDate): null;
         var year = ctrl.activeDate.getFullYear(),
           month = ctrl.activeDate.getMonth(),
           firstDayOfMonth = new Date(year, month, 1),


### PR DESCRIPTION
there is a bug with the initDate  variable  in the date pickera
'ctrl.activeDate' type is string as it read from the $attr[initDate] which always return string and there is no getFullYear function for the string
i have added a line that convert its type to Date opject