### PR TITLE
fix(debounce): Properly pass arguments to debounced function

### DIFF
--- a/src/debounce/debounce.js
+++ b/src/debounce/debounce.js
@@ -8,7 +8,7 @@ angular.module('ui.bootstrap.debounce', [])
 
       return function() {
         var self = this;
-        var args = Array.prototype.slice(arguments);
+        var args = Array.prototype.slice.call(arguments);
         if (timeoutPromise) {
           $timeout.cancel(timeoutPromise);
         }

--- a/src/debounce/test/debounce.spec.js
+++ b/src/debounce/test/debounce.spec.js
@@ -1,5 +1,5 @@
 describe('$$debounce', function() {
-  var $$debounce, $timeout, debouncedFunction, i;
+  var $$debounce, $timeout, debouncedFunction, i, args;
 
   beforeEach(module('ui.bootstrap.debounce'));
   beforeEach(inject(function(_$$debounce_, _$timeout_) {
@@ -7,6 +7,7 @@ describe('$$debounce', function() {
     $timeout = _$timeout_;
     i = 0;
     debouncedFunction = $$debounce(function() {
+      args = Array.prototype.slice.call(arguments);
       i++;
     }, 100);
   }));
@@ -36,5 +37,12 @@ describe('$$debounce', function() {
     $timeout.flush(50);
 
     expect(i).toBe(1);
+  });
+
+  it('should properly pass arguments to debounced function', function() {
+    debouncedFunction(1, 2, 3);
+    $timeout.flush(100);
+
+    expect(args).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
Original callback should be invoked with correct arguments passed to debounced function.

Closes #4859