### PR TITLE
fix(tooltip): null scope check in isOpen watch

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -368,7 +368,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
             if (isOpenParse) {
               scope.$watch(isOpenParse, function(val) {
                 /*jshint -W018 */
-                if (!val === ttScope.isOpen) {
+                if (ttScope && !val === ttScope.isOpen) {
                   toggleTooltipBind();
                 }
                 /*jshint +W018 */


### PR DESCRIPTION
The watch for the isOpen property from the model was not
checking to see if the internal tooltip scope was still
valid (null or undefined) before comparing the value to
the tooltip scope isOpen property.

Closes #4697
Fixes #4683