### PR TITLE
refactor(modal): don't use reserved keywords for IE9 compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,7 @@
     "block-scoped-var": 2,
     "complexity": 2,
     "curly": 2,
-    "dot-notation": 2,
+    "dot-notation": [2, {"allowKeywords": false}],
     "eqeqeq": 2,
     "guard-for-in": 2,
     "semi": 2,

--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -15,7 +15,7 @@ angular.module('ui.bootstrap.collapse', [])
               addClass: 'in',
               easing: 'ease',
               to: { height: element[0].scrollHeight + 'px' }
-            }).start().finally(expandDone);
+            }).start()['finally'](expandDone);
           } else {
             $animate.addClass(element, 'in', {
               to: { height: element[0].scrollHeight + 'px' }
@@ -50,7 +50,7 @@ angular.module('ui.bootstrap.collapse', [])
             $animateCss(element, {
               removeClass: 'in',
               to: {height: '0'}
-            }).start().finally(collapseDone);
+            }).start()['finally'](collapseDone);
           } else {
             $animate.removeClass(element, 'in', {
               to: {height: '0'}

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -673,7 +673,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
               modalOpenedDeferred.reject(reason);
               modalResultDeferred.reject(reason);
             })
-            ["finally"](function() {
+            ['finally'](function() {
               if (promiseChain === samePromise) {
                 promiseChain = null;
               }

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -673,7 +673,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
               modalOpenedDeferred.reject(reason);
               modalResultDeferred.reject(reason);
             })
-            .finally(function() {
+            ["finally"](function() {
               if (promiseChain === samePromise) {
                 promiseChain = null;
               }

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -672,8 +672,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
             }, function resolveError(reason) {
               modalOpenedDeferred.reject(reason);
               modalResultDeferred.reject(reason);
-            })
-            ['finally'](function() {
+            })['finally'](function() {
               if (promiseChain === samePromise) {
                 promiseChain = null;
               }


### PR DESCRIPTION
IE9 sees `.finally()` as a keyword.  This gets fixed with the ".min.js" version of the build, but precludes us from using the non-minified version in development.  Using the `["finally"]` form of this function fixes it and all is good with the world.