### PR TITLE
Added a way to get the number of opened windows

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -524,6 +524,10 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
       $modalStack.getTop = function() {
         return openedWindows.top();
       };
+      
+      $modalStack.getOpenedWindowsNum = function() {
+        return openedWindows.length();
+      }
 
       $modalStack.modalRendered = function(modalInstance) {
         var modalWindow = openedWindows.get(modalInstance);

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -527,7 +527,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
       
       $modalStack.getOpenedWindowsNum = function() {
         return openedWindows.length();
-      }
+      };
 
       $modalStack.modalRendered = function(modalInstance) {
         var modalWindow = openedWindows.get(modalInstance);


### PR DESCRIPTION
Using the `$uibModalStack.getOpenedWindowsNum()` we can get the number of opened windows/modals. This is great if we want to integrate with the angular-material design and edit the dropdown menu's z-index using the same formula as in the modal in angular-ui.