### PR TITLE
refactor(tooltip): rollup commit for several issues

### DIFF
--- a/src/popover/test/popover-html.spec.js
+++ b/src/popover/test/popover-html.spec.js
@@ -35,16 +35,20 @@ describe('popover', function() {
 
   it('should open on click', inject(function() {
     elm.trigger('click');
-    expect( tooltipScope.isOpen ).toBe(true);
+    tooltipScope.$digest();
+    expect(tooltipScope.isOpen).toBe(true);
 
     // We can only test *that* the popover-popup element was created as the
     // implementation is templated and replaced.
-    expect( elmBody.children().length ).toBe(2);
+    expect(elmBody.children().length).toBe(2);
   }));
 
   it('should close on second click', inject(function() {
     elm.trigger('click');
+    tooltipScope.$digest();
+    expect(tooltipScope.isOpen).toBe(true);
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(false);
   }));
 
@@ -53,6 +57,7 @@ describe('popover', function() {
     scope.$digest();
 
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(false);
 
     expect(elmBody.children().length).toBe(1);
@@ -63,6 +68,7 @@ describe('popover', function() {
     scope.$digest();
 
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(true);
 
     expect(elmBody.children().eq(1).text().trim()).toBe('My template');
@@ -75,6 +81,7 @@ describe('popover', function() {
 
   it('should hide popover when template becomes empty', inject(function($timeout) {
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(true);
 
     scope.template = '';
@@ -101,7 +108,9 @@ describe('popover', function() {
     elm = elmBody.find('input');
 
     elm.trigger('mouseenter');
+    tooltipScope.$digest();
     elm.trigger('mouseleave');
+    tooltipScope.$digest();
     expect(scope.clicked).toBeFalsy();
 
     elm.click();
@@ -109,8 +118,9 @@ describe('popover', function() {
   }));
 
   it('should popup with animate class by default', inject(function() {
-    elm.trigger( 'click' );
-    expect( tooltipScope.isOpen ).toBe( true );
+    elm.trigger('click');
+    tooltipScope.$digest();
+    expect(tooltipScope.isOpen).toBe(true);
 
     expect(elmBody.children().eq(1)).toHaveClass('fade');
   }));
@@ -127,6 +137,7 @@ describe('popover', function() {
     tooltipScope = elmScope.$$childTail;
 
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(true);
     expect(elmBody.children().eq(1)).not.toHaveClass('fade');
   }));
@@ -144,6 +155,7 @@ describe('popover', function() {
         tooltipScope = elmScope.$$childTail;
 
         elm.trigger('click');
+        tooltipScope.$digest();
         expect(tooltipScope.isOpen).toBe(true);
 
         expect(elmBody.children().length).toBe(2);
@@ -165,6 +177,7 @@ describe('popover', function() {
         tooltipScope = elmScope.$$childTail;
 
         elm.trigger('click');
+        tooltipScope.$digest();
         expect(tooltipScope.isOpen).toBe(true);
 
         expect(elmBody.children().length).toBe(2);
@@ -174,5 +187,3 @@ describe('popover', function() {
     });
   });
 });
-
-

--- a/src/popover/test/popover-template.spec.js
+++ b/src/popover/test/popover-template.spec.js
@@ -32,10 +32,11 @@ describe('popover template', function() {
   }));
 
   it('should open on click', inject(function() {
-    elm.trigger( 'click' );
-    expect( tooltipScope.isOpen ).toBe( true );
+    elm.trigger('click');
+    tooltipScope.$digest();
+    expect(tooltipScope.isOpen).toBe(true);
 
-    expect( elmBody.children().length ).toBe( 2 );
+    expect(elmBody.children().length ).toBe(2);
   }));
 
   it('should not open on click if templateUrl is empty', inject(function() {
@@ -43,6 +44,7 @@ describe('popover template', function() {
     scope.$digest();
 
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(false);
 
     expect(elmBody.children().length).toBe(1);
@@ -50,11 +52,12 @@ describe('popover template', function() {
 
   it('should show updated text', inject(function() {
     scope.myTemplateText = 'some text';
-    scope.$digest();
 
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(true);
 
+    scope.$digest();
     expect(elmBody.children().eq(1).text().trim()).toBe('some text');
 
     scope.myTemplateText = 'new text';
@@ -65,6 +68,7 @@ describe('popover template', function() {
 
   it('should hide popover when template becomes empty', inject(function($timeout) {
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(true);
 
     scope.templateUrl = '';
@@ -89,6 +93,7 @@ describe('popover template', function() {
         tooltipScope = elmScope.$$childTail;
 
         elm.trigger('click');
+        tooltipScope.$digest();
         expect(tooltipScope.isOpen).toBe(true);
 
         expect(elmBody.children().length).toBe(2);
@@ -110,6 +115,7 @@ describe('popover template', function() {
         tooltipScope = elmScope.$$childTail;
 
         elm.trigger('click');
+        tooltipScope.$digest();
         expect(tooltipScope.isOpen).toBe(true);
 
         expect(elmBody.children().length).toBe(2);

--- a/src/popover/test/popover.spec.js
+++ b/src/popover/test/popover.spec.js
@@ -34,6 +34,7 @@ describe('popover', function() {
 
   it('should open on click', inject(function() {
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(true);
 
     // We can only test *that* the popover-popup element was created as the
@@ -43,7 +44,10 @@ describe('popover', function() {
 
   it('should close on second click', inject(function() {
     elm.trigger('click');
+    tooltipScope.$digest();
+    expect(tooltipScope.isOpen).toBe(true);
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(false);
   }));
 
@@ -70,6 +74,7 @@ describe('popover', function() {
 
   it('should popup with animate class by default', inject(function() {
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(true);
 
     expect(elmBody.children().eq(1)).toHaveClass('fade');
@@ -87,6 +92,7 @@ describe('popover', function() {
     tooltipScope = elmScope.$$childTail;
 
     elm.trigger('click');
+    tooltipScope.$digest();
     expect(tooltipScope.isOpen).toBe(true);
     expect(elmBody.children().eq(1)).not.toHaveClass('fade');
   }));
@@ -104,6 +110,7 @@ describe('popover', function() {
         tooltipScope = elmScope.$$childTail;
 
         elm.trigger('click');
+        tooltipScope.$digest();
         expect(tooltipScope.isOpen).toBe(true);
 
         expect(elmBody.children().length).toBe(2);
@@ -124,6 +131,7 @@ describe('popover', function() {
         tooltipScope = elmScope.$$childTail;
 
         elm.trigger('click');
+        tooltipScope.$digest();
         expect(tooltipScope.isOpen).toBe(true);
 
         expect(elmBody.children().length).toBe(2);
@@ -131,8 +139,8 @@ describe('popover', function() {
         expect(ttipElement).toHaveClass('custom');
       }));
     });
-    
-    describe( 'is-open', function() {
+
+    describe('is-open', function() {
       beforeEach(inject(function ($compile) {
         scope.isOpen = false;
         elmBody = angular.element(
@@ -144,8 +152,8 @@ describe('popover', function() {
         elmScope = elm.scope();
         tooltipScope = elmScope.$$childTail;
       }));
-      
-      it( 'should show and hide with the controller value', function() {
+
+      it('should show and hide with the controller value', function() {
         expect(tooltipScope.isOpen).toBe(false);
         elmScope.isOpen = true;
         elmScope.$digest();
@@ -154,11 +162,13 @@ describe('popover', function() {
         elmScope.$digest();
         expect(tooltipScope.isOpen).toBe(false);
       });
-      
-      it( 'should update the controller value', function() {
+
+      it('should update the controller value', function() {
         elm.trigger('click');
+        tooltipScope.$digest();
         expect(elmScope.isOpen).toBe(true);
         elm.trigger('click');
+        tooltipScope.$digest();
         expect(elmScope.isOpen).toBe(false);
       });
     });

--- a/src/tooltip/test/tooltip-template.spec.js
+++ b/src/tooltip/test/tooltip-template.spec.js
@@ -34,6 +34,7 @@ describe('tooltip template', function() {
     evt = new Event(evt);
 
     element[0].dispatchEvent(evt);
+    element.scope().$$childTail.$digest();
   }
 
   it('should open on mouseenter', inject(function() {
@@ -55,10 +56,10 @@ describe('tooltip template', function() {
 
   it('should show updated text', inject(function() {
     scope.myTemplateText = 'some text';
-    scope.$digest();
 
     trigger(elm, 'mouseenter');
     expect(tooltipScope.isOpen).toBe(true);
+    scope.$digest();
 
     expect(elmBody.children().eq(1).text().trim()).toBe('some text');
 

--- a/src/tooltip/test/tooltip2.spec.js
+++ b/src/tooltip/test/tooltip2.spec.js
@@ -45,6 +45,7 @@ describe('tooltip directive', function() {
 
   function closeTooltip(hostEl, triggerEvt, shouldNotFlush) {
     trigger(hostEl, triggerEvt || 'mouseleave');
+    hostEl.scope().$$childTail.$digest();
     if (!shouldNotFlush) {
       $timeout.flush();
     }
@@ -54,6 +55,7 @@ describe('tooltip directive', function() {
     evt = new Event(evt);
 
     element[0].dispatchEvent(evt);
+    element.scope().$$childTail.$digest();
   }
 
   describe('basic scenarios with default options', function() {


### PR DESCRIPTION
This is a rollup commit intended to address several
issues around the positioning and parsing of
attributes.

- Fixes issue introduced under PR #4311 where setting
  height and width in tooltip position function
  messed up arrow placement.
- Fixes issue introduced under PR #4363 where setting
  visibility to hidden in tooltip position function
  caused elements in popover to lose focus.
- Fixes issue #1780 where tooltip would render if
  content was just whitespace.
- Fixes issue #3347 where tooltip isolate scope was
  being accessed after it was set to null.  Observers
  will now be created/destroyed as tooltip opens/closes
  which will also offer a performance improvement.
- Fixes issue #3557 by implementing evalAsync to set
  tooltip scope isOpen property.
- Fixes issue #4335 where if model isOpen property is
  undefined, tooltip would call show/hide toggle function.
- Closes PR #4429 where how the templated content
  was being evaluated could cause an infinite digest loop.

Closes #4400
Closes #4418
Closes #4429
Closes #4431

Fixes #1780
Fixes #3347
Fixes #3557
Fixes #4321
Fixes #4335