### PR TITLE
fix(modal): Replace unnecessary querySelectorAll with querySelector

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -178,7 +178,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
 
 
           $q.when(animationPromise).then(function() {
-            var inputsWithAutofocus = element[0].querySelectorAll('[autofocus]');
+            var inputWithAutofocus = element[0].querySelector('[autofocus]');
             /**
              * Auto-focusing of a freshly-opened modal element causes any child elements
              * with the autofocus attribute to lose focus. This is an issue on touch
@@ -187,8 +187,8 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
              * the onscreen keyboard. Fixed by updated the focusing logic to only autofocus
              * the modal element if the modal does not contain an autofocus element.
              */
-            if (inputsWithAutofocus.length) {
-              inputsWithAutofocus[0].focus();
+            if (inputWithAutofocus) {
+              inputWithAutofocus.focus();
             } else {
               element[0].focus();
             }
@@ -829,7 +829,7 @@ angular.module('ui.bootstrap.modal')
 
 
             $q.when(animationPromise).then(function() {
-              var inputsWithAutofocus = element[0].querySelectorAll('[autofocus]');
+              var inputWithAutofocus = element[0].querySelector('[autofocus]');
               /**
                * Auto-focusing of a freshly-opened modal element causes any child elements
                * with the autofocus attribute to lose focus. This is an issue on touch
@@ -838,8 +838,8 @@ angular.module('ui.bootstrap.modal')
                * the onscreen keyboard. Fixed by updated the focusing logic to only autofocus
                * the modal element if the modal does not contain an autofocus element.
                */
-              if (inputsWithAutofocus.length) {
-                inputsWithAutofocus[0].focus();
+              if (inputWithAutofocus) {
+                inputWithAutofocus.focus();
               } else {
                 element[0].focus();
               }


### PR DESCRIPTION
In this case only the first element that is returned from `querySelectorAll` is being used, its better to use `querySelector` which stops looking after the first match.