### PR TITLE
Added reopen-on-click typeahead option (Issue #759)

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -81,6 +81,8 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
 
     var showHint = originalScope.$eval(attrs.typeaheadShowHint) || false;
 
+    var reopenOnClick = originalScope.$eval(attrs.typeaheadReopenOnClick) || false;
+
     //INTERNAL VARIABLES
 
     //model setter executed upon match selection
@@ -451,6 +453,10 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
         if (!$rootScope.$$phase) {
           scope.$digest();
         }
+      } else if (reopenOnClick && element[0] === evt.target && element.val().length) {
+        element.focus();
+        hasFocus = true;
+        getMatchesAsync(modelCtrl.$viewValue, evt);
       }
     };
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -453,7 +453,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
         if (!$rootScope.$$phase) {
           scope.$digest();
         }
-      } else if (reopenOnClick && element[0] === evt.target && element.val().length) {
+      } else if (reopenOnClick && element[0] === evt.target && modelCtrl.$viewValue.length) {
         element.focus();
         hasFocus = true;
         getMatchesAsync(modelCtrl.$viewValue, evt);


### PR DESCRIPTION
Added code to allow to reopen the typeahead list on click, as per issue #759. This requires adding the "typeahead-reopen-on-click" boolean attribute to the typeahead input, example:
<input type="text" uib-typeahead="obj for obj in objs" typeahead-reopen-on-click="true">

Only works on typeahead-editable="true" since otherwise the view value is erased on blur. The `element[0] === evt.target` comparison makes sure only the clicked typeahead's list is reopened.