### PR TITLE
fix(outsideClick): closing when event element is removed from DOM

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -10,7 +10,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
 
   this.open = function(dropdownScope) {
     if (!openScope) {
-      $document.on('click', closeDropdown);
+      document.body.addEventListener('click', closeDropdown, true);
       $document.on('keydown', keybindFilter);
     }
 
@@ -24,7 +24,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
   this.close = function(dropdownScope) {
     if (openScope === dropdownScope) {
       openScope = null;
-      $document.off('click', closeDropdown);
+      document.body.removeEventListener('click', closeDropdown, true);
       $document.off('keydown', keybindFilter);
     }
   };

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -54,14 +54,14 @@ describe('uib-dropdown', function() {
       expect(element).toHaveClass(dropdownConfig.openClass);
 
       var optionEl = element.find('ul > li').eq(0).find('a').eq(0);
-      optionEl.click();
+      optionEl[0].click();
       expect(element).not.toHaveClass(dropdownConfig.openClass);
     });
 
     it('should close on document click', function() {
       clickDropdownToggle();
       expect(element).toHaveClass(dropdownConfig.openClass);
-      $document.click();
+      $document[0].body.click();
       expect(element).not.toHaveClass(dropdownConfig.openClass);
     });
 
@@ -186,7 +186,7 @@ describe('uib-dropdown', function() {
       expect(element).toHaveClass(dropdownConfig.openClass);
 
       $rootScope.$apply(function() {
-        $document.click();
+        $document[0].body.click();
       });
 
       expect(element).not.toHaveClass(dropdownConfig.openClass);
@@ -455,7 +455,7 @@ describe('uib-dropdown', function() {
         element = dropdown();
         clickDropdownToggle();
         expect(element).toHaveClass(dropdownConfig.openClass);
-        $document.click();
+        $document[0].body.click();
         expect(element).not.toHaveClass(dropdownConfig.openClass);
       });
 
@@ -463,7 +463,7 @@ describe('uib-dropdown', function() {
         element = dropdown('');
         clickDropdownToggle();
         expect(element).toHaveClass(dropdownConfig.openClass);
-        $document.click();
+        $document[0].body.click();
         expect(element).not.toHaveClass(dropdownConfig.openClass);
       });
     });
@@ -540,7 +540,7 @@ describe('uib-dropdown', function() {
         expect(element).toHaveClass(dropdownConfig.openClass);
         element.find('ul li a').click();
         expect(element).toHaveClass(dropdownConfig.openClass);
-        $document.click();
+        $document[0].body.click();
         expect(element).not.toHaveClass(dropdownConfig.openClass);
       });
 
@@ -551,7 +551,7 @@ describe('uib-dropdown', function() {
         expect(dropdownMenu.parent()).toHaveClass(dropdownConfig.appendToOpenClass);
         dropdownMenu.find('li').eq(0).trigger('click');
         expect(dropdownMenu.parent()).toHaveClass(dropdownConfig.appendToOpenClass);
-        $document.click();
+        $document[0].body.click();
         expect(dropdownMenu.parent()).not.toHaveClass(dropdownConfig.appendToOpenClass);
       });
     });

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -490,7 +490,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
               });
               triggers.hide.forEach(function(trigger) {
                 if (trigger === 'outsideClick') {
-                  $document.off('click', bodyHideTooltipBind);
+                  $document[0].removeEventListener('click', bodyHideTooltipBind, true);
                 } else {
                   element.off(trigger, hideTooltipBind);
                 }
@@ -507,7 +507,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
                 triggers.show.forEach(function(trigger, idx) {
                   if (trigger === 'outsideClick') {
                     element.on('click', toggleTooltipBind);
-                    $document.on('click', bodyHideTooltipBind);
+                    $document[0].addEventListener('click', bodyHideTooltipBind, true);
                   } else if (trigger === triggers.hide[idx]) {
                     element.on(trigger, toggleTooltipBind);
                   } else if (trigger) {


### PR DESCRIPTION
Prevent popover and dropdowns that have outsideClick from closing when the element clicked is inside the popover or dropdown the click event causes the element to be removed from the DOM.

Bug Example: http://plnkr.co/edit/a7mCnSmMfrARKCfDxCTw?p=preview
Fix Example: http://plnkr.co/edit/TSAjXnlMMNRSnuneRZsT?p=preview