### PR TITLE
feat(typeahead): apply angular watch to the typeahead-editable setting

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -295,6 +295,24 @@ describe('typeahead tests', function() {
         expect(inputEl.val()).toEqual('bar');
     });
 
+    it('should support changing the editable property to limit model bindings to matches only', function() {
+      $scope.isEditable = true;
+      var element = prepareInputEl('<div><input ng-model="result" uib-typeahead="item for item in source | filter:$viewValue" typeahead-editable="isEditable"></div>');
+      $scope.isEditable = false;
+      $scope.$digest();
+      changeInputValueTo(element, 'not in matches');
+      expect($scope.result).toEqual(undefined);
+    });
+
+    it('should support changing the editable property to bind view value to model even if not part of matches', function() {
+      $scope.isEditable = false;
+      var element = prepareInputEl('<div><input ng-model="result" uib-typeahead="item for item in source | filter:$viewValue" typeahead-editable="isEditable"></div>');
+      $scope.isEditable = true;
+      $scope.$digest();
+      changeInputValueTo(element, 'not in matches');
+      expect($scope.result).toEqual('not in matches');
+    });
+
     it('should bind loading indicator expression', inject(function($timeout) {
       $scope.isLoading = false;
       $scope.loadMatches = function(viewValue) {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -46,7 +46,6 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
     var isEditable = originalScope.$eval(attrs.typeaheadEditable) !== false;
     originalScope.$watch(attrs.typeaheadEditable, function (newVal) {
       isEditable = newVal !== false;
-      modelCtrl.$setValidity('editable', isEditable);
     }); 
 
     //binding to a variable that indicates if matches are being retrieved asynchronously

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -44,6 +44,10 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
 
     //should it restrict model values to the ones selected from the popup only?
     var isEditable = originalScope.$eval(attrs.typeaheadEditable) !== false;
+    originalScope.$watch(attrs.typeaheadEditable, function (newVal) {
+      isEditable = newVal !== false;
+      modelCtrl.$setValidity('editable', isEditable);
+    }); 
 
     //binding to a variable that indicates if matches are being retrieved asynchronously
     var isLoadingSetter = $parse(attrs.typeaheadLoading).assign || angular.noop;


### PR DESCRIPTION
Adds a watch for the typeahead-editable attribute.