### PR TITLE
update datepicker.js

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -653,7 +653,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
         if (angular.isDefined(dt)) {
           scope.date = dt;
         }
-        var date = scope.date ? dateFilter(scope.date, dateFormat) : '';
+        var date = scope.date ? dateFilter(scope.date, dateFormat) : null; // Setting to NULL is necessary for form validators to function
         element.val(date);
         ngModel.$setViewValue(date);
 


### PR DESCRIPTION
On line 656:

Angular validation is triggered when date is an empty string because an empty string is an invalid date object. Setting date to null mitigates this issue.

This happens when the input type is set to 'date'
