### PR TITLE
fix(rating): Set rating to 0 when viewValue is same as click value.

### DIFF
--- a/src/rating/rating.js
+++ b/src/rating/rating.js
@@ -30,7 +30,7 @@ angular.module('ui.bootstrap.rating', [])
 
   $scope.rate = function(value) {
     if ( !$scope.readonly && value >= 0 && value <= $scope.range.length ) {
-      ngModelCtrl.$setViewValue(value);
+      ngModelCtrl.$setViewValue(ngModelCtrl.$viewValue === value ? 0 : value);
       ngModelCtrl.$render();
     }
   };

--- a/src/rating/test/rating.spec.js
+++ b/src/rating/test/rating.spec.js
@@ -55,6 +55,12 @@ describe('rating directive', function () {
     expect(getState()).toEqual([true, true, true, true, true]);
     expect($rootScope.rate).toBe(5);
     expect(element.attr('aria-valuenow')).toBe('5');
+
+    getStar(5).click();
+    $rootScope.$digest();
+    expect(getState()).toEqual([false, false, false, false, false]);
+    expect($rootScope.rate).toBe(0);
+    expect(element.attr('aria-valuenow')).toBe('0');
   });
 
   it('handles correctly the hover event', function() {


### PR DESCRIPTION
This allows rating to be set to 0 using mouse. Currently you have been able to set rating to 0 using keyboard and now you can set it to 0 also using mouse.

This current behavior can be tested on default rating example http://angular-ui.github.io/bootstrap/#/rating

New version with this fix can be tested over here https://jsfiddle.net/RopoMen/bsbmcvza/embedded/result/

This PR is fixin rating issue #3246