### PR TITLE
Fix dropdown auto close in mobile phones for angular ~1.4.7

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -9,6 +9,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
 
   this.open = function(dropdownScope) {
     if (!openScope) {
+      $document.bind('touch', closeDropdown);
       $document.bind('click', closeDropdown);
       $document.bind('keydown', keybindFilter);
     }
@@ -23,6 +24,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
   this.close = function(dropdownScope) {
     if (openScope === dropdownScope) {
       openScope = null;
+      $document.unbind('touch', closeDropdown);
       $document.unbind('click', closeDropdown);
       $document.unbind('keydown', keybindFilter);
     }


### PR DESCRIPTION
Auto close dropdowns when click was broken in mobile phones with angular ~1.4.7