### PR TITLE
Tooltip positioning & placement improvements

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -68,6 +68,24 @@ describe('tooltip', function() {
     expect( tooltipScope.placement ).toBe( 'bottom' );
   }));
 
+  it('should update placement dynamically', inject( function( $compile, $timeout ) {
+    scope.place = 'bottom';
+    elm = $compile( angular.element(
+      '<span tooltip="tooltip text" tooltip-placement="{{place}}">Selector Text</span>'
+    ) )( scope );
+    scope.$apply();
+    elmScope = elm.scope();
+    tooltipScope = elmScope.$$childTail;
+
+    elm.trigger( 'mouseenter' );
+    expect( tooltipScope.placement ).toBe( 'bottom' );
+
+    scope.place = 'right';
+    scope.$digest();
+    $timeout.flush();
+    expect(tooltipScope.placement).toBe( 'right' );
+  }));
+
   it('should work inside an ngRepeat', inject( function( $compile ) {
 
     elm = $compile( angular.element(

--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -474,24 +474,26 @@ describe( 'tooltip positioning', function() {
     tooltipScope = elmScope.$$childTail;
   }));
 
-  it( 'should re-position on every digest', inject( function ($timeout) {
+  it( 'should re-position when value changes', inject( function ($timeout) {
     elm.trigger( 'mouseenter' );
 
     scope.$digest();
     $timeout.flush();
     var startingPositionCalls = $position.positionElements.calls.count();
 
+    scope.text = 'New Text';
     scope.$digest();
     $timeout.flush();
+    expect(elm.attr('tooltip')).toBe( 'New Text' );
     expect($position.positionElements.calls.count()).toEqual(startingPositionCalls + 1);
     // Check that positionElements was called with elm
     expect($position.positionElements.calls.argsFor(startingPositionCalls)[0][0])
       .toBe(elm[0]);
 
     scope.$digest();
-    $timeout.flush();
-    expect($position.positionElements.calls.count()).toEqual(startingPositionCalls + 2);
-    expect($position.positionElements.calls.argsFor(startingPositionCalls + 1)[0][0])
+    $timeout.verifyNoPendingTasks();
+    expect($position.positionElements.calls.count()).toEqual(startingPositionCalls + 1);
+    expect($position.positionElements.calls.argsFor(startingPositionCalls)[0][0])
       .toBe(elm[0]);
     scope.$digest();
   }));

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -307,6 +307,15 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
               positionTooltipAsync();
             });
 
+            attrs.$observe( prefix + 'Placement', function () {
+              if (ttScope.isOpen) {
+                $timeout(function () {
+                  prepPlacement();
+                  show()();
+                }, 0, false);
+              }
+            });
+
             function prepPopupClass() {
               ttScope.popupClass = attrs[prefix + 'Class'];
             }

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -136,6 +136,10 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
               tooltip.css( ttPosition );
             };
 
+            var positionTooltipAsync = function () {
+              $timeout(positionTooltip, 0, false);
+            };
+
             // Set up the correct scope to allow transclusion later
             ttScope.origScope = scope;
 
@@ -246,12 +250,9 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
                 }
               });
 
-              tooltipLinkedScope.$watch(function () {
-                $timeout(positionTooltip, 0, false);
-              });
-
               if (options.useContentExp) {
                 tooltipLinkedScope.$watch('contentExp()', function (val) {
+                  positionTooltipAsync();
                   if (!val && ttScope.isOpen ) {
                     hide();
                   }
@@ -287,6 +288,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
             if (!options.useContentExp) {
               attrs.$observe( type, function ( val ) {
                 ttScope.content = val;
+                positionTooltipAsync();
 
                 if (!val && ttScope.isOpen ) {
                   hide();
@@ -302,6 +304,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
 
             attrs.$observe( prefix+'Title', function ( val ) {
               ttScope.title = val;
+              positionTooltipAsync();
             });
 
             function prepPopupClass() {


### PR DESCRIPTION
This PR contains two changes:

1. Only update tooltip position when content changes, instead of every $digest. This fixes a bug where the tooltip would shift a pixel #3964, and should be a little more performant.
2. Adds the ability for changes to `tooltip-placement`/`popover-placement` to be reflected by the tooltip immediately #3978. The test for this is arguably incomplete, it only checks that the tooltip scope is updated, and doesn't check that the tooltip appearance has changed. I don't really know how to test the latter.

@chrisirhc It looks like you've done the most work on the tooltips recently, I would love to get your opinion on these changes.