### PR TITLE
fix(datepicker): validate using ng-required attribute

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -78,14 +78,14 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   this.render = function() {
     if ( ngModelCtrl.$viewValue ) {
       var date = new Date( ngModelCtrl.$viewValue ),
-          isValid = !isNaN(date) || !$attrs.ngRequired;
+          isValid = !isNaN(date);
 
       if ( isValid ) {
         this.activeDate = date;
-      } else {
+      } else if (!!$attrs.ngRequired){
         $log.error('Datepicker directive: "ng-model" value must be a Date object, a number of milliseconds since 01.01.1970 or a string representing an RFC2822 or ISO 8601 date.');
       }
-      ngModelCtrl.$setValidity('date', isValid);
+      ngModelCtrl.$setValidity('date', isValid || !$attrs.ngRequired);
     }
     this.refreshView();
   };

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -78,7 +78,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   this.render = function() {
     if ( ngModelCtrl.$viewValue ) {
       var date = new Date( ngModelCtrl.$viewValue ),
-          isValid = !isNaN(date);
+          isValid = !isNaN(date) || !$attrs.ngRequired;
 
       if ( isValid ) {
         this.activeDate = date;

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -82,10 +82,9 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
       if ( isValid ) {
         this.activeDate = date;
-      } else if (!!$attrs.ngRequired){
+      } else {
         $log.error('Datepicker directive: "ng-model" value must be a Date object, a number of milliseconds since 01.01.1970 or a string representing an RFC2822 or ISO 8601 date.');
       }
-      ngModelCtrl.$setValidity('date', isValid || !$attrs.ngRequired);
     }
     this.refreshView();
   };
@@ -616,6 +615,11 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
 
       function validator(modelValue, viewValue) {
         var value = modelValue || viewValue;
+
+        if (!attrs.ngRequired && !value) {
+          return true;
+        }
+
         if (angular.isNumber(value)) {
           value = new Date(value);
         }

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -334,11 +334,10 @@ describe('datepicker directive', function () {
           expect(angular.isDate($rootScope.date)).toBe(true);
         });
 
-        it('to a date that is invalid, it gets invalid', function() {
+        it('to a date that is invalid, it doesn\`t update', function() {
           $rootScope.date = new Date('pizza');
           $rootScope.$digest();
-          expect(element.hasClass('ng-invalid')).toBeTruthy();
-          expect(element.hasClass('ng-invalid-date')).toBeTruthy();
+          expect(getTitle()).toBe('September 2010');
           expect(angular.isDate($rootScope.date)).toBe(true);
           expect(isNaN($rootScope.date)).toBe(true);
         });
@@ -360,11 +359,10 @@ describe('datepicker directive', function () {
           expect(angular.isString($rootScope.date)).toBe(true);
         });
 
-        it('to a string that cannot be parsed by Date, it gets invalid', function() {
+        it('to a string that cannot be parsed by Date, it doesn\'t update', function() {
           $rootScope.date = 'pizza';
           $rootScope.$digest();
-          expect(element.hasClass('ng-invalid')).toBeTruthy();
-          expect(element.hasClass('ng-invalid-date')).toBeTruthy();
+          expect(getTitle()).toBe('September 2010');
           expect($rootScope.date).toBe('pizza');
         });
       });
@@ -1876,27 +1874,41 @@ describe('datepicker directive', function () {
     });
 
     describe('use with `ng-required` directive', function() {
-      beforeEach(inject(function() {
-        $rootScope.date = '';
-        var wrapElement = $compile('<div><input ng-model="date" datepicker-popup ng-required="true"><div>')($rootScope);
-        $rootScope.$digest();
-        assignElements(wrapElement);
-      }));
+      describe('`ng-required is true`', function() {
+        beforeEach(inject(function() {
+          $rootScope.date = '';
+          var wrapElement = $compile('<div><input ng-model="date" datepicker-popup ng-required="true"><div>')($rootScope);
+          $rootScope.$digest();
+          assignElements(wrapElement);
+        }));
 
-      it('should be invalid initially', function() {
-        expect(inputEl.hasClass('ng-invalid')).toBeTruthy();
+        it('should be invalid initially and when no date', function() {
+          expect(inputEl.hasClass('ng-invalid')).toBeTruthy();
+        });
+
+        it('should be valid if model has been specified', function() {
+          $rootScope.date = new Date();
+          $rootScope.$digest();
+          expect(inputEl.hasClass('ng-valid')).toBeTruthy();
+        });
+
+        it('should be valid if model value is a valid timestamp', function() {
+          $rootScope.date = Date.now();
+          $rootScope.$digest();
+          expect(inputEl.hasClass('ng-valid')).toBeTruthy();
+        });
       });
+      describe('`ng-required is false`', function() {
+        beforeEach(inject(function() {
+          $rootScope.date = '';
+          var wrapElement = $compile('<div><input ng-model="date" datepicker-popup ng-required="false"><div>')($rootScope);
+          $rootScope.$digest();
+          assignElements(wrapElement);
+        }));
 
-      it('should be valid if model has been specified', function() {
-        $rootScope.date = new Date();
-        $rootScope.$digest();
-        expect(inputEl.hasClass('ng-valid')).toBeTruthy();
-      });
-
-      it('should be valid if model value is a valid timestamp', function() {
-        $rootScope.date = Date.now();
-        $rootScope.$digest();
-        expect(inputEl.hasClass('ng-valid')).toBeTruthy();
+        it('should be valid initially and when no date', function() {
+          expect(inputEl.hasClass('ng-valid')).toBeTruthy();
+        });
       });
     });
 


### PR DESCRIPTION
This is a solution for the the issue (https://github.com/angular-ui/bootstrap/issues/3862), where date is always required for datepicker, even when ng-required is set to false.

(todo: still need to add tests)
