### PR TITLE
fix(position): auto position append to body

### DIFF
--- a/src/position/position.js
+++ b/src/position/position.js
@@ -387,7 +387,7 @@ angular.module('ui.bootstrap.position', [])
         var targetElemPos = {top: 0, left: 0, placement: ''};
 
         if (placement[2]) {
-          var viewportOffset = this.viewportOffset(hostElem);
+          var viewportOffset = this.viewportOffset(hostElem, appendToBody);
 
           var targetElemStyle = $window.getComputedStyle(targetElem);
           var adjustedSize = {


### PR DESCRIPTION
Use the body as the viewport to determine available size for auto position when the target element is append-to-body.

Fixes #5576