### PR TITLE
feat(datepicker): allow to only display days of selected month

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -15,7 +15,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   yearRange: 20,
   minDate: null,
   maxDate: null,
-  shortcutPropagation: false
+  shortcutPropagation: false,
+  daysOfMonthOnly: false
 })
 
 .controller('DatepickerController', ['$scope', '$attrs', '$parse', '$interpolate', '$timeout', '$log', 'dateFilter', 'datepickerConfig', function($scope, $attrs, $parse, $interpolate, $timeout, $log, dateFilter, datepickerConfig) {
@@ -27,7 +28,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
   // Configuration attributes
   angular.forEach(['formatDay', 'formatMonth', 'formatYear', 'formatDayHeader', 'formatDayTitle', 'formatMonthTitle',
-                   'minMode', 'maxMode', 'showWeeks', 'startingDay', 'yearRange', 'shortcutPropagation'], function( key, index ) {
+                   'minMode', 'maxMode', 'showWeeks', 'startingDay', 'yearRange', 'shortcutPropagation', 'daysOfMonthOnly'], function( key, index ) {
     self[key] = angular.isDefined($attrs[key]) ? (index < 8 ? $interpolate($attrs[key])($scope.$parent) : $scope.$parent.$eval($attrs[key])) : datepickerConfig[key];
   });
 
@@ -228,6 +229,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     require: '^datepicker',
     link: function(scope, element, attrs, ctrl) {
       scope.showWeeks = ctrl.showWeeks;
+      scope.daysOfMonthOnly = ctrl.daysOfMonthOnly;
 
       ctrl.step = { months: 1 };
       ctrl.element = element;

--- a/src/datepicker/docs/readme.md
+++ b/src/datepicker/docs/readme.md
@@ -85,6 +85,9 @@ All settings can be provided as attributes in the `datepicker` or globally confi
     _(Default: false)_ :
     An option to disable or enable shortcut's event propagation.
 
+ * `days-of-month-only`
+    _(Default: false)_ :
+    If true datepicker will only show days of selected month
 
 ### Popup Settings ###
 

--- a/template/datepicker/day.html
+++ b/template/datepicker/day.html
@@ -14,7 +14,7 @@
     <tr ng-repeat="row in rows track by $index">
       <td ng-if="showWeeks" class="text-center h6"><em>{{ weekNumbers[$index] }}</em></td>
       <td ng-repeat="dt in row track by dt.date" class="text-center" role="gridcell" id="{{::dt.uid}}" ng-class="::dt.customClass">
-        <button type="button" style="width:100%;" class="btn btn-default btn-sm" ng-class="{'btn-info': dt.selected, active: isActive(dt)}" ng-click="select(dt.date)" ng-disabled="dt.disabled" tabindex="-1"><span ng-class="::{'text-muted': dt.secondary, 'text-info': dt.current}">{{::dt.label}}</span></button>
+        <button ng-if="!daysOfMonthOnly || !dt.secondary" type="button" style="width:100%;" class="btn btn-default btn-sm" ng-class="{'btn-info': dt.selected, active: isActive(dt)}" ng-click="select(dt.date)" ng-disabled="dt.disabled" tabindex="-1"><span ng-class="::{'text-muted': dt.secondary, 'text-info': dt.current}">{{::dt.label}}</span></button>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
#### Problem

Days that don't belong to the selected month could confuse people. There is no option to handle this issue.

#### Solution

Add another config attribute that allows us to handle this. Per default it is set to `false` so basically nothing changes until someone explicitly set it to `true`

**daysOfMonthOnly: `false` (default)**

![screen shot 2015-07-13 at 23 06 31](https://cloud.githubusercontent.com/assets/731337/8660863/dbf225d4-29b3-11e5-8bc6-dbffa619adec.png)

**daysOfMonthOnly: `true`**

![screen shot 2015-07-13 at 23 08 00](https://cloud.githubusercontent.com/assets/731337/8660888/16e7c4d2-29b4-11e5-9b6d-557bb316c9a5.png)

#### Comments

- Not sure if `daysOfMonthOnly` is really a good name for that property. Any other suggestions?
- Instead of using `ng-if` we could just apply a certain css class like `dayInMonth` to the button so people can use CSS to handle this use case.

#### Possible improvements

If show weeks is set to `true` it can happen that all buttons in a row get disabled and the row is a bit short in height. There is definitely a better way to handle this:

![screen shot 2015-07-13 at 19 35 35](https://cloud.githubusercontent.com/assets/731337/8660932/6aa4c7c8-29b4-11e5-9ad6-3958a5ccc404.png)

But I first wanted to know if you guys think that this patch is worth adding or maybe there is already a different approach of achieving this.