### PR TITLE
fix(tooltip): clean up stackedMap on scope destroy

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -486,6 +486,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
               $timeout.cancel(positionTimeout);
               unregisterTriggers();
               removeTooltip();
+              openedTooltips.remove(ttScope);
               ttScope = null;
             });
           };


### PR DESCRIPTION
The tooltip was not being removed from the stackedMap
resulting in a memeory leak.  Tooltip will now be
removed from the stackedMap in scope destroy
function.

Fixes #4604