### PR TITLE
fix(datepicker): fix popup to work with ng-model-options:updateOn='default'

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -836,6 +836,9 @@ function($scope, $element, $attrs, $compile, $log, $parse, $window, $document, $
     popupEl = angular.element('<div uib-datepicker-popup-wrap><div uib-datepicker></div></div>');
     $scope.ngModelOptions = angular.copy(ngModelOptions);
     $scope.ngModelOptions.timezone = null;
+    if ($scope.ngModelOptions.updateOnDefault === true) {
+      $scope.ngModelOptions.updateOn = $scope.ngModelOptions.updateOn ? $scope.ngModelOptions.updateOn + ' default' : 'default';
+    }
     popupEl.attr({
       'ng-model': 'date',
       'ng-model-options': 'ngModelOptions',

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -3645,6 +3645,30 @@ describe('datepicker', function() {
         });
       });
 
+      describe('works with ngModelOptions updateOn : "default"', function() {
+        var $timeout, wrapElement;
+
+        beforeEach(inject(function(_$document_, _$sniffer_, _$timeout_) {
+          $document = _$document_;
+          $timeout = _$timeout_;
+          $rootScope.isopen = true;
+          $rootScope.date = new Date('2010-09-30T10:00:00.000Z');
+          wrapElement = $compile('<div><input ng-model="date" ' +
+            'ng-model-options="{ updateOn: \'default\' }" ' +
+            'uib-datepicker-popup is-open="isopen"><div>')($rootScope);
+          $rootScope.$digest();
+          assignElements(wrapElement);
+        }));
+
+        it('should close the popup and update the input when a day is clicked', function() {
+          clickOption(17);
+          assignElements(wrapElement);
+          expect(dropdownEl.length).toBe(0);
+          expect(inputEl.val()).toBe('2010-09-15');
+          expect($rootScope.date).toEqual(new Date('2010-09-15T10:00:00.000Z'));
+        });
+      });
+
       describe('attribute `datepickerOptions`', function() {
         describe('show-weeks', function() {
           beforeEach(function() {


### PR DESCRIPTION
When using datepicker with popup and `ng-model-options="{ updateOn: 'default'}"`, value can not be set via popup. 

Plnkr with the problem(and hacky solution):
http://plnkr.co/edit/4LLbxCkWBzoPwJuOAbye?p=preview

This PR fixes this problem and selection(update model) via datepicker popup is possible again.

## Use case for this scenario

Often we define `ng-model-options={ updateOn: 'blur'}` for multiple wrapped elements(e.g form). 
For datepicker that is inside that element(form) usually doesn't make sense to update model value on blur, so we need to add `ng-model-options` to the datepicker element.

## Technical information
AngularJS directive `ng-model-options` parses the given expression and object that is set to `ngModel.$options` is different then the object in expression. Here is `ngModelOptions` directives from angularJS code that changes this:
```javascript
var ngModelOptionsDirective = function() {
  return {
    restrict: 'A',
    controller: ['$scope', '$attrs', function($scope, $attrs) {
      var that = this;
      this.$options = copy($scope.$eval($attrs.ngModelOptions));
      // Allow adding/overriding bound events
      if (isDefined(this.$options.updateOn)) {
        this.$options.updateOnDefault = false;
        // extract "default" pseudo-event from list of events that can trigger a model update
        this.$options.updateOn = trim(this.$options.updateOn.replace(DEFAULT_REGEXP, function() {
          that.$options.updateOnDefault = true;
          return ' ';
        }));
      } else {
        this.$options.updateOnDefault = true;
      }
    }]
  };
```

So when we use `ngModelOptions.$options` value to compile `uib-datepicker-popup-wrap` , we lose `updateOn` property and ngModel can not be updated using the pop up.
