### PR TITLE
fix(modal): fix bindToController bug

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -671,7 +671,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
                   }
                 });
 
-                var ctrlInstance, ctrlLocals = {};
+                var ctrlInstance, ctrlInstantiate, ctrlLocals = {};
 
                 //controllers
                 if (modalOptions.controller) {
@@ -681,18 +681,28 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
                     ctrlLocals[key] = value;
                   });
 
-                  ctrlInstance = $controller(modalOptions.controller, ctrlLocals);
+                  // the third param will make the controller instantiate later,private api
+                  // @see https://github.com/angular/angular.js/blob/master/src/ng/controller.js#L126
+                  ctrlInstantiate = $controller(modalOptions.controller, ctrlLocals, true);
                   if (modalOptions.controllerAs) {
+
+                    ctrlInstance = ctrlInstantiate.instance;
+
                     if (modalOptions.bindToController) {
                       ctrlInstance.$close = modalScope.$close;
                       ctrlInstance.$dismiss = modalScope.$dismiss;
                       angular.extend(ctrlInstance, providedScope);
-                      if (angular.isFunction(ctrlInstance.$onInit)) {
-                        ctrlInstance.$onInit();
-                      }
+
+                    }
+
+                    ctrlInstance = ctrlInstantiate();
+                    if (angular.isFunction(ctrlInstance.$onInit)) {
+                      ctrlInstance.$onInit();
                     }
 
                     modalScope[modalOptions.controllerAs] = ctrlInstance;
+                  } else {
+                    ctrlInstantiate();
                   }
                 }
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -685,7 +685,6 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
                   // @see https://github.com/angular/angular.js/blob/master/src/ng/controller.js#L126
                   ctrlInstantiate = $controller(modalOptions.controller, ctrlLocals, true);
                   if (modalOptions.controllerAs) {
-
                     ctrlInstance = ctrlInstantiate.instance;
 
                     if (modalOptions.bindToController) {
@@ -696,13 +695,13 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
 
                     ctrlInstance = ctrlInstantiate();
 
-                    if (modalOptions.bindToController && angular.isFunction(ctrlInstance.$onInit)) {
-                      ctrlInstance.$onInit();
-                    }
-
                     modalScope[modalOptions.controllerAs] = ctrlInstance;
                   } else {
-                    ctrlInstantiate();
+                    ctrlInstance = ctrlInstantiate();
+                  }
+
+                  if (angular.isFunction(ctrlInstance.$onInit)) {
+                    ctrlInstance.$onInit();
                   }
                 }
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -692,11 +692,11 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap'])
                       ctrlInstance.$close = modalScope.$close;
                       ctrlInstance.$dismiss = modalScope.$dismiss;
                       angular.extend(ctrlInstance, providedScope);
-
                     }
 
                     ctrlInstance = ctrlInstantiate();
-                    if (angular.isFunction(ctrlInstance.$onInit)) {
+
+                    if (modalOptions.bindToController && angular.isFunction(ctrlInstance.$onInit)) {
                       ctrlInstance.$onInit();
                     }
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -815,6 +815,7 @@ describe('$uibModal', function() {
         open({
           template: '<div>{{test.fromCtrl}} {{test.closeDismissPresent()}} {{test.foo}}</div>',
           controller: function($uibModalInstance) {
+            expect(this.foo).toEqual($scope.foo);
             this.fromCtrl = 'Content from ctrl';
             this.closeDismissPresent = function() {
               return angular.isFunction(this.$close) && angular.isFunction(this.$dismiss);


### PR DESCRIPTION
when set bindToController true,props not be bound to controller instance correctly before it initialize,this pointer not be init with $scope props

what I added in modal unit test
```js
var $scope = $rootScope.$new(true);
$scope.foo = 'bar';
open({
  template: '<div>{{test.fromCtrl}} {{test.closeDismissPresent()}} {{test.foo}}</div>',
  controller: function($uibModalInstance) {
  + expect(this.foo).toEqual($scope.foo);
    this.fromCtrl = 'Content from ctrl';
    this.closeDismissPresent = function() {
```
it will make the test fail
```shell
Expected undefined to equal 'bar'.
```
because the props not bound to the this instance of controller correctly before the controller constructor called.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular-ui/bootstrap/5569)
<!-- Reviewable:end -->
