### PR TITLE
Accordion: don't toggle open class when is-open is undefined

### DIFF
--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -82,7 +82,7 @@ angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse'])
       scope.openClass = attrs.openClass || 'panel-open';
       scope.panelClass = attrs.panelClass;
       scope.$watch('isOpen', function(value) {
-        element.toggleClass(scope.openClass, value);
+        element.toggleClass(scope.openClass, Boolean(value));
         if (value) {
           accordionCtrl.closeOthers(scope);
         }


### PR DESCRIPTION
If `is-open` is not set the accordion group is closed, but the open class will be toggled, because jQuery expects a string or boolean (ignores undefined). See here: https://github.com/jquery/jquery/blob/c9cf250daafe806818da1dd207a88a8e94a4ad16/src/attributes/classes.js#L105