### PR TITLE
Fix collapse animation

### DIFF
--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -12,20 +12,19 @@ angular.module('ui.bootstrap.collapse', [])
 
           if ($animateCss) {
             $animateCss(element, {
-              addClass: 'in',
               easing: 'ease',
               to: { height: element[0].scrollHeight + 'px' }
             }).start().done(expandDone);
           } else {
-            $animate.addClass(element, 'in', {
-              to: { height: element[0].scrollHeight + 'px' }
+            $animate.animate(element, {}, {
+              height: element[0].scrollHeight + 'px'
             }).then(expandDone);
           }
         }
 
         function expandDone() {
           element.removeClass('collapsing')
-            .addClass('collapse')
+            .addClass('collapse in')
             .css({height: 'auto'});
         }
 
@@ -41,19 +40,18 @@ angular.module('ui.bootstrap.collapse', [])
             .css({height: element[0].scrollHeight + 'px'})
             // initially all panel collapse have the collapse class, this removal
             // prevents the animation from jumping to collapsed state
-            .removeClass('collapse')
+            .removeClass('collapse in')
             .addClass('collapsing')
             .attr('aria-expanded', false)
             .attr('aria-hidden', true);
 
           if ($animateCss) {
             $animateCss(element, {
-              removeClass: 'in',
               to: {height: '0'}
             }).start().done(collapseDone);
           } else {
-            $animate.removeClass(element, 'in', {
-              to: {height: '0'}
+            $animate.animate(element, {}, {
+              height: '0'
             }).then(collapseDone);
           }
         }

--- a/src/collapse/test/collapse.spec.js
+++ b/src/collapse/test/collapse.spec.js
@@ -111,9 +111,9 @@ describe('collapse directive', function() {
       scope.exp = false;
       scope.isCollapsed = false;
       scope.$digest();
+      $animate.flush();
       var collapseHeight = element.height();
       scope.exp = true;
-      $animate.flush();
       scope.$digest();
       expect(element.height()).toBeGreaterThan(collapseHeight);
     });
@@ -122,6 +122,7 @@ describe('collapse directive', function() {
       scope.exp = true;
       scope.isCollapsed = false;
       scope.$digest();
+      $animate.flush();
       var collapseHeight = element.height();
       scope.exp = false;
       scope.$digest();


### PR DESCRIPTION
This is a tricky one. If you look at TWBS js, you will notice that the class `in` is added [after the expand transition is complete](https://github.com/twbs/bootstrap/blob/master/js/collapse.js#L81) and [removed as the collapse transition starts](https://github.com/twbs/bootstrap/blob/master/js/collapse.js#L109) This is particularly confusing because it works differently than `.fade.in` for example and it differs slightly from our current behaviour of adding the `in` class using `$animate` which adds the class immediately at the start of the transition.

This discrepancy is not visible in the `collapse` example on the homepage which opens and closes a well, but it is visible, for example when collapsing a navbar (mobile version) -- a very common use case in TWBS version 3. @flachware adjusted the [Plunker example](http://plnkr.co/edit/ygOCVCK1ywvReoQ3WitO?p=preview) accordingly, and, when you open/close the menu, you will see a scrollbar during the expand animation (depending on your browser/OS handling of scrollbars obviously).

Now, this is isn't a big deal, and can be worked around by inserting CSS like this `.navbar-collapse.collapsing.in { overflow: hidden; }`, but if ui-bootstrap is supposed to just work out of the box given the official Bootstrap CSS, I think we should emulate the behaviour of Bootstrap JS as closely as possible. This PR tries to do just that by adding the `in` class in `expandDone` and removing it at the start of the collapsing transition. If you would prefer a different solution just let me know!
