### PR TITLE
feat(datepicker): timeless-json-mode

### DIFF
--- a/src/datepicker/docs/demo.html
+++ b/src/datepicker/docs/demo.html
@@ -11,15 +11,20 @@
   }
 </style>
 <div ng-controller="DatepickerDemoCtrl">
-    <pre>Selected date is: <em>{{dt | date:'fullDate' }}</em></pre>
+    <pre ng-hide="timelessJsonMode">Selected date is: <em>{{dt | date:'fullDate' }}</em></pre>
+    <pre ng-show="timelessJsonMode">Selected date is: <em>{{tdt | date:'fullDate' }}</em></pre>
 
     <h4>Inline</h4>
-    <div style="display:inline-block; min-height:290px;">
+    <div style="display:inline-block; min-height:290px;" ng-hide="timelessJsonMode">
       <uib-datepicker ng-model="dt" min-date="minDate" show-weeks="true" class="well well-sm" custom-class="getDayClass(date, mode)"></uib-datepicker>
     </div>
 
+    <div style="display:inline-block; min-height:290px;" ng-show="timelessJsonMode">
+      <uib-datepicker ng-model="tdt" timeless-json-mode min-date="minDate" show-weeks="true" class="well well-sm" custom-class="getDayClass(date, mode)"></uib-datepicker>
+    </div>
+
     <h4>Popup</h4>
-    <div class="row">
+    <div class="row" ng-hide="timelessJsonMode">
         <div class="col-md-6">
             <p class="input-group">
               <input type="text" class="form-control" uib-datepicker-popup="{{format}}" ng-model="dt" is-open="popup1.opened" min-date="minDate" max-date="maxDate" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" close-text="Close" alt-input-formats="altInputFormats" />
@@ -38,9 +43,34 @@
             </p>
         </div>
     </div>
+
+    <div class="row" ng-show="timelessJsonMode">
+        <div class="col-md-6">
+            <p class="input-group">
+              <input type="text" class="form-control" uib-datepicker-popup="{{format}}" timeless-json-mode ng-model="tdt" is-open="status.opened" min-date="timelessJsonUtils.jsonDateToTicks(minDate)" max-date="timelessJsonUtils.jsonDateAddDays(maxDate, 0)" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" close-text="Close" />
+              <span class="input-group-btn">
+                <button type="button" class="btn btn-default" ng-click="open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+              </span>
+            </p>
+        </div>
+
+        <div class="col-md-6">
+            <p class="input-group">
+              <input type="date" class="form-control" uib-datepicker-popup timeless-json-mode="withUtils" ng-model="tdt" is-open="status.opened" min-date="jsonDateToTicks(minDate)" max-date="jsonDateAddDays(maxDate, 0)" datepicker-options="dateOptions" date-disabled="disabled(date, mode)" ng-required="true" close-text="Close" />
+              <span class="input-group-btn">
+                <button type="button" class="btn btn-default" ng-click="open($event)"><i class="glyphicon glyphicon-calendar"></i></button>
+              </span>
+            </p>
+        </div>
+    </div>
+
     <div class="row">
         <div class="col-md-6">
             <label>Format: <span class="muted-text">(manual alternate <em>{{altInputFormats[0]}}</em>)</span></label> <select class="form-control" ng-model="format" ng-options="f for f in formats"><option></option></select>
+        </div>
+        <div class="col-md-6">
+              <label><input type="checkbox" ng-model="timelessJsonMode" ng-click="toggleJsonMode()" /> Timeless Json Mode:</label>
+              <pre ng-show="timelessJsonMode">Model value is: <em>{{tdt}}</em></pre>
         </div>
     </div>
 

--- a/src/datepicker/docs/demo.js
+++ b/src/datepicker/docs/demo.js
@@ -1,11 +1,14 @@
-angular.module('ui.bootstrap.demo').controller('DatepickerDemoCtrl', function ($scope) {
+angular.module('ui.bootstrap.demo').controller('DatepickerDemoCtrl',
+function ($scope, dateFilter, timelessJsonUtils) {
   $scope.today = function() {
     $scope.dt = new Date();
+    $scope.tdt = dateFilter($scope.dt, 'yyyy-MM-dd');
   };
   $scope.today();
 
   $scope.clear = function() {
     $scope.dt = null;
+    $scope.tdt = null;
   };
 
   // Disable weekend selection
@@ -30,6 +33,7 @@ angular.module('ui.bootstrap.demo').controller('DatepickerDemoCtrl', function ($
 
   $scope.setDate = function(year, month, day) {
     $scope.dt = new Date(year, month, day);
+    $scope.tdt = dateFilter($scope.dt, 'yyyy-MM-dd');
   };
 
   $scope.dateOptions = {
@@ -79,5 +83,14 @@ angular.module('ui.bootstrap.demo').controller('DatepickerDemoCtrl', function ($
     }
 
     return '';
+  };
+
+  $scope.timelessJsonUtils = timelessJsonUtils;
+  $scope.toggleJsonMode = function() {
+    if ($scope.timelessJsonMode) {
+      $scope.tdt = dateFilter($scope.dt, 'yyyy-MM-dd');
+    } else {
+      $scope.dt = timelessJsonUtils.jsonToDate($scope.tdt);
+    }
   };
 });

--- a/src/datepicker/docs/readme.md
+++ b/src/datepicker/docs/readme.md
@@ -95,6 +95,15 @@ The datepicker has 3 modes:
   _(Default: `20`)_ -
   Number of years displayed in year selection.
 
+ * `timeless-json-mode`
+  _(Default: false)_ :
+  Whether to keep models with [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-like dates as 'yyyy-MM-dd' strings
+    * `timeless-json-mode = 'withUtils'` adds `service` `timelessJsonUtils` methods to parent scope
+    * `timelessJsonUtils` methods:
+        * `jsonDateToTicks(date)`: for use with `min-date` and `max-date`
+        * `jsonDateAddDays(date, additionalDays)`: alias of `jsonDateToTicks`
+        * `jsonToDate(date[, ngModel, dateFilter, dateFormat])`: used internally, converts a `ISO 8601`-like date to a `Date` object.
+
 ### uib-datepicker-popup settings ###
 
 Options for the uib-datepicker must be passed as JSON using the `datepicker-options` attribute. This list is only for popup settings.

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1266,6 +1266,99 @@ describe('datepicker', function() {
       });
     });
 
+    describe('datepickerConfig.timelessJsonMode = true', function() {
+      var originalConfig = {};
+      beforeEach(inject(function(uibDatepickerConfig) {
+        angular.extend(originalConfig, uibDatepickerConfig);
+        uibDatepickerConfig.timelessJsonMode = true;
+        $rootScope.date = '2005-11-07T00:00:00.000';
+        element = $compile('<uib-datepicker ng-model="date"></uib-datepicker>')($rootScope);
+        $rootScope.$digest();
+      }));
+
+      afterEach(inject(function(uibDatepickerConfig) {
+        // return it to the original state
+        angular.extend(uibDatepickerConfig, originalConfig);
+      }));
+
+      it('formats model to yyyy-MM-dd on initialization', function() {
+        expect($rootScope.date).toEqual('2005-11-07');
+        expectSelectedElement(8);
+      });
+
+      it('updates the input when a day is clicked', function() {
+        clickOption(9);
+        expect($rootScope.date).toEqual('2005-11-08');
+      });
+    });
+
+    describe('uib-datepicker timeless-json-mode="true"', function() {
+      beforeEach(inject(function() {
+        $rootScope.date = '2005-11-07T00:00:00.000';
+        element = $compile('<uib-datepicker ng-model="date" timeless-json-mode="true"></uib-datepicker>')($rootScope);
+        $rootScope.$digest();
+      }));
+
+      it('formats model to yyyy-MM-dd on initialization', function() {
+        expect($rootScope.date).toEqual('2005-11-07');
+        expectSelectedElement(8);
+      });
+
+      it('updates the input when a day is clicked', function() {
+        clickOption(9);
+        expect($rootScope.date).toEqual('2005-11-08');
+      });
+    });
+
+    describe('uib-datepicker timeless-json-mode="false"', function() {
+      beforeEach(inject(function() {
+        $rootScope.date = '2005-11-07T00:00:00.000';
+        element = $compile('<uib-datepicker ng-model="date" timeless-json-mode="false"></uib-datepicker>')($rootScope);
+        $rootScope.$digest();
+      }));
+
+      it('DOES NOT format model to yyyy-MM-dd on initialization', function() {
+        expect($rootScope.date).not.toEqual('2005-11-07');
+      });
+
+      it('DOES NOT update with format when the input when a day is clicked', function() {
+        clickOption(9);
+        expect($rootScope.date).not.toEqual('2005-11-08');
+      });
+    });
+
+    describe('uibDatepickerConfig.timelessJsonMode = "withUtils"', function() {
+      var originalConfig = {};
+      beforeEach(inject(function(uibDatepickerConfig) {
+        angular.extend(originalConfig, uibDatepickerConfig);
+        uibDatepickerConfig.timelessJsonMode = 'withUtils';
+        $rootScope.date = '2005-11-07T00:00:00.000';
+        element = $compile('<uib-datepicker ng-model="date" max-date="jsonDateToTicks(date, 1)"></uib-datepicker>')($rootScope);
+        $rootScope.$digest();
+      }));
+
+      afterEach(inject(function(uibDatepickerConfig) {
+        // return it to the original state
+        angular.extend(uibDatepickerConfig, originalConfig);
+      }));
+
+      it('jsonDateToTicks/jsonDateAddDays should be on parent scope and work with max-date', function() {
+        expect(getAllOptionsEl().eq(10).prop('disabled')).toBe(true);
+      });
+    });
+
+    describe('uib-datepicker jsonDateToTicks/jsonDateAddDays with timeless-json-mode="withUtils"', function() {
+      beforeEach(inject(function() {
+        $rootScope.date = '2005-11-07T00:00:00.000';
+        element = $compile('<uib-datepicker ng-model="date" timeless-json-mode="withUtils" max-date="jsonDateToTicks(date, 1)"></uib-datepicker>')($rootScope);
+        $rootScope.$digest();
+      }));
+
+      it('jsonDateToTicks/jsonDateAddDays should be on parent scope and work with max-date', function() {
+        expect(getAllOptionsEl().eq(10).prop('disabled')).toBe(true);
+      });
+    });
+
     describe('setting datepickerPopupConfig', function() {
       var originalConfig = {};
       beforeEach(inject(function(uibDatepickerPopupConfig) {
@@ -1284,6 +1377,207 @@ describe('datepicker', function() {
         expect(element.val()).toEqual('09-30-2010');
       });
 
+    });
+
+    describe('uib-datepicker-popup uibDatepickerConfig.timelessJsonMode = true', function() {
+      var inputEl, dropdownEl, $document, $sniffer, $timeout;
+
+      function assignElements(wrapElement) {
+        inputEl = wrapElement.find('input');
+        dropdownEl = wrapElement.find('ul');
+        element = dropdownEl.find('table');
+      }
+
+      beforeEach(inject(function(uibDatepickerConfig) {
+        uibDatepickerConfig.timelessJsonMode = true;
+        $rootScope.date = '2010-09-30T00:00:00.000';
+        $rootScope.isopen = true;
+        var wrapper = $compile('<div><input ng-model="date" uib-datepicker-popup="MM/dd/yyyy" is-open="isopen"></div>')($rootScope);
+        $rootScope.$digest();
+        assignElements(wrapper);
+      }));
+
+      afterEach(inject(function (uibDatepickerConfig) {
+        // return it to the original state
+        delete uibDatepickerConfig.timelessJsonMode;
+      }));
+
+      it('formats model to yyyy-MM-dd on initialization', function() {
+        expect(inputEl.val()).toBe('09/30/2010');
+        expect($rootScope.date).toEqual('2010-09-30');
+      });
+
+      it('updates the input when a day is clicked', function() {
+        clickOption(17);
+        expect(inputEl.val()).toBe('09/15/2010');
+        expect($rootScope.date).toEqual('2010-09-15');
+      });
+    });
+
+    describe('uib-datepicker-popup timeless-json-mode', function() {
+      var inputEl, dropdownEl, $document, $sniffer, $timeout;
+
+      function assignElements(wrapElement) {
+        inputEl = wrapElement.find('input');
+        dropdownEl = wrapElement.find('ul');
+        element = dropdownEl.find('table');
+      }
+
+      beforeEach(inject(function() {
+        $rootScope.date = '2010-09-30T00:00:00.000';
+        $rootScope.isopen = true;
+        var wrapper = $compile('<div><input ng-model="date" uib-datepicker-popup="MM/dd/yyyy" timeless-json-mode is-open="isopen"></div>')($rootScope);
+        $rootScope.$digest();
+        assignElements(wrapper);
+      }));
+
+      it('formats model to yyyy-MM-dd on initialization', function() {
+        expect(inputEl.val()).toBe('09/30/2010');
+        expect($rootScope.date).toEqual('2010-09-30');
+      });
+
+      it('updates the input when a day is clicked', function() {
+        clickOption(17);
+        expect(inputEl.val()).toBe('09/15/2010');
+        expect($rootScope.date).toEqual('2010-09-15');
+      });
+    });
+
+    describe('uib-datepicker-popup timeless-json-mode="false"', function() {
+      var inputEl, dropdownEl, $document, $sniffer, $timeout;
+
+      function assignElements(wrapElement) {
+        inputEl = wrapElement.find('input');
+        dropdownEl = wrapElement.find('ul');
+        element = dropdownEl.find('table');
+      }
+
+      beforeEach(inject(function() {
+        $rootScope.date = '2010-09-30T00:00:00.000';
+        $rootScope.isopen = true;
+        var wrapper = $compile('<div><input ng-model="date" uib-datepicker-popup="MM/dd/yyyy" timeless-json-mode="false" is-open="isopen"></div>')($rootScope);
+        $rootScope.$digest();
+        assignElements(wrapper);
+      }));
+
+      it('DOES NOT format model to yyyy-MM-dd on initialization', function() {
+        expect(inputEl.val()).toBe('09/30/2010');
+        expect($rootScope.date).not.toEqual('2010-09-30');
+      });
+
+      it('DOES NOT update with format the input when a day is clicked', function() {
+        clickOption(17);
+        expect(inputEl.val()).toBe('09/15/2010');
+        expect($rootScope.date).not.toEqual('2010-09-15');
+      });
+    });
+
+    describe('uib-datepicker-popup uibDatepickerConfig.timelessJsonMode = true with HTML5', function() {
+      var inputEl, dropdownEl, $document, $sniffer, $timeout;
+
+      function assignElements(wrapElement) {
+        inputEl = wrapElement.find('input');
+        dropdownEl = wrapElement.find('ul');
+        element = dropdownEl.find('table');
+      }
+
+      beforeEach(inject(function(uibDatepickerConfig) {
+        uibDatepickerConfig.timelessJsonMode = true;
+        $rootScope.date = '2010-09-30T00:00:00.000';
+        $rootScope.isopen = true;
+        var wrapper = $compile('<div><input type="date" ng-model="date" uib-datepicker-popup is-open="isopen"></div>')($rootScope);
+        $rootScope.$digest();
+        assignElements(wrapper);
+      }));
+
+      afterEach(inject(function (uibDatepickerConfig) {
+        // return it to the original state
+        delete uibDatepickerConfig.timelessJsonMode;
+      }));
+
+      it('formats model to yyyy-MM-dd on initialization', function() {
+        expect(inputEl.val()).toBe('2010-09-30');
+        expect($rootScope.date).toEqual('2010-09-30');
+      });
+
+      it('updates the input when a day is clicked', function() {
+        clickOption(17);
+        expect(inputEl.val()).toBe('2010-09-15');
+        expect($rootScope.date).toEqual('2010-09-15');
+      });
+    });
+
+    describe('jsonDateUtils service: timelessJsonUtils.jsonDateToTicks', function() {
+      var inputEl, dropdownEl, $document, $sniffer, $timeout;
+
+      function assignElements(wrapElement) {
+        inputEl = wrapElement.find('input');
+        dropdownEl = wrapElement.find('ul');
+        element = dropdownEl.find('table');
+      }
+
+      beforeEach(inject(function(timelessJsonUtils) {
+        $rootScope.toTicks = timelessJsonUtils.jsonDateToTicks;
+        $rootScope.date = '2010-09-15T00:00:00.000';
+        $rootScope.isopen = true;
+        var wrapper = $compile('<div><input ng-model="date" uib-datepicker-popup="MM/dd/yyyy" timeless-json-mode max-date="toTicks(date, 1)" is-open="isopen"></div>')($rootScope);
+        $rootScope.$digest();
+        assignElements(wrapper);
+      }));
+
+      it('service method jsonDateUtils.jsonDateToTicks should work with max-date', function() {
+        expect(getAllOptionsEl().eq(19).prop('disabled')).toBe(true);
+      });
+    });
+
+    describe('uib-datepicker-popup uibDatepickerConfig.timelessJsonMode = "withUtils"', function() {
+      var inputEl, dropdownEl, $document, $sniffer, $timeout;
+
+      function assignElements(wrapElement) {
+        inputEl = wrapElement.find('input');
+        dropdownEl = wrapElement.find('ul');
+        element = dropdownEl.find('table');
+      }
+
+      beforeEach(inject(function(uibDatepickerConfig) {
+        uibDatepickerConfig.timelessJsonMode = 'withUtils';
+        $rootScope.date = '2010-09-15T00:00:00.000';
+        $rootScope.isopen = true;
+        var wrapper = $compile('<div><input ng-model="date" uib-datepicker-popup="MM/dd/yyyy" max-date="jsonDateAddDays(date, 1)" is-open="isopen"></div>')($rootScope);
+        $rootScope.$digest();
+        assignElements(wrapper);
+      }));
+
+      afterEach(inject(function (uibDatepickerConfig) {
+        // return it to the original state
+        delete uibDatepickerConfig.timelessJsonMode;
+      }));
+
+      it('jsonDateToTicks/jsonDateAddDays should be on parent scope and work with max-date', function() {
+        expect(getAllOptionsEl().eq(19).prop('disabled')).toBe(true);
+      });
+    });
+
+    describe('uib-datepicker-popup jsonDateToTicks/jsonDateAddDays with timeless-json-mode="withUtils"', function() {
+      var inputEl, dropdownEl, $document, $sniffer, $timeout;
+
+      function assignElements(wrapElement) {
+        inputEl = wrapElement.find('input');
+        dropdownEl = wrapElement.find('ul');
+        element = dropdownEl.find('table');
+      }
+
+      beforeEach(inject(function() {
+        $rootScope.date = '2010-09-15T00:00:00.000';
+        $rootScope.isopen = true;
+        var wrapper = $compile('<div><input ng-model="date" uib-datepicker-popup="MM/dd/yyyy" timeless-json-mode="withUtils" timeless-json-utils max-date="jsonDateToTicks(date, 1)" is-open="isopen"></div>')($rootScope);
+        $rootScope.$digest();
+        assignElements(wrapper);
+      }));
+
+      it('jsonDateToTicks/jsonDateAddDays should be on parent scope and work with max-date', function() {
+        expect(getAllOptionsEl().eq(19).prop('disabled')).toBe(true);
+      });
     });
 
     describe('setting datepickerPopupConfig inside ng-if', function() {
@@ -1675,6 +1969,28 @@ describe('datepicker', function() {
 
           it('shows the correct title', function() {
             expect(getTitle()).toBe('November 1980');
+          });
+        });
+
+        describe('timelessJsonMode', function() {
+          beforeEach(inject(function() {
+              $rootScope.date = new Date('November 07, 2005');
+              $rootScope.opts = {
+                'timelessJsonMode': true
+              };
+              var wrapElement = $compile('<div><input ng-model="date" uib-datepicker-popup datepicker-options="opts" is-open="true"></div>')($rootScope);
+              $rootScope.$digest();
+              assignElements(wrapElement);
+          }));
+
+          it('formats model to yyyy-MM-dd on initialization', function() {
+            expect($rootScope.date).toEqual('2005-11-07');
+            expectSelectedElement(8);
+          });
+
+          it('updates the input when a day is clicked', function() {
+            clickOption(9);
+            expect($rootScope.date).toEqual('2005-11-08');
           });
         });
       });


### PR DESCRIPTION
datepickerConfig option timelessJsonMode for json models when we don't care about the time.
* also available as attribute or via datepicker-options
* on init and parse: sets model to 'yyyy-MM-dd' format
* on format: converts model to date before normal formatting
* timelessJsonUtils constant with method jsonDateToTicks for use with min-date, max-date
	* alias jsonDateAddDays
	* set timelessJsonMode = 'withUtils' to add methods to parent scope
	* also: jsonToDate -- used internally

[plunker](http://plnkr.co/edit/WzoImdpZtQcQDfN7AN5e?p=preview)
[codepen](http://codepen.io/davious/pen/qOXNZY?editors=101)

Related: #1891, #2906, #2952

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/bootstrap/4218)
<!-- Reviewable:end -->
