### PR TITLE
fix(datepicker): datepicker-popup nest in dropdown

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -551,7 +551,7 @@ angular.module('ui.bootstrap.dropdown')
     restrict: 'AC',
     require: '?^dropdown',
     link: function(scope, element, attrs, dropdownCtrl) {
-      if (!dropdownCtrl) {
+      if (!dropdownCtrl || angular.isDefined(attrs.dropdownNested)) {
         return;
       }
 


### PR DESCRIPTION
Extends the fix from commit c5fe8b to the deprecated non uib dropdown-menu.

Closes #4197 (again)