### PR TITLE
feat(rating): ability to disable rating reset

### DIFF
--- a/src/rating/docs/readme.md
+++ b/src/rating/docs/readme.md
@@ -38,6 +38,11 @@ Rating directive that will take care of visualising a star rating bar.
   _(Default: ['one', 'two', 'three', 'four', 'five']`)_ -
   An array of strings defining titles for all icons.
 
+* `enable-reset`
+  <small class="badge">$</small>
+  _(Default: `true`)_ -
+  Clicking the icon of the current rating will reset the rating to 0.
+
 * `state-off`
   <small class="badge">$</small>
   <small class="badge">C</small>

--- a/src/rating/rating.js
+++ b/src/rating/rating.js
@@ -4,6 +4,7 @@ angular.module('ui.bootstrap.rating', [])
   max: 5,
   stateOn: null,
   stateOff: null,
+  enableReset: true,
   titles : ['one', 'two', 'three', 'four', 'five']
 })
 
@@ -25,7 +26,9 @@ angular.module('ui.bootstrap.rating', [])
 
     this.stateOn = angular.isDefined($attrs.stateOn) ? $scope.$parent.$eval($attrs.stateOn) : ratingConfig.stateOn;
     this.stateOff = angular.isDefined($attrs.stateOff) ? $scope.$parent.$eval($attrs.stateOff) : ratingConfig.stateOff;
-    var tmpTitles = angular.isDefined($attrs.titles) ? $scope.$parent.$eval($attrs.titles) : ratingConfig.titles ;
+    this.enableReset = angular.isDefined($attrs.enableReset) ?
+      $scope.$parent.$eval($attrs.enableReset) : ratingConfig.enableReset;
+    var tmpTitles = angular.isDefined($attrs.titles) ? $scope.$parent.$eval($attrs.titles) : ratingConfig.titles;
     this.titles = angular.isArray(tmpTitles) && tmpTitles.length > 0 ?
       tmpTitles : ratingConfig.titles;
 
@@ -52,7 +55,8 @@ angular.module('ui.bootstrap.rating', [])
 
   $scope.rate = function(value) {
     if (!$scope.readonly && value >= 0 && value <= $scope.range.length) {
-      ngModelCtrl.$setViewValue(ngModelCtrl.$viewValue === value ? 0 : value);
+      var newViewValue = self.enableReset && ngModelCtrl.$viewValue === value ? 0 : value;
+      ngModelCtrl.$setViewValue(newViewValue);
       ngModelCtrl.$render();
     }
   };

--- a/src/rating/test/rating.spec.js
+++ b/src/rating/test/rating.spec.js
@@ -146,6 +146,31 @@ describe('rating directive', function() {
     expect(getState()).toEqual([true, true, true, true, true]);
   });
 
+  it('handles enable-reset attribute', function() {
+    $rootScope.canReset = false;
+    element = $compile('<uib-rating ng-model="rate" enable-reset="canReset"></uib-rating>')($rootScope);
+    $rootScope.$digest();
+
+    var star = {
+      states: [true, true, true, true, true],
+      rating: 5
+    };
+
+    var selectStar = getStar(star.rating);
+
+    selectStar.click();
+    $rootScope.$digest();
+    expect(getState()).toEqual(star.states);
+    expect($rootScope.rate).toBe(star.rating);
+    expect(element.attr('aria-valuenow')).toBe(star.rating.toString());
+
+    selectStar.click();
+    $rootScope.$digest();
+    expect(getState()).toEqual(star.states);
+    expect($rootScope.rate).toBe(star.rating);
+    expect(element.attr('aria-valuenow')).toBe(star.rating.toString());
+  });
+
   it('should fire onHover', function() {
     $rootScope.hoveringOver = jasmine.createSpy('hoveringOver');
     element = $compile('<uib-rating ng-model="rate" on-hover="hoveringOver(value)"></uib-rating>')($rootScope);


### PR DESCRIPTION
- Add ability to specify whether clicking the icon of the current rating will reset the rating to 0

See: https://github.com/angular-ui/bootstrap/issues/5532