### PR TITLE
Accordion accessibility enhancements

### DIFF
--- a/src/accordion/test/accordion.spec.js
+++ b/src/accordion/test/accordion.spec.js
@@ -449,6 +449,18 @@ describe('accordion', function () {
         expect(findGroupBody(1).find('div').attr('tabindex')).toEqual('-1');
       });
 
+      it('should change aria hidden when is open', function () {
+        findGroupLink(1).click();
+        scope.$digest();
+        expect(findGroupBody(0).attr('aria-hidden')).toEqual('true');
+        expect(findGroupBody(1).attr('aria-hidden')).toEqual('false');
+
+        findGroupLink(0).click();
+        scope.$digest();
+        expect(findGroupBody(0).attr('aria-hidden')).toEqual('false');
+        expect(findGroupBody(1).attr('aria-hidden')).toEqual('true');
+      });
+
     });
   });
 });

--- a/src/accordion/test/accordion.spec.js
+++ b/src/accordion/test/accordion.spec.js
@@ -411,5 +411,55 @@ describe('accordion', function () {
       });
     });
 
+    describe(' with accessibility ', function () {
+      beforeEach(function () {
+        var tpl =
+          '<accordion>' +
+          '<accordion-group heading="title 1">Content 1</accordion-group>' +
+          '<accordion-group heading="title 2">Content 2</accordion-group>' +
+          '</accordion>';
+        element = angular.element(tpl);
+        $compile(element)(scope);
+        scope.$digest();
+        groups = element.find('.panel');
+      });
+      afterEach(function () {
+        element.remove();
+      });
+
+      it('should have aria-label at link', function () {
+        expect(findGroupLink(0).attr('aria-label')).toEqual('title 1');
+        expect(findGroupLink(1).attr('aria-label')).toEqual('title 2');
+      });
+
+      it('should have role button in title', function () {
+        expect(findGroupLink(0).attr('role')).toEqual('button');
+        expect(findGroupLink(1).attr('role')).toEqual('button');
+      });
+
+      it('should be tabbable when is open', function () {
+        findGroupLink(1).click();
+        scope.$digest();
+        expect(findGroupBody(0).find('div').attr('tabindex')).toEqual('-1');
+        expect(findGroupBody(1).find('div').attr('tabindex')).toEqual('0');
+
+        findGroupLink(0).click();
+        scope.$digest();
+        expect(findGroupBody(0).find('div').attr('tabindex')).toEqual('0');
+        expect(findGroupBody(1).find('div').attr('tabindex')).toEqual('-1');
+      });
+
+      it('should change aria hidden when is open', function () {
+        findGroupLink(1).click();
+        scope.$digest();
+        expect(findGroupBody(0).find('div').attr('aria-hidden')).toEqual('true');
+        expect(findGroupBody(1).find('div').attr('aria-hidden')).toEqual('false');
+
+        findGroupLink(0).click();
+        scope.$digest();
+        expect(findGroupBody(0).find('div').attr('aria-hidden')).toEqual('false');
+        expect(findGroupBody(1).find('div').attr('aria-hidden')).toEqual('true');
+      });
+    });
   });
 });

--- a/src/accordion/test/accordion.spec.js
+++ b/src/accordion/test/accordion.spec.js
@@ -449,17 +449,6 @@ describe('accordion', function () {
         expect(findGroupBody(1).find('div').attr('tabindex')).toEqual('-1');
       });
 
-      it('should change aria hidden when is open', function () {
-        findGroupLink(1).click();
-        scope.$digest();
-        expect(findGroupBody(0).find('div').attr('aria-hidden')).toEqual('true');
-        expect(findGroupBody(1).find('div').attr('aria-hidden')).toEqual('false');
-
-        findGroupLink(0).click();
-        scope.$digest();
-        expect(findGroupBody(0).find('div').attr('aria-hidden')).toEqual('false');
-        expect(findGroupBody(1).find('div').attr('aria-hidden')).toEqual('true');
-      });
     });
   });
 });

--- a/template/accordion/accordion-group.html
+++ b/template/accordion/accordion-group.html
@@ -1,10 +1,11 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h4 class="panel-title">
-      <a href="#" tabindex="0" class="accordion-toggle" ng-click="$event.preventDefault(); toggleOpen()" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
+    <h4 class="panel-title" role="presentation">
+      <a href="#" tabindex="0" class="accordion-toggle" ng-click="$event.preventDefault(); toggleOpen()"
+         role="button" aria-label="{{heading}}" aria-expanded="{{isOpen}}" accordion-transclude="heading"><span ng-class="{'text-muted': isDisabled}">{{heading}}</span></a>
     </h4>
   </div>
   <div class="panel-collapse collapse" collapse="!isOpen">
-	  <div class="panel-body" ng-transclude></div>
+	  <div class="panel-body" tabindex="{{isOpen ? '0' : '-1'}}" role="document" aria-hidden="{{!isOpen}}" ng-transclude></div>
   </div>
 </div>

--- a/template/accordion/accordion-group.html
+++ b/template/accordion/accordion-group.html
@@ -6,6 +6,6 @@
     </h4>
   </div>
   <div class="panel-collapse collapse" collapse="!isOpen">
-	  <div class="panel-body" tabindex="{{isOpen ? '0' : '-1'}}" role="document" aria-hidden="{{!isOpen}}" ng-transclude></div>
+	  <div class="panel-body" tabindex="{{isOpen ? '0' : '-1'}}" role="document" ng-transclude></div>
   </div>
 </div>


### PR DESCRIPTION
- Added roles to title for better reading of screen readers
- Make content of accordion tabbable when he is open (for keyboard navigation)
- Added aria attributes to describe accordion state

Using aria attributes I described title like a button, aria doesn't define accordion, only buttons and tabs. There is no consensus in this approach, but I think that for blind, hear button is conceptually closer than tab. We can discuss this.