### PR TITLE
chore(development): removed href

### DIFF
--- a/template/tabs/tab.html
+++ b/template/tabs/tab.html
@@ -1,3 +1,3 @@
 <li ng-class="{active: active, disabled: disabled}">
-  <a href ng-click="select()" tab-heading-transclude>{{heading}}</a>
+  <a ng-click="select()" tab-heading-transclude>{{heading}}</a>
 </li>


### PR DESCRIPTION
On my single page app, deleting a tab takes me to "#", instead of just changing the active tab.  Removing the HREF makes it work.  I don't believe it is necessary.