### PR TITLE
fix(tooltip): tooltip appears on wrong position by a fraction of a second

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -110,6 +110,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position'])
           'animation="animation" '+
           'is-open="isOpen"'+
           'origin-scope="origScope" '+
+          'style="visibility: hidden"'+
           '>'+
         '</div>';
 
@@ -138,7 +139,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position'])
               if (!positionTimeout) {
                 positionTimeout = $timeout(function() {
                   // Reset the positioning and box size for correct width and height values.
-                  tooltip.css({ top: 0, left: 0, width: 'auto', height: 'auto', visibility: 'none' });
+                  tooltip.css({ top: 0, left: 0, width: 'auto', height: 'auto', visibility: 'hidden' });
 
                   var ttBox = $position.position(tooltip);
                   var ttCss = $position.positionElements(element, tooltip, ttScope.placement, appendToBody);
@@ -227,8 +228,6 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position'])
               if (!$rootScope.$$phase) {
                 ttScope.$apply(); // digest required as $apply is not called
               }
-
-              tooltip.css({ display: 'block', visibility: 'hidden' });
 
               positionTooltip();
             }

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -132,12 +132,13 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position'])
             var isOpenExp = angular.isDefined(attrs[prefix + 'IsOpen']) ? $parse(attrs[prefix + 'IsOpen']) : false;
 
             var positionTooltip = function() {
-              if (!tooltip) { return; }
+              // check if tooltip exists and is not empty
+              if (!tooltip || !tooltip.html()) { return; }
 
               if (!positionTimeout) {
                 positionTimeout = $timeout(function() {
                   // Reset the positioning and box size for correct width and height values.
-                  tooltip.css({ top: 0, left: 0, width: 'auto', height: 'auto' });
+                  tooltip.css({ top: 0, left: 0, width: 'auto', height: 'auto', visibility: 'none' });
 
                   var ttBox = $position.position(tooltip);
                   var ttCss = $position.positionElements(element, tooltip, ttScope.placement, appendToBody);


### PR DESCRIPTION
- Avoid position computation when tooltip is empty
- Force visibility to none when resetting style

Fixes: #4195