### PR TITLE
Make sure baseDate is actually a valid date.

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -125,7 +125,7 @@ angular.module('ui.bootstrap.dateparser', [])
 
     if ( results && results.length ) {
       var fields, dt;
-      if (baseDate) {
+      if (angular.isDate(baseDate) && !isNaN(baseDate)) {
         fields = {
           year: baseDate.getFullYear(),
           month: baseDate.getMonth(),


### PR DESCRIPTION
If the baseDate is an invalid date object it will not default the fields structure correctly.  This is can easily be reproduced by just trying to type in a date on the http://angular-ui.github.io/bootstrap/ datepicker popup example.