### PR TITLE
Add option to disable pagination from outside.

### DIFF
--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -1,5 +1,3 @@
-angular.module('ui.bootstrap.pagination', [])
-
 .controller('PaginationController', ['$scope', '$attrs', '$parse', function ($scope, $attrs, $parse) {
   var self = this,
       ngModelCtrl = { $setViewValue: angular.noop }, // nullModelCtrl
@@ -43,11 +41,12 @@ angular.module('ui.bootstrap.pagination', [])
   };
 
   this.render = function() {
-    $scope.page = parseInt(ngModelCtrl.$viewValue, 10) || 1;
+      $scope.page = parseInt(ngModelCtrl.$viewValue, 10) || 1;
   };
 
   $scope.selectPage = function(page, evt) {
-    if ( $scope.page !== page && page > 0 && page <= $scope.totalPages) {
+    var disabled_click = $scope.paginationDisabled && evt !== undefined;
+    if (!disabled_click && $scope.page !== page && page > 0 && page <= $scope.totalPages) {
       if (evt && evt.target) {
         evt.target.blur();
       }
@@ -75,7 +74,8 @@ angular.module('ui.bootstrap.pagination', [])
   previousText: 'Previous',
   nextText: 'Next',
   lastText: 'Last',
-  rotate: true
+  rotate: true,
+  paginationDisabled:false
 })
 
 .directive('pagination', ['$parse', 'paginationConfig', function($parse, paginationConfig) {
@@ -86,7 +86,8 @@ angular.module('ui.bootstrap.pagination', [])
       firstText: '@',
       previousText: '@',
       nextText: '@',
-      lastText: '@'
+      lastText: '@',
+      paginationDisabled:'='
     },
     require: ['pagination', '?ngModel'],
     controller: 'PaginationController',

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -42,12 +42,12 @@ angular.module('ui.bootstrap.pagination', [])
   };
 
   this.render = function() {
-      $scope.page = parseInt(ngModelCtrl.$viewValue, 10) || 1;
+    $scope.page = parseInt(ngModelCtrl.$viewValue, 10) || 1;
   };
 
   $scope.selectPage = function(page, evt) {
-    var disabled_click = $scope.paginationDisabled && evt !== undefined;
-    if (!disabled_click && $scope.page !== page && page > 0 && page <= $scope.totalPages) {
+    var clickAllowed = !$scope.ngDisabled || !evt;
+    if (clickAllowed && $scope.page !== page && page > 0 && page <= $scope.totalPages) {
       if (evt && evt.target) {
         evt.target.blur();
       }
@@ -75,8 +75,7 @@ angular.module('ui.bootstrap.pagination', [])
   previousText: 'Previous',
   nextText: 'Next',
   lastText: 'Last',
-  rotate: true,
-  paginationDisabled:false
+  rotate: true
 })
 
 .directive('pagination', ['$parse', 'paginationConfig', function($parse, paginationConfig) {
@@ -88,7 +87,7 @@ angular.module('ui.bootstrap.pagination', [])
       previousText: '@',
       nextText: '@',
       lastText: '@',
-      paginationDisabled:'='
+      ngDisabled:'='
     },
     require: ['pagination', '?ngModel'],
     controller: 'PaginationController',

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -1,3 +1,4 @@
+angular.module('ui.bootstrap.pagination', [])
 .controller('PaginationController', ['$scope', '$attrs', '$parse', function ($scope, $attrs, $parse) {
   var self = this,
       ngModelCtrl = { $setViewValue: angular.noop }, // nullModelCtrl

--- a/src/pagination/test/pagination.spec.js
+++ b/src/pagination/test/pagination.spec.js
@@ -7,6 +7,7 @@ describe('pagination directive', function () {
     $rootScope = _$rootScope_;
     $rootScope.total = 47; // 5 pages
     $rootScope.currentPage = 3;
+    $rootScope.disabled = false;
     $document = _$document_;
     element = $compile('<pagination total-items="total" ng-model="currentPage"></pagination>')($rootScope);
     $rootScope.$digest();
@@ -30,6 +31,12 @@ describe('pagination directive', function () {
 
   function updateCurrentPage(value) {
     $rootScope.currentPage = value;
+    $rootScope.$digest();
+  }
+
+  function setDisabled(value)
+  {
+    $rootScope.disabled = value;
     $rootScope.$digest();
   }
 
@@ -673,4 +680,29 @@ describe('pagination directive', function () {
     });
   });
 
+  describe('disabled with ngDisable', function () {
+    beforeEach(function() {
+      element = $compile('<pagination total-items="total" ng-model="currentPage" ng-disabled="disabled"></pagination>')($rootScope);
+      $rootScope.currentPage = 3;
+      $rootScope.$digest();
+    });
+
+    it('should not respond to clicking', function() {
+      setDisabled(true);
+      clickPaginationEl(2);
+      expect($rootScope.currentPage).toBe(3);
+      setDisabled(false);
+      clickPaginationEl(2);
+      expect($rootScope.currentPage).toBe(2);
+    });
+
+    it('should change the class of all buttons except selected one', function () {
+      setDisabled(false);
+      expect(getPaginationEl(3).hasClass('active')).toBe(true);
+      expect(getPaginationEl(4).hasClass('active')).toBe(false);
+      setDisabled(true);
+      expect(getPaginationEl(3).hasClass('disabled')).toBe(false);
+      expect(getPaginationEl(4).hasClass('disabled')).toBe(true);
+    });
+  });
 });

--- a/template/pagination/pagination.html
+++ b/template/pagination/pagination.html
@@ -1,7 +1,7 @@
 <ul class="pagination">
-  <li ng-if="boundaryLinks" ng-class="{disabled: noPrevious()}"><a href ng-click="selectPage(1, $event)">{{getText('first')}}</a></li>
-  <li ng-if="directionLinks" ng-class="{disabled: noPrevious()}"><a href ng-click="selectPage(page - 1, $event)">{{getText('previous')}}</a></li>
-  <li ng-repeat="page in pages track by $index" ng-class="{active: page.active}"><a href ng-click="selectPage(page.number, $event)">{{page.text}}</a></li>
-  <li ng-if="directionLinks" ng-class="{disabled: noNext()}"><a href ng-click="selectPage(page + 1, $event)">{{getText('next')}}</a></li>
-  <li ng-if="boundaryLinks" ng-class="{disabled: noNext()}"><a href ng-click="selectPage(totalPages, $event)">{{getText('last')}}</a></li>
+  <li ng-if="boundaryLinks" ng-class="{disabled: noPrevious()||paginationDisabled}"><a href ng-click="selectPage(1, $event)">{{getText('first')}}</a></li>
+  <li ng-if="directionLinks" ng-class="{disabled: noPrevious()||paginationDisabled}"><a href ng-click="selectPage(page - 1, $event)">{{getText('previous')}}</a></li>
+  <li ng-repeat="page in pages track by $index" ng-class="{active: page.active,disabled: paginationDisabled&&!page.active}"><a href ng-click="selectPage(page.number, $event)">{{page.text}}</a></li>
+  <li ng-if="directionLinks" ng-class="{disabled: noNext()||paginationDisabled}"><a href ng-click="selectPage(page + 1, $event)">{{getText('next')}}</a></li>
+  <li ng-if="boundaryLinks" ng-class="{disabled: noNext()||paginationDisabled}"><a href ng-click="selectPage(totalPages, $event)">{{getText('last')}}</a></li>
 </ul>

--- a/template/pagination/pagination.html
+++ b/template/pagination/pagination.html
@@ -1,7 +1,7 @@
 <ul class="pagination">
-  <li ng-if="boundaryLinks" ng-class="{disabled: noPrevious()||paginationDisabled}"><a href ng-click="selectPage(1, $event)">{{getText('first')}}</a></li>
-  <li ng-if="directionLinks" ng-class="{disabled: noPrevious()||paginationDisabled}"><a href ng-click="selectPage(page - 1, $event)">{{getText('previous')}}</a></li>
-  <li ng-repeat="page in pages track by $index" ng-class="{active: page.active,disabled: paginationDisabled&&!page.active}"><a href ng-click="selectPage(page.number, $event)">{{page.text}}</a></li>
-  <li ng-if="directionLinks" ng-class="{disabled: noNext()||paginationDisabled}"><a href ng-click="selectPage(page + 1, $event)">{{getText('next')}}</a></li>
-  <li ng-if="boundaryLinks" ng-class="{disabled: noNext()||paginationDisabled}"><a href ng-click="selectPage(totalPages, $event)">{{getText('last')}}</a></li>
+  <li ng-if="boundaryLinks" ng-class="{disabled: noPrevious()||ngDisabled}"><a href ng-click="selectPage(1, $event)">{{getText('first')}}</a></li>
+  <li ng-if="directionLinks" ng-class="{disabled: noPrevious()||ngDisabled}"><a href ng-click="selectPage(page - 1, $event)">{{getText('previous')}}</a></li>
+  <li ng-repeat="page in pages track by $index" ng-class="{active: page.active,disabled: ngDisabled&&!page.active}"><a href ng-click="selectPage(page.number, $event)">{{page.text}}</a></li>
+  <li ng-if="directionLinks" ng-class="{disabled: noNext()||ngDisabled}"><a href ng-click="selectPage(page + 1, $event)">{{getText('next')}}</a></li>
+  <li ng-if="boundaryLinks" ng-class="{disabled: noNext()||ngDisabled}"><a href ng-click="selectPage(totalPages, $event)">{{getText('last')}}</a></li>
 </ul>


### PR DESCRIPTION
I want to use this plugin in my project to paginate through tables, but because table content is ajax-based, I dont want to allow user clicking two times at next button at once.
The problem is not only mine, as can be seen in [this question](http://stackoverflow.com/questions/21609545/how-to-disable-ui-bootstrap-pagination/26902100#comment50910741_26902100).

To solve this issue I have added attribute paginationDisabled to pagination widget. When it is set to true - the widget does not responds to clicking and all buttons are marked as disabled.
Is should be used like this:

    <pagination 
        total-items="totalItems" 
        ng-model="currentPage" 
        ng-change="pageChanged()" 
        pagination-disabled="blocked"
    ></pagination>
