### PR TITLE
#4823 Carusel corrupted if render slides with ng-repeat and change slides set.

### DIFF
--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -179,6 +179,7 @@ angular.module('ui.bootstrap.carousel', [])
       } else {
         self.select(slides[index]);
       }
+      $scope.$currentTransition = null;
     } else if (currentIndex > index) {
       currentIndex--;
     }


### PR DESCRIPTION
turns off animation trottling in case of changing active slides during remove process.