### PR TITLE
add a customOptions attribute to uibAccordionGroup

### DIFF
--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -78,6 +78,7 @@ angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse'])
 
       scope.openClass = attrs.openClass || 'panel-open';
       scope.panelClass = attrs.panelClass || 'panel-default';
+      scope.customOptions = attrs.customOptions ? JSON.parse(attrs.customOptions) : '';
       scope.$watch('isOpen', function(value) {
         element.toggleClass(scope.openClass, !!value);
         if (value) {

--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -78,7 +78,7 @@ angular.module('ui.bootstrap.accordion', ['ui.bootstrap.collapse'])
 
       scope.openClass = attrs.openClass || 'panel-open';
       scope.panelClass = attrs.panelClass || 'panel-default';
-      scope.customOptions = attrs.customOptions ? JSON.parse(attrs.customOptions) : '';
+      scope.customOptions = attrs.customOptions ? angular.fromJson(attrs.customOptions) : {};
       scope.$watch('isOpen', function(value) {
         element.toggleClass(scope.openClass, !!value);
         if (value) {

--- a/src/accordion/docs/readme.md
+++ b/src/accordion/docs/readme.md
@@ -41,6 +41,10 @@ The body of each accordion group is transcluded into the body of the collapsible
   _(Default: `uib/template/accordion/accordion-group.html`)_ -
   Add the ability to override the template used on the component.
 
+*  `custom-options`
+  _(Default: `{}`)_ -
+  A json oblject to be pass to custom templates
+
 ### Accordion heading
 
 Instead of the `heading` attribute on the `uib-accordion-group`, you can use an `uib-accordion-heading` element inside a group that will be used as the group's header.


### PR DESCRIPTION
This is useful if you want to pass custom attributes to a custom template. It needs a Json object as a value.