### PR TITLE
fix(modal): remove a trailing space in class attribute

### DIFF
--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -2,5 +2,5 @@
     uib-modal-animation-class="fade"
     modal-in-class="in"
     ng-style="{'z-index': 1050 + index*10, display: 'block'}">
-    <div class="modal-dialog {{size ? 'modal-' + size : ''}}"><div class="modal-content" uib-modal-transclude></div></div>
+    <div class="modal-dialog{{size ? ' modal-' + size : ''}}"><div class="modal-content" uib-modal-transclude></div></div>
 </div>


### PR DESCRIPTION
- Remove a trailing space of `class="modal-dialog "`

It was introduced in #5224 with [a reason](https://github.com/angular-ui/bootstrap/pull/5224#discussion-diff-49548766) but we can remove it without using `ng-class`.