### PR TITLE
Corrected the meridian threshold when determining if toggling should be allowed in the timepicker.

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -92,7 +92,7 @@ angular.module('ui.bootstrap.timepicker', [])
   };
 
   $scope.noToggleMeridian = function() {
-    if (selected.getHours() < 13) {
+    if (selected.getHours() < 12) {
       return addMinutes(selected, 12 * 60) > max;
     } else {
       return addMinutes(selected, -12 * 60) < min;


### PR DESCRIPTION
Edited the noToggleMeridian method in the timepicker directive to correctly compare against 12 (instead of 13) when determining if the resulting time should be compared against the minimum or the maximum. If the selected time was after noon, the resulting time after toggling would be in the morning of the same day, and should be compared against the minimum and not the maximum.