### PR TITLE
fix(position): positionArrow descendant selector

### DIFF
--- a/src/position/position.js
+++ b/src/position/position.js
@@ -464,16 +464,12 @@ angular.module('ui.bootstrap.position', [])
       positionArrow: function(elem, placement) {
         elem = this.getRawNode(elem);
 
-        var isTooltip = true;
-
-        var innerElem = elem.querySelector('.tooltip-inner');
-        if (!innerElem) {
-          isTooltip = false;
-          innerElem = elem.querySelector('.popover-inner');
-        }
+        var innerElem = elem.querySelector('.tooltip-inner, .popover-inner');
         if (!innerElem) {
           return;
         }
+
+        var isTooltip = angular.element(innerElem).hasClass('tooltip-inner');
 
         var arrowElem = isTooltip ? elem.querySelector('.tooltip-arrow') : elem.querySelector('.arrow');
         if (!arrowElem) {


### PR DESCRIPTION
- The element selector was not limited to direct descendants so
nested tooltip/popover arrow elements were getting selected instead
of the direct descendant arrow element.

Fixes #5230