### PR TITLE
chore(docs): clarified that typeahead-min-length must be greater than 0

### DIFF
--- a/src/typeahead/docs/readme.md
+++ b/src/typeahead/docs/readme.md
@@ -42,7 +42,7 @@ The typeahead directives provide several attributes:
 
 * `typeahead-min-length` <i class="glyphicon glyphicon-eye-open"></i>
    _(Defaults: 1)_ :
-   Minimal no of characters that needs to be entered before typeahead kicks-in
+   Minimal no of characters that needs to be entered before typeahead kicks-in. Must be greater than or equal to 1.
 
 * `typeahead-no-results` <i class="glyphicon glyphicon-eye-open"></i>
    _(Defaults: angular.noop)_ :


### PR DESCRIPTION
Since there has been a lot of confusion about setting `typeahead-min-length` to 0

https://github.com/angular-ui/bootstrap/issues/764#issuecomment-128427107