### PR TITLE
Add Dropdown AppendTo functionality

### DIFF
--- a/src/dropdown/docs/demo.html
+++ b/src/dropdown/docs/demo.html
@@ -55,7 +55,7 @@
         <li role="menuitem"><a href="#">Separated link</a></li>
       </ul>
     </div>
-    
+
     <!-- Single button using template-url -->
     <div class="btn-group" dropdown>
       <button id="button-template-url" type="button" class="btn btn-primary" dropdown-toggle ng-disabled="disabled">
@@ -84,6 +84,52 @@
             <li class="divider"></li>
             <li role="menuitem"><a href="#">Separated link</a></li>
         </ul>
+    </div>
+
+    <hr>
+    <!-- AppendTo use case -->
+    <h4>append-to vs. append-to-body vs. inline example</h4>
+    <div id="dropdown-scrollable-container" style="height: 15em; overflow: auto;">
+      <div id="dropdown-long-content" style="height: 100em;">
+        <div id="dropdown-hidden-container" style="height: 4em; overflow: hidden;">
+          <div class="btn-group" dropdown dropdown-append-to="appendToEl">
+            <button id="btn-append-to" type="button" class="btn btn-primary" dropdown-toggle>
+              Dropdown in Container <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="btn-append-to">
+              <li role="menuitem"><a href="#">Action</a></li>
+              <li role="menuitem"><a href="#">Another action</a></li>
+              <li role="menuitem"><a href="#">Something else here</a></li>
+              <li class="divider"></li>
+              <li role="menuitem"><a href="#">Separated link</a></li>
+            </ul>
+          </div>
+          <div class="btn-group" dropdown dropdown-append-to-body>
+            <button id="btn-append-to-to-body" type="button" class="btn btn-primary" dropdown-toggle>
+              Dropdown on Body <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="btn-append-to-to-body">
+              <li role="menuitem"><a href="#">Action</a></li>
+              <li role="menuitem"><a href="#">Another action</a></li>
+              <li role="menuitem"><a href="#">Something else here</a></li>
+              <li class="divider"></li>
+              <li role="menuitem"><a href="#">Separated link</a></li>
+            </ul>
+          </div>
+          <div class="btn-group" dropdown>
+            <button id="btn-append-to-single-button" type="button" class="btn btn-primary" dropdown-toggle>
+              Inline Dropdown <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="btn-append-to-single-button">
+              <li role="menuitem"><a href="#">Action</a></li>
+              <li role="menuitem"><a href="#">Another action</a></li>
+              <li role="menuitem"><a href="#">Something else here</a></li>
+              <li class="divider"></li>
+              <li role="menuitem"><a href="#">Separated link</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
 
     <script type="text/ng-template" id="dropdown.html">

--- a/src/dropdown/docs/demo.js
+++ b/src/dropdown/docs/demo.js
@@ -18,4 +18,6 @@ angular.module('ui.bootstrap.demo').controller('DropdownCtrl', function ($scope,
     $event.stopPropagation();
     $scope.status.isopen = !$scope.status.isopen;
   };
+
+  $scope.appendToEl = angular.element(document.querySelector('#dropdown-long-content'));
 });

--- a/src/dropdown/docs/readme.md
+++ b/src/dropdown/docs/readme.md
@@ -6,6 +6,8 @@ There is also the `on-toggle(open)` optional expression fired when dropdown chan
 Add `dropdown-append-to-body` to the `dropdown` element to append to the inner `dropdown-menu` to the body.
 This is useful when the dropdown button is inside a div with `overflow: hidden`, and the menu would otherwise be hidden.
 
+Pass an [angular.element](https://docs.angularjs.org/api/ng/function/angular.element) object as the `dropdown-append-to` attribute on the `dropdown` element to append the inner `dropdown-menu` to the passed in element. This is particularly useful when appending to the body element isn't possible, perhaps because the dropdown button is enclosed in a scrollable container. Explore the demo on the left to see this in action. Expand the three different dropdowns and try scrolling inside the containing element.
+
 Add `keyboard-nav` to the `dropdown` element to enable navigation of dropdown list elements with the arrow keys.
 
 By default the dropdown will automatically close if any of its elements is clicked, you can change this behavior by setting the `auto-close` option as follows:

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -220,6 +220,10 @@ describe('dropdownToggle', function() {
       element = dropdown();
     });
 
+    afterEach(function() {
+      $document.find('body').removeClass('dropdown');
+    });
+
     it('adds the menu to the body', function() {
       expect($document.find('#dropdown-menu').parent()[0]).toBe($document.find('body')[0]);
     });
@@ -246,6 +250,53 @@ describe('dropdownToggle', function() {
       element.find('[dropdown-toggle]').click();
 
       expect(body.hasClass('open')).toBe(false);
+    });
+  });
+
+  describe('using dropdown-append-to', function() {
+    var initialPage;
+
+    function dropdown() {
+      return $compile('<li dropdown dropdown-append-to="appendTo"><a href dropdown-toggle></a><ul class="dropdown-menu" id="dropdown-menu"><li><a href>Hello On Container</a></li></ul></li>')($rootScope);
+    }
+
+    beforeEach(function() {
+      $document.find('body').append(angular.element('<div id="dropdown-container"></div>'));
+
+      $rootScope.appendTo = $document.find('#dropdown-container');
+      $rootScope.$digest();
+
+      element = dropdown();
+      $document.find('body').append(element);
+    });
+
+    afterEach(function() {
+      // Cleanup the extra elements we appended
+      $document.find('#dropdown-container').remove();
+    });
+
+    it('appends to container', function() {
+      expect($document.find('#dropdown-menu').parent()[0].id).toBe('dropdown-container');
+    });
+
+    it('adds dropdown class to container', function() {
+      expect($document.find('#dropdown-container').hasClass('dropdown')).toBe(true);
+    });
+
+    it('toggles open class on container', function() {
+      var container = $document.find('#dropdown-container');
+
+      expect(container.hasClass('open')).toBe(false);
+      element.find('[dropdown-toggle]').click();
+      expect(container.hasClass('open')).toBe(true);
+      element.find('[dropdown-toggle]').click();
+      expect(container.hasClass('open')).toBe(false);
+    });
+
+    it('removes the menu when the dropdown is removed', function() {
+      element.remove();
+      $rootScope.$digest();
+      expect($document.find('#dropdown-menu').length).toEqual(0);
     });
   });
 


### PR DESCRIPTION
This fixes #4467.

In a UI that we're building we ran into an issue where the dropdowns had to be attached to body (because their containing element had some sort of hidden overflow, like the bootstrap responsive tables) but the body in this app is a static "window", as there's a div element that the main content is scrolled in (this is because there's a snap.js drawer used).  In this situation, if the dropdowns are appended to the body element, when the user scrolls after opening a dropdown, the dropdown menu would stay in a fixed position above the scrolling content beneath.

I've added a "dropdown-append-to" attribute that accepts an "angular.element" object and will use that element as the container for the dropdown menu when it is opened.  This allows us to attach the dropdown to the scrolling container which makes them scroll with the content, but don't get cutoff by hidden overflow in their immediate container.

Here's a little gif I put together of the three types of "attachment" and how they look in this sort of situation:

![uprcvrq1v7](https://cloud.githubusercontent.com/assets/136907/10150334/2c120da2-65fc-11e5-82a5-429c4feebd26.gif)

This was actually taken from the angular-ui bootstrap docs that has the changes from this PR in them.

I added tests for this, and modified the docs/demo from dropdown as well.