### PR TITLE
avoid the cannot read isOpen of null bug

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -234,6 +234,8 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position'])
 
             // Hide the tooltip popup element.
             function hide() {
+              if (!ttScope) return; // If no longer exists
+              
               // First things first: we don't show it anymore.
               ttScope.isOpen = false;
               if (isOpenExp) {


### PR DESCRIPTION
if in an ng-repeat and you delete item from array, if tooltip showing, you get "cannot read isOpen of null". this is a fix for that.