### PR TITLE
fix(tabs): adding bootstrap 4 specific class

### DIFF
--- a/src/tabs/test/tabs.spec.js
+++ b/src/tabs/test/tabs.spec.js
@@ -56,6 +56,9 @@ describe('tabs', function() {
     it('should pass class and other attributes on to tab template', function() {
       expect(elm).toHaveClass('hello');
       expect(elm.attr('data-pizza')).toBe('pepperoni');
+      //Ensure that we have bootstrap 4 link class so things are future proofed.
+      var link = $(elm.find('a')[0]);
+      expect(link).toHaveClass('nav-link');
     });
 
     it('should create clickable titles', function() {

--- a/template/tabs/tab.html
+++ b/template/tabs/tab.html
@@ -1,3 +1,3 @@
-<li ng-class="{active: active, disabled: disabled}" class="uib-tab">
-  <a href ng-click="select()" uib-tab-heading-transclude>{{heading}}</a>
+<li ng-class="{active: active, disabled: disabled}" class="uib-tab nav-item">
+  <a href ng-click="select()" class="nav-link" uib-tab-heading-transclude>{{heading}}</a>
 </li>


### PR DESCRIPTION
adding `nav-link` class to tab items to future-proof  for bootstrap 4: docs here: 
http://v4-alpha.getbootstrap.com/components/navs/#tabs

As far as I have looked, this class should not interfere or collide with any existing bootstrap 3 classes, and makes tabs usable for bootstrap 4.