### PR TITLE
test(datepicker): fix incorrect format used in `hh` test

### DIFF
--- a/src/dateparser/test/dateparser.spec.js
+++ b/src/dateparser/test/dateparser.spec.js
@@ -71,7 +71,7 @@ describe('date parser', function() {
     it('should work correctly for `hh`', function() {
       expectParse('22.March.15.22', 'd.MMMM.yy.hh', undefined);
       expectParse('22.March.15.12', 'd.MMMM.yy.hh', new Date(2015, 2, 22, 12));
-      expectParse('8-March-1991-11', 'd-MMMM-yyyy-HH', new Date(1991, 2, 8, 11));
+      expectParse('8-March-1991-11', 'd-MMMM-yyyy-hh', new Date(1991, 2, 8, 11));
       expectParse('February/5/1980/00', 'MMMM/d/yyyy/hh', new Date(1980, 1, 5, 0));
       expectParse('1955/February/5 03', 'yyyy/MMMM/d hh', new Date(1955, 1, 5, 3));
       expectParse('11-08-13 23', 'd-MM-yy hh', undefined);


### PR DESCRIPTION
I noticed while making my other PR that one of the `hh` test actual uses `HH` in the format string. This PR fixes this minor typo.