### PR TITLE
Correction in the popup position

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -425,7 +425,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
         matches:'=',
         query:'=',
         active:'=',
-        position:'&',
+        position:'=',
         moveInProgress:'=',
         select:'&'
       },


### PR DESCRIPTION
Upon receiving position in the directive, we need to use '=' to place the correct bind the scope position.