### PR TITLE
fix(tooltip): Correct Jasmine custom matcher message condition.

### DIFF
--- a/src/tooltip/test/tooltip2.spec.js
+++ b/src/tooltip/test/tooltip2.spec.js
@@ -24,7 +24,7 @@ describe('tooltip directive', function() {
               pass: util.equals(ttipElements.length, noOfOpened, customEqualityTesters)
             };
 
-            if (result.message) {
+            if (result.pass) {
               result.message = 'Expected "' + angular.mock.dump(ttipElements) + '" not to have "' + ttipElements.length + '" opened tooltips.';
             } else {
               result.message = 'Expected "' + angular.mock.dump(ttipElements) + '" to have "' + ttipElements.length + '" opened tooltips.';


### PR DESCRIPTION
Right now the custom matcher in tooltip2.spec.js would always show 'to have' message, as `result.message` would always evaluate to false. Probably a typo.