### PR TITLE
Properly apply right alignment when appendTo is used

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -217,7 +217,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
         if (!rightalign) {
           css.left = pos.left - appendOffset.left + 'px';
         } else {
-          css.right = window.innerWidth -
+          css.right = appendTo.prop('offsetWidth') -
             (pos.left - appendOffset.left + $element.prop('offsetWidth')) + 'px';
         }
       }


### PR DESCRIPTION
When appendTo is used and the dropdown is right-aligned the positioning is off
because it is calculated relative to the window instead of the specified container.