### PR TITLE
fix(grunt): do not inject uib css by default (issue #5548)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -436,7 +436,7 @@ module.exports = function(grunt) {
       .replace(/\\/g, '\\\\')
       .replace(/'/g, "\\'")
       .replace(/\r?\n/g, '\\n');
-    js = `angular.module('ui.bootstrap.${moduleName}').run(function() {!angular.$$csp().noInlineStyle && angular.element(document).find('head').prepend('<style type="text/css">${css}</style>'); });`;
+    js = `angular.module('ui.bootstrap.${moduleName}').run(function() {!angular.$$csp().noInlineStyle && angular.$$uibInjectCss && angular.element(document).find('head').prepend('<style type="text/css">${css}</style>'); });`;
     state.js.push(js);
 
     return state;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -436,7 +436,7 @@ module.exports = function(grunt) {
       .replace(/\\/g, '\\\\')
       .replace(/'/g, "\\'")
       .replace(/\r?\n/g, '\\n');
-    js = `angular.module('ui.bootstrap.${moduleName}').run(function() {!angular.$$csp().noInlineStyle && angular.$$uibInjectCss && angular.element(document).find('head').prepend('<style type="text/css">${css}</style>'); });`;
+    js = `angular.module('ui.bootstrap.${moduleName}').run(function() {!angular.$$csp().noInlineStyle && !angular.$$uibCss && angular.element(document).find('head').prepend('<style type="text/css">${css}</style>'); angular.$$uibCss = true; });`;
     state.js.push(js);
 
     return state;


### PR DESCRIPTION
Injecting CSS in the run block causes memory leaks when running jasmine tests