### PR TITLE
Only call timeout if the time is a valid integer

### DIFF
--- a/src/alert/alert.js
+++ b/src/alert/alert.js
@@ -23,9 +23,12 @@ angular.module('ui.bootstrap.alert', [])
   return {
     require: 'alert',
     link: function(scope, element, attrs, alertCtrl) {
-      $timeout(function(){
-        alertCtrl.close();
-      }, parseInt(attrs.dismissOnTimeout, 10));
+      var dismissOnTimeout = parseInt(attrs.dismissOnTimeout, 10);
+      if(dismissOnTimeout) {
+        $timeout(function(){
+          alertCtrl.close();
+        }, dismissOnTimeout);
+      }
     }
   };
 }]);

--- a/src/alert/test/dismissOnTimeout.spec.js
+++ b/src/alert/test/dismissOnTimeout.spec.js
@@ -18,4 +18,13 @@ describe('dismissOnTimeout', function () {
     $timeout.flush();
     expect(scope.removeAlert).toHaveBeenCalled();
   });
+  
+  it('should not close automatically if auto-dismiss is an invalid integer', function () {
+    scope.removeAlert = jasmine.createSpy();
+    $compile('<alert close="removeAlert()" dismiss-on-timeout="">Default alert!</alert>')(scope);
+    scope.$digest();
+
+    $timeout.flush();
+    expect(scope.removeAlert).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Allows the use of ng-attr-dismiss-on-timeout="{{alert.dismissOnTimeout}}" when alert.dismissOnTimeout isn't defined. This fix will keep the alert on the screen instead of running $timeout(function(){ alertCtrl.close(); }, NaN); which runs instantly.