### PR TITLE
feat(modal): Call $onInit on controller if defined

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -687,6 +687,9 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
                       ctrlInstance.$close = modalScope.$close;
                       ctrlInstance.$dismiss = modalScope.$dismiss;
                       angular.extend(ctrlInstance, providedScope);
+                      if (angular.isFunction(ctrlInstance.$onInit)) {
+                        ctrlInstance.$onInit();
+                      }
                     }
 
                     modalScope[modalOptions.controllerAs] = ctrlInstance;

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -826,6 +826,27 @@ describe('$uibModal', function() {
         });
         expect($document).toHaveModalOpenWithContent('Content from ctrl true bar', 'div');
       });
+
+      it('should have $onInit called', function() {
+        var $scope = $rootScope.$new(true);
+        var $onInit = jasmine.createSpy('$onInit');
+        $scope.foo = 'bar';
+        open({
+          template: '<div>{{test.fromCtrl}} {{test.closeDismissPresent()}} {{test.foo}}</div>',
+          controller: function($uibModalInstance) {
+            this.$onInit = $onInit;
+            this.fromCtrl = 'Content from ctrl';
+            this.closeDismissPresent = function() {
+              return angular.isFunction(this.$close) && angular.isFunction(this.$dismiss);
+            };
+          },
+          controllerAs: 'test',
+          bindToController: true,
+          scope: $scope
+        });
+        expect($document).toHaveModalOpenWithContent('Content from ctrl true bar', 'div');
+        expect($onInit).toHaveBeenCalled();
+      });
     });
 
     describe('resolve', function() {


### PR DESCRIPTION
After being instantiated, modal controllers which use ‘bindToController’ will have $onInit called, if defined.

Closes #5472