### PR TITLE
fix(modal): missing require in modal

### DIFF
--- a/src/modal/index.js
+++ b/src/modal/index.js
@@ -1,8 +1,8 @@
+require('../position');
 require('../stackedMap');
 require('../../template/modal/backdrop.html.js');
 require('../../template/modal/window.html.js');
 require('./modal');
-require('../position/position.css');
 
 var MODULE_NAME = 'ui.bootstrap.module.modal';
 


### PR DESCRIPTION
Attempting to import the modal alone without position causes the error:

Error: [$injector:modulerr] Failed to instantiate module ui.bootstrap.module.modal due to:
Error: [$injector:modulerr] Failed to instantiate module ui.bootstrap.modal due to:
Error: [$injector:modulerr] Failed to instantiate module ui.bootstrap.position due to:
Error: [$injector:nomod] Module 'ui.bootstrap.position' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.

Apologies, I'm not sure how to update tests or provide a demo for this since it's strictly a webpack build issue.

Commit message:
Fixes the fact that ui.bootstrap.position is an angular module
dependency but not required in src/modal/index.js