### PR TITLE
fix(modal): fix race condition with openedClass

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -479,7 +479,9 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
 
         $animate.enter($compile(angularDomEl)(modal.scope), appendToElement)
           .then(function() {
-            $animate.addClass(appendToElement, modalBodyClass);
+            if (!modal.scope.$$uibDestructionScheduled) {
+              $animate.addClass(appendToElement, modalBodyClass);
+            }
           });
 
         openedWindows.top().value.modalDomEl = angularDomEl;

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -1219,6 +1219,16 @@ describe('$uibModal', function() {
         expect(body).not.toHaveClass('bar');
         expect(body).not.toHaveClass('modal-open');
       });
+
+      it('should not add the modal-open class if modal is closed before animation', function() {
+        var modal = open({
+          template: '<div>dummy modal</div>'
+        }, true);
+
+        close(modal);
+
+        expect(body).not.toHaveClass('modal-open');
+      });
     });
   });
 


### PR DESCRIPTION
When `modal-window` entering animation runs after the modal has closed `openedClass` is left to `body` element.

This pull request fixes the issue by checking if modal closing has been scheduled after the animation has finished.