### PR TITLE
avoid the cannot read isOpen of null bug

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -234,8 +234,10 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position'])
 
             // Hide the tooltip popup element.
             function hide() {
-              if (!ttScope) return; // If no longer exists
-              
+              if (!ttScope) {
+                return;
+              }
+
               // First things first: we don't show it anymore.
               ttScope.isOpen = false;
               if (isOpenExp) {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -234,6 +234,8 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position'])
 
             // Hide the tooltip popup element.
             function hide() {
+              if (!ttScope) return; // If no longer exists
+              
               // First things first: we don't show it anymore.
               ttScope.isOpen = false;
               if (isOpenExp) {


### PR DESCRIPTION
When removing an item that has a tooltip showing from an ng-repeat, you can get an "isOpen of null" bug. This prevents that.