### PR TITLE
feat(typeahead): always visible popup

### DIFF
--- a/src/typeahead/docs/readme.md
+++ b/src/typeahead/docs/readme.md
@@ -91,6 +91,11 @@ This directive works with promises, meaning you can retrieve matches using the `
   _(Default: `false`)_ -
   On blur, select the currently highlighted match.
 
+* `typeahead-close-on-blur`
+  <small class="badge">$</small>
+  _(Default: `true`)_ -
+  When clicking away from editor, close results popup.
+
 * `typeahead-select-on-exact`
   <small class="badge">$</small>
   _(Default: `false`)_ -

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -824,6 +824,17 @@ describe('typeahead tests', function() {
 
   describe('non-regressions tests', function() {
 
+    it('feat 5707 - keeps matches popup open on click outside typeahead when close-on-blur is false', function() {
+      var element = prepareInputEl('<div><input ng-model="result" uib-typeahead="item for item in source | filter:$viewValue" typeahead-close-on-blur="false"></div>');
+
+      changeInputValueTo(element, 'b');
+
+      $document.find('body').click();
+      $scope.$digest();
+
+      expect(element).not.toBeClosed();
+    });
+
     it('issue 231 - closes matches popup on click outside typeahead', function() {
       var element = prepareInputEl('<div><input ng-model="result" uib-typeahead="item for item in source | filter:$viewValue"></div>');
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -61,6 +61,9 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
     //should it select highlighted popup value when losing focus?
     var isSelectOnBlur = angular.isDefined(attrs.typeaheadSelectOnBlur) ? originalScope.$eval(attrs.typeaheadSelectOnBlur) : false;
 
+    //should it select highlighted popup value when losing focus?
+    var isCloseOnBlur = angular.isDefined(attrs.typeaheadCloseOnBlur) ? originalScope.$eval(attrs.typeaheadCloseOnBlur) : true;
+
     //binding to a variable that indicates if there were no results after the query is completed
     var isNoResultsSetter = $parse(attrs.typeaheadNoResults).assign || angular.noop;
 
@@ -455,7 +458,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
     var dismissClickHandler = function(evt) {
       // Issue #3973
       // Firefox treats right click as a click on document
-      if (element[0] !== evt.target && evt.which !== 3 && scope.matches.length !== 0) {
+      if (isCloseOnBlur && element[0] !== evt.target && evt.which !== 3 && scope.matches.length !== 0) {
         resetMatches();
         if (!$rootScope.$$phase) {
           originalScope.$digest();


### PR DESCRIPTION
- Add functionality to not clear results when clicking away from editor
- This is useful when implemented as always visible result list (not a popup)