### PR TITLE
Enabled typeahead popup scroll

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -379,7 +379,8 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position'])
           if (evt.which === 40) {
             scope.activeIdx = (scope.activeIdx + 1) % scope.matches.length;
             scope.$digest();
-
+            popUpEl.children()[scope.activeIdx].scrollIntoView(false);
+            
           } else if (evt.which === 38) {
             scope.activeIdx = (scope.activeIdx > 0 ? scope.activeIdx : scope.matches.length) - 1;
             scope.$digest();
@@ -498,19 +499,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position'])
       }
     };
   }])
-
-  .directive('shouldFocus', function(){
-     return {
-       restrict: 'A',
-       link: function(scope,element,attrs){
-         scope.$watch(attrs.shouldFocus,function(newValue,oldValue){
-           if (newValue) { 
-            element[0].scrollIntoView(false);
-          }  
-         });
-       }
-     };
-  })
 
   .filter('typeaheadHighlight', ['$sce', '$injector', '$log', function($sce, $injector, $log) {
     var isSanitizePresent;

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -499,6 +499,19 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position'])
     };
   }])
 
+  .directive('focusMe', function(){
+     return {
+       restrict: 'A',
+       link: function(scope,element,attrs){
+         scope.$watch(attrs.shouldFocus,function(newValue,oldValue){
+           if (newValue) { 
+            element[0].scrollIntoView(false);
+          }  
+         });
+       }
+     };
+  })
+
   .filter('typeaheadHighlight', ['$sce', '$injector', '$log', function($sce, $injector, $log) {
     var isSanitizePresent;
     isSanitizePresent = $injector.has('$sanitize');

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -499,7 +499,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position'])
     };
   }])
 
-  .directive('focusMe', function(){
+  .directive('shouldFocus', function(){
      return {
        restrict: 'A',
        link: function(scope,element,attrs){

--- a/template/typeahead/typeahead-popup.html
+++ b/template/typeahead/typeahead-popup.html
@@ -1,5 +1,5 @@
 <ul class="dropdown-menu" ng-show="isOpen() && !moveInProgress" ng-style="{top: position().top+'px', left: position().left+'px'}" style="display: block;" role="listbox" aria-hidden="{{!isOpen()}}">
-    <li ng-repeat="match in matches track by $index" focus-me="isActive($index)" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index)" role="option" id="{{::match.id}}">
+    <li ng-repeat="match in matches track by $index" should-focus="isActive($index)" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index)" role="option" id="{{::match.id}}">
         <div typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>
     </li>
 </ul>

--- a/template/typeahead/typeahead-popup.html
+++ b/template/typeahead/typeahead-popup.html
@@ -1,5 +1,5 @@
 <ul class="dropdown-menu" ng-show="isOpen() && !moveInProgress" ng-style="{top: position().top+'px', left: position().left+'px'}" style="display: block;" role="listbox" aria-hidden="{{!isOpen()}}">
-    <li ng-repeat="match in matches track by $index" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index)" role="option" id="{{::match.id}}">
+    <li ng-repeat="match in matches track by $index" focus-me="isActive($index)" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index)" role="option" id="{{::match.id}}">
         <div typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>
     </li>
 </ul>

--- a/template/typeahead/typeahead-popup.html
+++ b/template/typeahead/typeahead-popup.html
@@ -1,5 +1,5 @@
 <ul class="dropdown-menu" ng-show="isOpen() && !moveInProgress" ng-style="{top: position().top+'px', left: position().left+'px'}" style="display: block;" role="listbox" aria-hidden="{{!isOpen()}}">
-    <li ng-repeat="match in matches track by $index" should-focus="isActive($index)" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index)" role="option" id="{{::match.id}}">
+    <li ng-repeat="match in matches track by $index" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index)" role="option" id="{{::match.id}}">
         <div typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>
     </li>
 </ul>


### PR DESCRIPTION
Enabled scrolling on key up/down event on typeahead (custom) popup template. 
This is particularly useful if using custom template with fixed or max height. For popup exceeding results, scrolling with moose and keys can be used.
This is not my code (I did not write it) but I found it online (someone put it on plunker).
But it works and I think it would be of great use!