### PR TITLE
fix(modal): prevent body content shifting when vertical scrollbar

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,6 +19,7 @@ module.exports = function(config) {
       'node_modules/angular/angular.js',
       'node_modules/angular-mocks/angular-mocks.js',
       'node_modules/angular-sanitize/angular-sanitize.js',
+      'node_modules/bootstrap/dist/css/bootstrap.css',
       'misc/test-lib/helpers.js',
       'src/**/*.js',
       'template/**/*.js'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0-SNAPSHOT",
   "homepage": "http://angular-ui.github.io/bootstrap/",
   "dependencies": {},
-  "scripts":{
+  "scripts": {
     "test": "grunt"
   },
   "repository": {
@@ -15,6 +15,7 @@
     "angular": "^1.4.4",
     "angular-mocks": "^1.4.4",
     "angular-sanitize": "^1.4.4",
+    "bootstrap": "^3.3.5",
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.0",

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -346,7 +346,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
           // reset any right padding set to body when opening the modal
           // make sure no other modal is open before resetting
           if(modalWindow.appendTo === 'body' && openedWindows.length() === 0){
-            var body = $document.find('body').eq(0);
+            var body = $document.find('body');
             body.css('padding-right', modalWindow.modalDomEl.originalBodyRightPadding);
           }
         });
@@ -533,7 +533,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
               $$scrollbarHelper.measureScrollbar();
             }
 
-            var body = $document.find('body').eq(0);
+            var body = $document.find('body');
             // set originalBodyRightPadding property to reset it when the last modal closes
             modalDomEl.originalBodyRightPadding = body.css('padding-right');
             body.css('padding-right', ($$scrollbarHelper.scrollbarWidth + parseInt(modalDomEl.originalBodyRightPadding || '0'))+'px');

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -151,33 +151,6 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
         element.addClass(attrs.windowTopClass || '');
         scope.size = attrs.size;
 
-        // get topmost modal object
-        var bodyIsOverflowing;
-        var modal = $modalStack.getTop();
-        
-        // only when modal is attached to body
-        if(modal && modal.value && modal.value.appendTo === 'body'){
-          
-          // check bodyOverflowing property that was set when opening modal
-          if(modal.value.modalDomEl && modal.value.modalDomEl.bodyOverflowing){
-            bodyIsOverflowing = true;
-          }
-
-          // start - from adjustDialog method of modal.js of bootstrap
-          // check if modal is overflowing
-          var modalIsOverflowing = element[0].scrollHeight > document.documentElement.clientHeight;
-          
-          if(!$$scrollbarHelper.scrollbarWidth){
-            $$scrollbarHelper.measureScrollbar();
-          }
-
-          element.css({
-            'padding-left': (!bodyIsOverflowing && modalIsOverflowing ? $$scrollbarHelper.scrollbarWidth : '') + 'px',
-            'padding-right': (bodyIsOverflowing && !modalIsOverflowing ? $$scrollbarHelper.scrollbarWidth : '') + 'px'
-          });
-          // end - from adjustDialog method of modal.js of bootstrap
-        }
-
         scope.close = function(evt) {
           var modal = $modalStack.getTop();
           if (modal && modal.value.backdrop && modal.value.backdrop !== 'static' && (evt.target === evt.currentTarget)) {
@@ -251,6 +224,34 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
           var modal = $modalStack.getTop();
           if (modal) {
             $modalStack.modalRendered(modal.key);
+
+            // get topmost modal object
+            var bodyIsOverflowing;
+            var modalIsOverflowing;
+            
+            // only when modal is attached to body
+            if(modal.value.appendTo === 'body'){
+              
+              // check bodyOverflowing property that was set when opening modal
+              if(modal.value.modalDomEl.bodyOverflowing){
+                bodyIsOverflowing = true;
+              }
+
+              // start - from adjustDialog method of modal.js of bootstrap
+              // check if modal is overflowing
+              modalIsOverflowing = element[0].scrollHeight > document.documentElement.clientHeight;
+              
+              if(!$$scrollbarHelper.scrollbarWidth){
+                $$scrollbarHelper.measureScrollbar();
+              }
+
+              if(modalIsOverflowing && !bodyIsOverflowing){
+                element.css('padding-left', $$scrollbarHelper.scrollbarWidth + 'px');
+              }else if(bodyIsOverflowing && !modalIsOverflowing){
+                element.css('padding-right', $$scrollbarHelper.scrollbarWidth + 'px');
+              }
+              // end - from adjustDialog method of modal.js of bootstrap
+            }
           }
         });
       }

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -1225,4 +1225,56 @@ describe('$uibModal', function () {
       expect(called).toBeTruthy();
     });
   });
+
+  describe('body content when vertical scrollbar present', function() {
+    it('should not shift document elements - no body right padding specified', function() {
+
+      var largeBlockWithButton = '<div class="container"><button class="btn btn-default" id="clickMeButton" ng-click="open()">Open me!</button><div style="height: 3000px;"><p>&nbsp;</p><p>Block with large height to force vertical scroll</p></div></div></div>';
+      var element = angular.element(largeBlockWithButton);
+      angular.element(document.body).append(element);
+
+      var clickMeButton = $document.find('div #clickMeButton');
+      var buttonLeftBeforeModalOpen = clickMeButton.offset().left;
+
+      var modal = open({template: '<div>Content</div>'});
+      expect($document).toHaveModalsOpen(1);
+      var buttonLeftAfterModalOpen = clickMeButton.offset().left;
+      expect(buttonLeftAfterModalOpen).toBe(buttonLeftBeforeModalOpen);
+
+      dismiss(modal, 'closing in test');
+
+      expect($document).toHaveModalsOpen(0);
+      var buttonLeftAfterModalClose = clickMeButton.offset().left;
+      expect(buttonLeftAfterModalClose).toBe(buttonLeftBeforeModalOpen);
+
+      element.remove();
+    });
+
+    it('should not shift document elements - body has right padding specified', function() {
+
+      // add right body padding
+      var body = $document.find('body').eq(0);
+      body.css('padding-right', '50px');
+
+      var largeBlockWithButton = '<div class="container"><button class="btn btn-default" id="clickMeButton" ng-click="open()">Open me!</button><div style="height: 3000px;"><p>&nbsp;</p><p>Block with large height to force vertical scroll</p></div></div></div>';
+      var element = angular.element(largeBlockWithButton);
+      angular.element(document.body).append(element);
+
+      var clickMeButton = $document.find('div #clickMeButton');
+      var buttonLeftBeforeModalOpen = clickMeButton.offset().left;
+
+      var modal = open({template: '<div>Content</div>'});
+      expect($document).toHaveModalsOpen(1);
+      var buttonLeftAfterModalOpen = clickMeButton.offset().left;
+      expect(buttonLeftAfterModalOpen).toBe(buttonLeftBeforeModalOpen);
+
+      dismiss(modal, 'closing in test');
+
+      expect($document).toHaveModalsOpen(0);
+      var buttonLeftAfterModalClose = clickMeButton.offset().left;
+      expect(buttonLeftAfterModalClose).toBe(buttonLeftBeforeModalOpen);
+
+      element.remove();
+    });
+  });
 });


### PR DESCRIPTION
Prevents page body content shifting to the right when modal is open (when appendTo is 'body')

Closes #3714