### PR TITLE
fix(dropdown): Don't allow using dropdownMenu and uibDropdownMenu

### DIFF
--- a/src/dropdown/docs/demo.html
+++ b/src/dropdown/docs/demo.html
@@ -5,7 +5,7 @@
       <a href id="simple-dropdown" uib-dropdown-toggle>
         Click me for a dropdown, yo!
       </a>
-      <ul class="uib-dropdown-menu" aria-labelledby="simple-dropdown">
+      <ul class="dropdown-menu" uib-dropdown-menu aria-labelledby="simple-dropdown">
         <li ng-repeat="choice in items">
           <a href>{{choice}}</a>
         </li>
@@ -17,7 +17,7 @@
       <button id="single-button" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
         Button dropdown <span class="caret"></span>
       </button>
-      <ul class="uib-dropdown-menu" role="menu" aria-labelledby="single-button">
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="single-button">
         <li role="menuitem"><a href="#">Action</a></li>
         <li role="menuitem"><a href="#">Another action</a></li>
         <li role="menuitem"><a href="#">Something else here</a></li>
@@ -33,7 +33,7 @@
         <span class="caret"></span>
         <span class="sr-only">Split button!</span>
       </button>
-      <ul class="uib-dropdown-menu" role="menu" aria-labelledby="split-button">
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="split-button">
         <li role="menuitem"><a href="#">Action</a></li>
         <li role="menuitem"><a href="#">Another action</a></li>
         <li role="menuitem"><a href="#">Something else here</a></li>
@@ -47,7 +47,7 @@
       <button id="btn-append-to-body" type="button" class="btn btn-primary" uib-dropdown-toggle>
         Dropdown on Body <span class="caret"></span>
       </button>
-      <ul class="uib-dropdown-menu" role="menu" aria-labelledby="btn-append-to-body">
+      <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="btn-append-to-body">
         <li role="menuitem"><a href="#">Action</a></li>
         <li role="menuitem"><a href="#">Another action</a></li>
         <li role="menuitem"><a href="#">Something else here</a></li>
@@ -55,13 +55,13 @@
         <li role="menuitem"><a href="#">Separated link</a></li>
       </ul>
     </div>
-    
+
     <!-- Single button using template-url -->
     <div class="btn-group" uib-dropdown>
       <button id="button-template-url" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
         Dropdown using template <span class="caret"></span>
       </button>
-      <ul class="uib-dropdown-menu" template-url="dropdown.html" aria-labelledby="button-template-url">
+      <ul class="dropdown-menu" uib-dropdown-menu template-url="dropdown.html" aria-labelledby="button-template-url">
       </ul>
     </div>
 
@@ -77,7 +77,7 @@
         <button id="simple-btn-keyboard-nav" type="button" class="btn btn-primary" uib-dropdown-toggle>
             Dropdown with keyboard navigation <span class="caret"></span>
         </button>
-        <ul class="uib-dropdown-menu" role="menu" aria-labelledby="simple-btn-keyboard-nav">
+        <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="simple-btn-keyboard-nav">
             <li role="menuitem"><a href="#">Action</a></li>
             <li role="menuitem"><a href="#">Another action</a></li>
             <li role="menuitem"><a href="#">Something else here</a></li>
@@ -87,7 +87,7 @@
     </div>
 
     <script type="text/ng-template" id="dropdown.html">
-        <ul class="uib-dropdown-menu" role="menu" aria-labelledby="button-template-url">
+        <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="button-template-url">
           <li role="menuitem"><a href="#">Action in Template</a></li>
           <li role="menuitem"><a href="#">Another action in Template</a></li>
           <li role="menuitem"><a href="#">Something else here</a></li>

--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -247,7 +247,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
 
 .directive('uibDropdownMenu', function() {
   return {
-    restrict: 'AC',
+    restrict: 'A',
     require: '?^uibDropdown',
     link: function(scope, element, attrs, dropdownCtrl) {
       if (!dropdownCtrl || angular.isDefined(attrs.dropdownNested)) {
@@ -385,7 +385,7 @@ angular.module('ui.bootstrap.dropdown')
 
 .directive('dropdownMenu', ['$log', '$dropdownSuppressWarning', function($log, $dropdownSuppressWarning) {
   return {
-    restrict: 'AC',
+    restrict: 'A',
     require: '?^dropdown',
     link: function(scope, element, attrs, dropdownCtrl) {
       if (!dropdownCtrl) {

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -190,9 +190,9 @@ describe('dropdownToggle', function() {
 
   describe('using dropdownMenuTemplate', function() {
     function dropdown() {
-      $templateCache.put('custom.html', '<ul class="uib-dropdown-menu"><li>Item 1</li></ul>');
+      $templateCache.put('custom.html', '<ul class="dropdown-menu" uib-dropdown-menu><li>Item 1</li></ul>');
 
-      return $compile('<li uib-dropdown><a href uib-dropdown-toggle></a><ul class="uib-dropdown-menu" template-url="custom.html"></ul></li>')($rootScope);
+      return $compile('<li uib-dropdown><a href uib-dropdown-toggle></a><ul class="dropdown-menu" uib-dropdown-menu template-url="custom.html"></ul></li>')($rootScope);
     }
 
     beforeEach(function() {
@@ -201,20 +201,20 @@ describe('dropdownToggle', function() {
 
     it('should apply custom template for dropdown menu', function() {
       element.find('a').click();
-      expect(element.find('ul.uib-dropdown-menu').eq(0).find('li').eq(0).text()).toEqual('Item 1');
+      expect(element.find('ul.dropdown-menu').eq(0).find('li').eq(0).text()).toEqual('Item 1');
     });
 
     it('should clear ul when dropdown menu is closed', function() {
       element.find('a').click();
-      expect(element.find('ul.uib-dropdown-menu').eq(0).find('li').eq(0).text()).toEqual('Item 1');
+      expect(element.find('ul.dropdown-menu').eq(0).find('li').eq(0).text()).toEqual('Item 1');
       element.find('a').click();
-      expect(element.find('ul.uib-dropdown-menu').eq(0).find('li').length).toEqual(0);
+      expect(element.find('ul.dropdown-menu').eq(0).find('li').length).toEqual(0);
     });
   });
 
   describe('using dropdown-append-to-body', function() {
     function dropdown() {
-      return $compile('<li uib-dropdown dropdown-append-to-body><a href uib-dropdown-toggle></a><ul class="uib-dropdown-menu" id="dropdown-menu"><li><a href>Hello On Body</a></li></ul></li>')($rootScope);
+      return $compile('<li uib-dropdown dropdown-append-to-body><a href uib-dropdown-toggle></a><ul class="dropdown-menu" id="dropdown-menu" uib-dropdown-menu><li><a href>Hello On Body</a></li></ul></li>')($rootScope);
     }
 
     beforeEach(function() {
@@ -435,7 +435,7 @@ describe('dropdownToggle', function() {
       });
 
       it('should work with dropdown-append-to-body', function() {
-        element = $compile('<li uib-dropdown dropdown-append-to-body auto-close="outsideClick"><a href uib-dropdown-toggle></a><ul class="uib-dropdown-menu" id="dropdown-menu"><li><a href>Hello On Body</a></li></ul></li>')($rootScope);
+        element = $compile('<li uib-dropdown dropdown-append-to-body auto-close="outsideClick"><a href uib-dropdown-toggle></a><ul class="dropdown-menu" id="dropdown-menu" uib-dropdown-menu><li><a href>Hello On Body</a></li></ul></li>')($rootScope);
         clickDropdownToggle();
         expect(element.hasClass(dropdownConfig.openClass)).toBe(true);
         $document.find('#dropdown-menu').find('li').eq(0).trigger('click');
@@ -655,7 +655,7 @@ describe('dropdownToggle', function() {
 
   describe('`keyboard-nav` option with `dropdown-append-to-body` option', function() {
     function dropdown() {
-      return $compile('<li uib-dropdown dropdown-append-to-body uib-keyboard-nav><a href uib-dropdown-toggle></a><ul class="uib-dropdown-menu" id="dropdown-menu"><li><a href>Hello On Body</a></li><li><a href>Hello Again</a></li></ul></li>')($rootScope);
+      return $compile('<li uib-dropdown dropdown-append-to-body uib-keyboard-nav><a href uib-dropdown-toggle></a><ul class="dropdown-menu" id="dropdown-menu" uib-dropdown-menu><li><a href>Hello On Body</a></li><li><a href>Hello Again</a></li></ul></li>')($rootScope);
     }
 
     beforeEach(function() {
@@ -691,12 +691,12 @@ describe('dropdownToggle', function() {
 describe('dropdown deprecation', function() {
   beforeEach(module('ngAnimateMock'));
   beforeEach(module('ui.bootstrap.dropdown'));
-  
+
   it('should suppress warning', function() {
     module(function($provide) {
       $provide.value('$dropdownSuppressWarning', true);
     });
-    
+
     inject(function($compile, $log, $rootScope) {
       spyOn($log, 'warn');
       var element = $compile('<li dropdown><a href dropdown-toggle></a><ul><li><a href>Hello</a></li></ul></li>')($rootScope);
@@ -704,7 +704,7 @@ describe('dropdown deprecation', function() {
       expect($log.warn.calls.count()).toBe(0);
     });
   });
-  
+
   it('should give warning by default', inject(function($compile, $log, $rootScope) {
     spyOn($log, 'warn');
     var element = $compile('<li dropdown><a href></a><ul><li><a href dropdown-toggle>Hello</a></li></ul></li>')($rootScope);
@@ -714,7 +714,7 @@ describe('dropdown deprecation', function() {
     expect($log.warn.calls.argsFor(1)).toEqual(['dropdown-toggle is now deprecated. Use uib-dropdown-toggle instead.']);
     expect($log.warn.calls.argsFor(2)).toEqual(['dropdown is now deprecated. Use uib-dropdown instead.']);
   }));
-  
+
   it('should give warning by default for keyboardNav', inject(function($compile, $log, $rootScope) {
     spyOn($log, 'warn');
     var element = $compile('<li dropdown keyboard-nav><a href ></a><ul><li><a href>Hello</a></li></ul></li>')($rootScope);


### PR DESCRIPTION
Without this it's impossible to remove all deprecation warning without messing up the bootstrap styles.

BREAKING CHANGE: dropdownMenu and uibDropdownMenu have to be used as attributes, not classes.

As an aside, several directives are horribly broken when used without the `uib-` prefix, so this is actually a rather important fix.