### PR TITLE
fix(datepicker): focus input on keyboard selection in popup

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -210,10 +210,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
         return; // do nothing
       }
       $scope.select(self.activeDate);
-      focusElement();
     } else if (evt.ctrlKey && (key === 'up' || key === 'down')) {
       $scope.toggleMode(key === 'up' ? 1 : -1);
-      focusElement();
     } else {
       self.handleKeyDown(key, evt);
       self.refreshView();


### PR DESCRIPTION
removed the `focusElement()` call from keydown handler so that the popup control is not focused after selecting a date with the keyboard. instead, the focus stays with the input, as called from `dateSelected()`