### PR TITLE
Fix Collapse flickering

### DIFF
--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -17,6 +17,10 @@ angular.module('ui.bootstrap.collapse', [])
         }
 
         function collapse() {
+          if(! element.hasClass('collapse') && ! element.hasClass('in')) {
+            return collapseDone();
+          }
+
           element
             // IMPORTANT: The height must be set before adding "collapsing" class.
             // Otherwise, the browser attempts to animate from height 0 (in


### PR DESCRIPTION
Only add `collapsing` class if `collapse` or `in` are already attached to element.

Fixes #3801
[Plunker](http://plnkr.co/edit/GYRzp1ZnPmnb080Nr25K?p=preview)