### PR TITLE
Fix for DateParser

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -125,7 +125,7 @@ angular.module('ui.bootstrap.dateparser', [])
 
     if ( results && results.length ) {
       var fields, dt;
-      if (baseDate) {
+      if (baseDate && baseDate.constructor == Date) {
         fields = {
           year: baseDate.getFullYear(),
           month: baseDate.getMonth(),


### PR DESCRIPTION
It appears that manually typing a date value into the textbox with the datepicker attached causes this section to fail. 

baseDate becomes a String object rather than being maintained as a Date object.

see proposed change on line 128

__ 
Here is the rendered textbox with the datepicker attached. 

&lt;input type="text" class="form-control ng-pristine ng-valid ng-isolate-scope ng-valid-date ng-touched" datepicker-popup="dd/MM/yyyy" ng-model="task.CompletedDate" name="Model.TransactionTaskList[0].CompletedDate" is-open="Common.DatePickerOpened['Model.TransactionTaskList['+$index+']'+'.CompletedDate']" min-date="&quot;2015-07-24T04:00:00.000Z&quot;" max-date="&quot;2015-07-31T04:00:00.000Z&quot;" datepicker-options="Common.dateOptions" close-text="Close" ng-change="Methods.SetParentDirty(task);"&gt;

Typing a non-date element (repro: select 31/05/2015, then delete the last character) throws the following error: 
Datepicker directive: "ng-model" value must be a Date object, a number of milliseconds since 01.01.1970 or a string representing an RFC2822 or ISO 8601 date.

Also appears that the "name" attribute is not available to the $scope.Form at line 1071 in ui-bootstrap-tpls-0.13.0.js 
