### PR TITLE
Fixed an issue when dropdown isn't hiding on blur

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -403,6 +403,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
         modelCtrl.$viewValue = '';
         element.val('');
       }
+      resetMatches();
       hasFocus = false;
       selected = false;
     });


### PR DESCRIPTION
Watch this video to reproduce: https://drive.google.com/file/d/0BwFqqUDC76RARU1MV0x3ZWV0OFk/view?usp=sharing

OS: Kubuntu 14.04
Browser: Chrome Version 45.0.2454.93 (64-bit)

Not sure that this fix is correct, but it works (dropdown is hidden on blur).
