### PR TITLE
fix(tooltip): check for ttScope in $$postDigest

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -374,7 +374,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
                       repositionScheduled = true;
                       tooltipLinkedScope.$$postDigest(function() {
                         repositionScheduled = false;
-                        if (ttScope.isOpen) {
+                        if (ttScope && ttScope.isOpen) {
                           positionTooltip();
                         }
                       });


### PR DESCRIPTION
In the tooltip $$postDigest function a check is done
on ttScope.isOpen but ttScope may have been set to null
in the scope.$on('$destroy'...) function.  Added a
check to make sure ttScope is defined and not null.

Fixes #4552