### PR TITLE
Datepicker issue3879

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ node_modules
 npm-debug.log
 
 template/**/*.js
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ npm-debug.log
 
 template/**/*.js
 
-.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -370,7 +370,7 @@ module.exports = function(grunt) {
         grunt.config.set('karma.options', karmaOptions);
       }
       grunt.task.run(this.args.length ? 'karma:jenkins' : 'karma:continuous');
-      //grunt.task.run('karma:continuous');
+      grunt.task.run('karma:continuous');
     }
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -370,7 +370,6 @@ module.exports = function(grunt) {
         grunt.config.set('karma.options', karmaOptions);
       }
       grunt.task.run(this.args.length ? 'karma:jenkins' : 'karma:continuous');
-      grunt.task.run('karma:continuous');
     }
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -370,6 +370,7 @@ module.exports = function(grunt) {
         grunt.config.set('karma.options', karmaOptions);
       }
       grunt.task.run(this.args.length ? 'karma:jenkins' : 'karma:continuous');
+      //grunt.task.run('karma:continuous');
     }
   });
 

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -78,13 +78,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
   $scope.isActive = function(dateObject) {
     var compareDate = typeof self.otherMonthSelectedDate !== 'undefined' ? self.otherMonthSelectedDate : self.activeDate;
-    /*if (typeof self.otherMonthSelectedDate !== 'undefined') {
-      if (self.compare(dateObject.date, self.otherMonthSelectedDate) === 0) {
-        $scope.activeDateId = dateObject.uid;
-        return true;
-      }
-      return false;
-    }*/
+
     if (self.compare(dateObject.date, compareDate) === 0) {
       if (self.ignoreDateCompare) {
         return false;
@@ -197,6 +191,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
         prevValue = ngModelCtrl.$modelValue.getTime();
       }
 
+      //calculate the start date in the calendar view based on which day of the week activeDate is
       var start = new Date(self.activeDate.getTime());
       //if from is a monday we keep it as it is
       if (start.getDay() !== 1) {
@@ -218,6 +213,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       end.setFullYear(nextYear, nextMonth, 1);
       end = end.getTime();
       var oneDay = 86400000;
+      //add days to the end date to get the correct end date for the calendar view
       var numberofDays = (end-start)/oneDay;
 
       var days2Add = 42 - Math.round(numberofDays);
@@ -232,6 +228,9 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
         self.ignoreDateCompare = false;
         var tmp = new Date(prevValue);
         if (tmp.getMonth() !== month) {
+          /*need an extra variable to keep track on a selected date at the end of the previous month
+            or in the beginning of the next month
+          */
           self.otherMonthSelectedDate = tmp;
         } else {
           self.otherMonthSelectedDate = undefined;
@@ -246,69 +245,11 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     var year = self.activeDate.getFullYear() + direction * (self.step.years || 0),
         month = self.activeDate.getMonth() + direction * (self.step.months || 0);
     self.activeDate.setFullYear(year, month, 1);
-    /*if ($scope.datepickerMode === 'day') {
-      self.calculateDateinterval();
-    } else {
-      self.clearIntervalVars();
-    }*/
     self.calculateDateinterval();
-    /*
-    if (typeof ngModelCtrl.$modelValue !== 'undefined' && ngModelCtrl.$modelValue !== null) {
-      var prevValue = undefined;
-      if (typeof ngModelCtrl.$modelValue === 'string' || ngModelCtrl.$modelValue instanceof String) {
-          prevValue = Date.parse(ngModelCtrl.$modelValue);
-      } else {
-          prevValue = ngModelCtrl.$modelValue.getTime();
-      }
-
-      var start = new Date(self.activeDate.getTime());
-      //if from is a monday we keep it as it is
-      if (start.getDay() !== 1) {
-        start.setFullYear(year, month, 0); //set last day previous month
-        var day = start.getDay();
-        if (day === 0) {
-          day = 5;
-        } else if (day > 0) {
-          day = day - 1;
-        }
-        start.setFullYear(year, month, -day);
-      }
-
-      start = start.getTime();
-
-      var nextYear = month === 11 ? year+1 : year;
-      var nextMonth = month+1 % 12;
-      var end = new Date(self.activeDate.getTime());
-      end.setFullYear(nextYear, nextMonth, 1);
-      end = end.getTime();
-      var oneDay = 86400000;
-      var numberofDays = (end-start)/oneDay;
-
-      var days2Add = 42 - Math.round(numberofDays);
-      end = new Date(end);
-      end.setFullYear(nextYear, nextMonth, days2Add);
-      var tmpDate = new Date(start);
-
-      end = end.getTime();
-      if (!(start <= prevValue && prevValue <= end)) {
-        self.ignoreDateCompare = true;
-      } else {
-        self.ignoreDateCompare = false;
-        var tmp = new Date(prevValue);
-        if (tmp.getMonth() !== month) {
-          self.otherMonthSelectedDate = tmp;
-        } else {
-          self.otherMonthSelectedDate = undefined;
-          self.activeDate = tmp;
-        }
-
-      }
-    }*/
     self.refreshView();
   };
 
   $scope.toggleMode = function(direction) {
-    //self.clearIntervalVars();
     direction = direction || 1;
 
     if (($scope.datepickerMode === self.maxMode && direction === 1) || ($scope.datepickerMode === self.minMode && direction === -1)) {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -222,7 +222,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       var tmpDate = new Date(start);
 
       end = end.getTime();
-      if (!(start <= prevValue && prevValue <= end)) {
+      if (start > prevValue || prevValue > end) {
         self.ignoreDateCompare = true;
       } else {
         self.ignoreDateCompare = false;

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -183,7 +183,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   this.calculateDateinterval = function () {
     var year = self.activeDate.getFullYear();
     var month = self.activeDate.getMonth();
-    if (typeof ngModelCtrl.$modelValue !== 'undefined' && ngModelCtrl.$modelValue !== null) {
+    if (angular.isDefined(ngModelCtrl.$modelValue) && ngModelCtrl.$modelValue !== null) {
       var prevValue;
       if (angular.isString(ngModelCtrl.$modelValue)) {
         prevValue = Date.parse(ngModelCtrl.$modelValue);

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -191,10 +191,18 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       }
 
       var from = new Date(self.activeDate.getTime());
-      var day = self.activeDate.getDay();
-      if (day !== 0) {
+      //if from is a monday we keep it as it is
+      if (from.getDay() !== 1) {
+        from.setFullYear(year, month, 0); //set last day previous month
+        var day = from.getDay();
+        if (day === 0) {
+          day = 5;
+        } else if (day > 0) {
+          day = day - 1;
+        }
         from.setFullYear(year, month, -day);
       }
+
       from = from.getTime();
 
       var nextYear = month === 11 ? year+1 : year;
@@ -202,7 +210,16 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       var tom = new Date(self.activeDate.getTime());
       tom.setFullYear(nextYear, nextMonth, 1);
       tom = tom.getTime();
-      if (!(from <= prevValue && prevValue < tom)) {
+      var oneDay = 86400000;
+      var numberofDays = (tom-from)/oneDay;
+
+      var days2Add = 42 - Math.round(numberofDays);
+      tom = new Date(tom);
+      tom.setFullYear(nextYear, nextMonth, days2Add);
+      var tmpDate = new Date(from);
+      
+      tom = tom.getTime();
+      if (!(from <= prevValue && prevValue <= tom)) {
         self.directionChanged = true;
       } else {
         self.directionChanged = false;

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -184,7 +184,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     var year = self.activeDate.getFullYear();
     var month = self.activeDate.getMonth();
     if (typeof ngModelCtrl.$modelValue !== 'undefined' && ngModelCtrl.$modelValue !== null) {
-      var prevValue = undefined;
+      var prevValue;
       if (typeof ngModelCtrl.$modelValue === 'string' || ngModelCtrl.$modelValue instanceof String) {
         prevValue = Date.parse(ngModelCtrl.$modelValue);
       } else {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -207,8 +207,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
       start = start.getTime();
 
-      var nextYear = month === 11 ? year+1 : year;
-      var nextMonth = month+1 % 12;
+      var nextYear = month === 11 ? year + 1 : year;
+      var nextMonth = month + 1 % 12;
       var end = new Date(self.activeDate.getTime());
       end.setFullYear(nextYear, nextMonth, 1);
       end = end.getTime();

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -176,7 +176,69 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       ngModelCtrl.$render();
     } else {
       self.activeDate = date;
+      self.calculateDateinterval();
       $scope.datepickerMode = self.modes[self.modes.indexOf($scope.datepickerMode) - 1];
+    }
+  };
+
+  this.clearIntervalVars = function () {
+    self.ignoreDateCompare = false;
+    self.otherMonthSelectedDate = undefined;
+  };
+
+  this.calculateDateinterval = function () {
+    var year = self.activeDate.getFullYear();
+    var month = self.activeDate.getMonth();
+    if (typeof ngModelCtrl.$modelValue !== 'undefined' && ngModelCtrl.$modelValue !== null) {
+      var prevValue = undefined;
+      if (typeof ngModelCtrl.$modelValue === 'string' || ngModelCtrl.$modelValue instanceof String) {
+        prevValue = Date.parse(ngModelCtrl.$modelValue);
+      } else {
+        prevValue = ngModelCtrl.$modelValue.getTime();
+      }
+
+      var start = new Date(self.activeDate.getTime());
+      //if from is a monday we keep it as it is
+      if (start.getDay() !== 1) {
+        start.setFullYear(year, month, 0); //set last day previous month
+        var day = start.getDay();
+        if (day === 0) {
+          day = 5;
+        } else if (day > 0) {
+          day = day - 1;
+        }
+        start.setFullYear(year, month, -day);
+      }
+
+      start = start.getTime();
+
+      var nextYear = month === 11 ? year+1 : year;
+      var nextMonth = month+1 % 12;
+      var end = new Date(self.activeDate.getTime());
+      end.setFullYear(nextYear, nextMonth, 1);
+      end = end.getTime();
+      var oneDay = 86400000;
+      var numberofDays = (end-start)/oneDay;
+
+      var days2Add = 42 - Math.round(numberofDays);
+      end = new Date(end);
+      end.setFullYear(nextYear, nextMonth, days2Add);
+      var tmpDate = new Date(start);
+
+      end = end.getTime();
+      if (!(start <= prevValue && prevValue <= end)) {
+        self.ignoreDateCompare = true;
+      } else {
+        self.ignoreDateCompare = false;
+        var tmp = new Date(prevValue);
+        if (tmp.getMonth() !== month) {
+          self.otherMonthSelectedDate = tmp;
+        } else {
+          self.otherMonthSelectedDate = undefined;
+          self.activeDate = tmp;
+        }
+
+      }
     }
   };
 
@@ -184,6 +246,13 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     var year = self.activeDate.getFullYear() + direction * (self.step.years || 0),
         month = self.activeDate.getMonth() + direction * (self.step.months || 0);
     self.activeDate.setFullYear(year, month, 1);
+    /*if ($scope.datepickerMode === 'day') {
+      self.calculateDateinterval();
+    } else {
+      self.clearIntervalVars();
+    }*/
+    self.calculateDateinterval();
+    /*
     if (typeof ngModelCtrl.$modelValue !== 'undefined' && ngModelCtrl.$modelValue !== null) {
       var prevValue = undefined;
       if (typeof ngModelCtrl.$modelValue === 'string' || ngModelCtrl.$modelValue instanceof String) {
@@ -234,11 +303,12 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
         }
 
       }
-    }
+    }*/
     self.refreshView();
   };
 
   $scope.toggleMode = function(direction) {
+    //self.clearIntervalVars();
     direction = direction || 1;
 
     if (($scope.datepickerMode === self.maxMode && direction === 1) || ($scope.datepickerMode === self.minMode && direction === -1)) {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -77,7 +77,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   }
 
   $scope.isActive = function(dateObject) {
-    var compareDate = typeof self.otherMonthSelectedDate !== 'undefined' ? self.otherMonthSelectedDate : self.activeDate;
+    var compareDate = angular.isDefined(self.otherMonthSelectedDate) ? self.otherMonthSelectedDate : self.activeDate;
 
     if (self.compare(dateObject.date, compareDate) === 0) {
       if (self.ignoreDateCompare) {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -185,7 +185,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     var month = self.activeDate.getMonth();
     if (typeof ngModelCtrl.$modelValue !== 'undefined' && ngModelCtrl.$modelValue !== null) {
       var prevValue;
-      if (typeof ngModelCtrl.$modelValue === 'string' || ngModelCtrl.$modelValue instanceof String) {
+      if (angular.isString(ngModelCtrl.$modelValue)) {
         prevValue = Date.parse(ngModelCtrl.$modelValue);
       } else {
         prevValue = ngModelCtrl.$modelValue.getTime();

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -276,6 +276,13 @@ describe('datepicker directive', function() {
         expect($rootScope.date).toEqual(new Date('September 15, 2010 15:30:00'));
       });
 
+      it('moves to the previous month & renders correctly the selected date', function () {
+        clickOption(3);
+        expect($rootScope.date).toEqual(new Date('September 01, 2010 15:30:00'));
+        clickPreviousButton();
+        expectSelectedElement(31);
+      });
+
       it('moves to the previous month & renders correctly when `previous` button is clicked', function() {
         clickPreviousButton();
 
@@ -299,6 +306,20 @@ describe('datepicker directive', function() {
 
         clickOption(17);
         expect($rootScope.date).toEqual(new Date('August 18, 2010 15:30:00'));
+      });
+
+      it('moves to the next month & renders correctly the selected date', function () {
+        clickOption(32);
+        expect($rootScope.date).toEqual(new Date('September 30, 2010 15:30:00'));
+        clickNextButton();
+        expectSelectedElement(4);
+      });
+
+      it('moves to the next month & renders all dates without selection', function () {
+        clickOption(7);
+        expect($rootScope.date).toEqual(new Date('September 05, 2010 15:30:00'));
+        clickNextButton();
+        expectSelectedElement(null);
       });
 
       it('moves to the next month & renders correctly when `next` button is clicked', function() {

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -769,7 +769,7 @@ describe('datepicker directive', function() {
           it('will move to day mode when selecting', function() {
             triggerKeyDown(element, 'left', true);
             triggerKeyDown(element, 'enter', true);
-            expect(getActiveLabel()).toBe('30');
+            expect(getActiveLabel()).toBe('');
             expect(getTitle()).toBe('August 2010');
             expect($rootScope.date).toEqual(new Date('September 30, 2010 15:30:00'));
           });
@@ -835,7 +835,7 @@ describe('datepicker directive', function() {
           it('will move to month mode when selecting', function() {
             triggerKeyDown(element, 'left', true);
             triggerKeyDown(element, 'enter', true);
-            expect(getActiveLabel()).toBe('September');
+            expect(getActiveLabel()).toBe('');
             expect(getTitle()).toBe('2009');
             expect($rootScope.date).toEqual(new Date('September 30, 2010 15:30:00'));
           });


### PR DESCRIPTION
This solves issue #3879, a problem regarding the datepicker.
I've added a method for date calculation. If a date is selected and the user moves to next or previous month, the date selection is kept if the date is visible in the new view. Otherwise no date is selected.
This also works when navigating via year or month mode.
I've added some tests for this new functionality, I've done some manually testing in Chrome, Firefox and IE9.

Regards,
Olle Thalén
 