### PR TITLE
Fix bug when addTab doesn't select 'active' tab

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -48,7 +48,7 @@ angular.module('ui.bootstrap.tabs', [])
       return 0;
     });
 
-    if (tab.index === ctrl.active || !angular.isNumber(ctrl.active) && ctrl.tabs.length === 1) {
+    if (tab.index !== ctrl.active || !angular.isNumber(ctrl.active) && ctrl.tabs.length === 1) {
       var newActiveIndex = findTabIndex(tab.index);
       ctrl.select(newActiveIndex);
     }


### PR DESCRIPTION
When adding a new tab, uib-tabset's `active` attribute isn't used to select the specified (active) tab. This manifests when trying to make the most recently added tab as the active tab.

### HTML
```html
<uib-tabset active="active">
   <uib-tab ng-repeat="t in tabs"> {{t}} </uib-tab>
</uib-tabset> 
<button ng-click="addItem()">Add</button>
```

### script.js

```javascript
$scope.tabs = [];
$scope.active = null;
$scope.addItem() {
   tabs.push("something");
   active = tabs.length-1; // select the most recently added item
}
```

