### PR TITLE
feat(datepicker): Disabled Date New Functionality

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -180,10 +180,10 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     newYear = newYear.setFullYear(year, month, 1);
 
     var disabledStart = new Date(),
-        disabledEnd = new Date(),
-        disabledStart = disabledStart.setFullYear(self.disabledStart.year, self.disabledStart.month, self.disabledStart.day),
-        disabledEnd = disabledEnd.setFullYear(self.disabledEnd.year, self.disabledEnd.month, self.disabledEnd.day),
-        timeDiff = Math.abs(disabledEnd - disabledStart),
+        disabledEnd = new Date();
+    disabledStart = disabledStart.setFullYear(self.disabledStart.year, self.disabledStart.month, self.disabledStart.day),
+    disabledEnd = disabledEnd.setFullYear(self.disabledEnd.year, self.disabledEnd.month, self.disabledEnd.day);
+    var timeDiff = Math.abs(disabledEnd - disabledStart),
         diffDayCount = Math.ceil(timeDiff / (1000 * 3600 * 24)),
         diffDay = Math.ceil(diffDayCount / 31);
     if (direction > 0 && newYear >= disabledStart) {
@@ -204,11 +204,11 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
   $scope.checkMin = function () {
       return self.activeDate.getMonth() === self.minMonth && self.activeDate.getFullYear() === self.minYear;
-  }
+  };
 
   $scope.checkMax = function () {
       return self.activeDate.getMonth() === self.maxMonth && self.activeDate.getFullYear() === self.maxYear;
-  }
+  };
 
   $scope.toggleMode = function(direction) {
     direction = direction || 1;

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -179,10 +179,11 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     var newYear = new Date();
     newYear = newYear.setFullYear(year, month, 1);
 
-    var disabledStart = new Date(),
-        disabledEnd = new Date();
-    disabledStart = disabledStart.setFullYear(self.disabledStart.year, self.disabledStart.month, self.disabledStart.day),
+    var disabledStart = new Date();
+    disabledStart = disabledStart.setFullYear(self.disabledStart.year, self.disabledStart.month, self.disabledStart.day);
+    var disabledEnd = new Date();
     disabledEnd = disabledEnd.setFullYear(self.disabledEnd.year, self.disabledEnd.month, self.disabledEnd.day);
+
     var timeDiff = Math.abs(disabledEnd - disabledStart),
         diffDayCount = Math.ceil(timeDiff / (1000 * 3600 * 24)),
         diffDay = Math.ceil(diffDayCount / 31);

--- a/template/datepicker/day.html
+++ b/template/datepicker/day.html
@@ -1,9 +1,9 @@
 <table role="grid" aria-labelledby="{{::uniqueId}}-title" aria-activedescendant="{{activeDateId}}">
   <thead>
     <tr>
-      <th><button type="button" class="btn btn-default btn-sm pull-left" ng-click="move(-1)" tabindex="-1"><i class="glyphicon glyphicon-chevron-left"></i></button></th>
+      <th><button type="button" class="btn btn-default btn-sm pull-left" ng-click="move(-1)" ng-disabled="checkMin()" tabindex="-1"><i class="glyphicon glyphicon-chevron-left"></i></button></th>
       <th colspan="{{::5 + showWeeks}}"><button id="{{::uniqueId}}-title" role="heading" aria-live="assertive" aria-atomic="true" type="button" class="btn btn-default btn-sm" ng-click="toggleMode()" ng-disabled="datepickerMode === maxMode" tabindex="-1" style="width:100%;"><strong>{{title}}</strong></button></th>
-      <th><button type="button" class="btn btn-default btn-sm pull-right" ng-click="move(1)" tabindex="-1"><i class="glyphicon glyphicon-chevron-right"></i></button></th>
+      <th><button type="button" class="btn btn-default btn-sm pull-right" ng-click="move(1)" ng-disabled="checkMax()" tabindex="-1"><i class="glyphicon glyphicon-chevron-right"></i></button></th>
     </tr>
     <tr>
       <th ng-if="showWeeks" class="text-center"></th>


### PR DESCRIPTION
There were two things I needed from the date picker that didn't exist.  I wanted to skip an entire month when shuffling through months if that entire month was disabled.  And I wanted to prevent people from scrolling further back then the first month with an available date and past the last month with an available date.  So the following changes resolve this for my specific date picker:
- Added functionality to allow blocking out and skipping of entire
months from the date picker.  I am passing in a day, month, and year range to calculate if a whole month is disabled and if I should skip the month.
- Disabled back month button when at the start and forward button when
at the end date.  I added an ng-disabled to the template and have it running through a new function to calculate weather it is the first or last month available.