### PR TITLE
fix tooltip.addClass() argument

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -189,7 +189,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
                     options.placementClassPrefix + 'right-bottom');
 
                   var placement = ttPosition.placement.split('-');
-                  tooltip.addClass(placement[0], options.placementClassPrefix + ttPosition.placement);
+                  tooltip.addClass(placement[0] + ' ' + options.placementClassPrefix + ttPosition.placement);
                   $position.positionArrow(tooltip, ttPosition.placement);
 
                   positionTimeout = null;


### PR DESCRIPTION
If used jQuery UI, second argument for .addClass() is duration
```
.addClass( className [, duration ] [, easing ] [, complete ] )
```
[.addClass()](http://api.jqueryui.com/addClass/)

> duration (default: 400)
> Type: Number or String
> A string or number determining how long the animation will run.

```
tooltip.addClass(placement[0], options.placementClassPrefix + ttPosition.placement);
```
This code give move animation with default duration value `{duration: 400}`
May be this animation effect not needed?
