### PR TITLE
added docs to indicate what the eye icon means for directive settings

### DIFF
--- a/misc/demo/index.html
+++ b/misc/demo/index.html
@@ -173,6 +173,12 @@
                     </p>
                     <h3>FAQ</h3>
                     <p>Please check <a href="https://github.com/angular-ui/bootstrap/wiki/FAQ" target="_blank">our FAQ section</a> for common problems / solutions.</p>
+                    <h3>Reading the documentation</h3>
+                    <p>
+                      Each of the directives provided in <code>ui-bootstrap</code> have documentation and interactive Plunker examples. There is also a list of settings which outline the default
+                      values of settings, and whether they are readonly. In addition to this, some settings have an eye icon next to them like this <i class="glyphicon glyphicon-eye-open"></i>. The
+                      eye means that the setting has an Angular <a href="https://docs.angularjs.org/api/ng/type/$rootScope.Scope#$watch" title="Angular $watch" target="_blank">$watch</a> listener applied to it.
+                    </p>
                 </section>
                 <% demoModules.forEach(function(module) { %>
                     <section id="<%= module.name %>">


### PR DESCRIPTION
I couldn't figure out what the eye icon meant for certain settings and I couldn't see anywhere where it was explained. The icon referenced:

![image](https://cloud.githubusercontent.com/assets/10840857/9100564/cdb88fd4-3c1f-11e5-86a3-075432ca3c7e.png)

So I just added a little explanation under a new heading called "Reading the documentation" in the demo index.html.