### PR TITLE
chore(docs): downloads - promote npm

### DIFF
--- a/misc/demo/index.html
+++ b/misc/demo/index.html
@@ -278,11 +278,10 @@
             </div>
           </div>
           <div class="form-group">
-            <label class="col-sm-3 control-label"><strong>Bower</strong></label>
+            <label class="col-sm-3 control-label"><strong>npm</strong></label>
             <div class="col-sm-9">
-              <small>If you are using Bower just run:</small>
-              <pre style="margin-bottom:0;">bower install angular-bootstrap</pre>
-              <small class="help-block"><a href="http://bower.io/" target="_blank">Bower</a> is a package manager for the web.</small>
+              <pre style="margin-bottom:0;">npm install angular-ui-bootstrap</pre>
+              <small class="help-block"><a href="https://www.npmjs.com/" target="_blank">npm</a> is a package manager for the web.</small>
             </div>
           </div>
         </form>


### PR DESCRIPTION
In the download modal on the demo page, changed Bower info to suggest using npm instead.