### PR TITLE
Bugfix that removes "setIsOpen is not a function"

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -220,7 +220,9 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
       self.selectedOption = null;
     }
 
-    setIsOpen($scope, isOpen);
+    if (setIsOpen) {
+      setIsOpen($scope, isOpen);
+    }
   });
 
   $scope.$on('$locationChangeSuccess', function() {


### PR DESCRIPTION
When binding "is-open" to an expression, the variable "getIsOpen" does not have "assign" function after the $parse call. This is ok since the the "isOpen" variable is assigned from the outside anyway. We just need to stop trying to execute the assign function to prevent the error.

We might be able to disable more code when the "is-open" attribute is used, but that's a much bigger job.