### PR TITLE
fix(typeahead): fix typeahead programmatically focus issue

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -1337,6 +1337,7 @@ describe('typeahead tests', function() {
       var element = prepareInputEl('<div><input ng-model="result" uib-typeahead="item for item in source | filter:$viewValue" typeahead-min-length="0"></div>');
       var inputEl = findInput(element);
       inputEl.focus();
+      $timeout.flush();
       $scope.$digest();
       expect(element).toBeOpenWithActive(3, 0);
     });

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -407,7 +407,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
     element.bind('focus', function () {
       hasFocus = true;
       if (minLength === 0 && !modelCtrl.$viewValue) {
-        getMatchesAsync(modelCtrl.$viewValue);
+        $timeout(function() {
+          getMatchesAsync(modelCtrl.$viewValue);
+        }, 0);
       }
     });
 


### PR DESCRIPTION
Fix issue mentioned in the comments of #764 that open it programmatically by using .focus() is not working