### PR TITLE
feat(dropdown): improve key handling

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -10,8 +10,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
 
   this.open = function(dropdownScope) {
     if (!openScope) {
-      $document.on('click', closeDropdown);
-      $document.on('keydown', keybindFilter);
+      $document.on('click', this.closeDropdown);
     }
 
     if (openScope && openScope !== dropdownScope) {
@@ -24,12 +23,11 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
   this.close = function(dropdownScope) {
     if (openScope === dropdownScope) {
       openScope = null;
-      $document.off('click', closeDropdown);
-      $document.off('keydown', keybindFilter);
+      $document.off('click', this.closeDropdown);
     }
   };
 
-  var closeDropdown = function(evt) {
+  this.closeDropdown = function(evt) {
     // This method may still be called during the same mouse event that
     // unbound this event handler. So check openScope before proceeding.
     if (!openScope) { return; }
@@ -56,16 +54,6 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
     }
   };
 
-  var keybindFilter = function(evt) {
-    if (evt.which === 27) {
-      openScope.focusToggleElement();
-      closeDropdown();
-    } else if (openScope.isKeynavEnabled() && [38, 40].indexOf(evt.which) !== -1 && openScope.isOpen) {
-      evt.preventDefault();
-      evt.stopPropagation();
-      openScope.focusDropdownEntry(evt.which);
-    }
-  };
 }])
 
 .controller('UibDropdownController', ['$scope', '$element', '$attrs', '$parse', 'uibDropdownConfig', 'uibDropdownService', '$animate', '$uibPosition', '$document', '$compile', '$templateRequest', function($scope, $element, $attrs, $parse, dropdownConfig, uibDropdownService, $animate, $position, $document, $compile, $templateRequest) {
@@ -84,6 +72,19 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
     body = $document.find('body');
 
   $element.addClass('dropdown');
+
+  var keybindFilter = function(evt) {
+    if (evt.which === 27 && scope.isOpen) {
+      evt.preventDefault();
+      evt.stopPropagation();
+      scope.focusToggleElement();
+      uibDropdownService.closeDropdown();
+    } else if (scope.isKeynavEnabled() && [38, 40].indexOf(evt.which) !== -1 && scope.isOpen) {
+      evt.preventDefault();
+      evt.stopPropagation();
+      scope.focusDropdownEntry(evt.which);
+    }
+  };
 
   this.init = function() {
     if ($attrs.isOpen) {
@@ -115,6 +116,8 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
         self.dropdownMenu.remove();
       });
     }
+
+    $element.on('keydown', keybindFilter);
   };
 
   this.toggle = function(open) {

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -75,7 +75,7 @@ describe('uib-dropdown', function() {
 
     it('should not close on backspace key', function() {
       clickDropdownToggle();
-      triggerKeyDown($document, 8);
+      triggerKeyDown(element, 8);
       expect(element).toHaveClass(dropdownConfig.openClass);
     });
 
@@ -556,7 +556,7 @@ describe('uib-dropdown', function() {
       clickDropdownToggle();
       expect(element).toHaveClass(dropdownConfig.openClass);
 
-      triggerKeyDown($document, 38);
+      triggerKeyDown(element, 38);
       var focusEl = element.find('ul').eq(0).find('a').eq(0);
       expect(focusEl).not.toHaveFocus();
     });
@@ -574,7 +574,7 @@ describe('uib-dropdown', function() {
     it('should not change focus when other keys are pressed', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
-      triggerKeyDown($document, 37);
+      triggerKeyDown(element, 37);
 
       expect(element).toHaveClass(dropdownConfig.openClass);
       var focusEl = element.find('ul').eq(0).find('a');
@@ -605,7 +605,7 @@ describe('uib-dropdown', function() {
       var focusEl = element.find('ul').eq(0).find('a').eq(1);
       expect(focusEl).toHaveFocus();
 
-      triggerKeyDown($document, 40);
+      triggerKeyDown(element, 40);
       expect(focusEl).toHaveFocus();
     });
 

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -68,7 +68,7 @@ describe('uib-dropdown', function() {
     it('should close on escape key & focus toggle element', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
-      triggerKeyDown($document, 27);
+      triggerKeyDown(element, 27);
       expect(element).not.toHaveClass(dropdownConfig.openClass);
       expect(element.find('a')).toHaveFocus();
     });
@@ -470,7 +470,7 @@ describe('uib-dropdown', function() {
         element = dropdown('disabled');
         $document.find('body').append(element);
         clickDropdownToggle();
-        triggerKeyDown($document, 27);
+        triggerKeyDown(element, 27);
         expect(element).not.toHaveClass(dropdownConfig.openClass);
         expect(element.find('a')).toHaveFocus();
       });
@@ -524,7 +524,7 @@ describe('uib-dropdown', function() {
     it('should focus first list element when down arrow pressed', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
-      triggerKeyDown($document, 40);
+      triggerKeyDown(element, 40);
 
       expect(element).toHaveClass(dropdownConfig.openClass);
       var optionEl = element.find('ul').eq(0).find('a').eq(0);
@@ -533,7 +533,7 @@ describe('uib-dropdown', function() {
 
     it('should not focus first list element when down arrow pressed if closed', function() {
       $document.find('body').append(element);
-      triggerKeyDown($document, 40);
+      triggerKeyDown(element, 40);
 
       expect(element).not.toHaveClass(dropdownConfig.openClass);
       var focusEl = element.find('ul').eq(0).find('a').eq(0);
@@ -543,8 +543,8 @@ describe('uib-dropdown', function() {
     it('should focus second list element when down arrow pressed twice', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
-      triggerKeyDown($document, 40);
-      triggerKeyDown($document, 40);
+      triggerKeyDown(element, 40);
+      triggerKeyDown(element, 40);
 
       expect(element).toHaveClass(dropdownConfig.openClass);
       var focusEl = element.find('ul').eq(0).find('a').eq(1);
@@ -564,7 +564,7 @@ describe('uib-dropdown', function() {
     it('should focus last list element when up arrow pressed after dropdown toggled', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
-      triggerKeyDown($document, 38);
+      triggerKeyDown(element, 38);
 
       expect(element).toHaveClass(dropdownConfig.openClass);
       var focusEl = element.find('ul').eq(0).find('a').eq(1);
@@ -585,10 +585,10 @@ describe('uib-dropdown', function() {
     it('should focus first list element when down arrow pressed 2x and up pressed 1x', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
-      triggerKeyDown($document, 40);
-      triggerKeyDown($document, 40);
+      triggerKeyDown(element, 40);
+      triggerKeyDown(element, 40);
 
-      triggerKeyDown($document, 38);
+      triggerKeyDown(element, 38);
 
       expect(element).toHaveClass(dropdownConfig.openClass);
       var focusEl = element.find('ul').eq(0).find('a').eq(0);
@@ -598,8 +598,8 @@ describe('uib-dropdown', function() {
     it('should stay focused on final list element if down pressed at list end', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
-      triggerKeyDown($document, 40);
-      triggerKeyDown($document, 40);
+      triggerKeyDown(element, 40);
+      triggerKeyDown(element, 40);
 
       expect(element).toHaveClass(dropdownConfig.openClass);
       var focusEl = element.find('ul').eq(0).find('a').eq(1);
@@ -614,13 +614,13 @@ describe('uib-dropdown', function() {
       $document.find('body').append(element);
       clickDropdownToggle();
 
-      triggerKeyDown($document, 40);
+      triggerKeyDown(element, 40);
 
       expect(element).toHaveClass(dropdownConfig.openClass);
       var focusEl = element.find('ul').eq(0).find('a').eq(0);
       expect(focusEl).toHaveFocus();
 
-      triggerKeyDown($document, 27);
+      triggerKeyDown(element, 27);
       expect(element).not.toHaveClass(dropdownConfig.openClass);
     });
 
@@ -636,7 +636,7 @@ describe('uib-dropdown', function() {
       it('should focus first list element when down arrow pressed', function() {
         clickDropdownToggle();
 
-        triggerKeyDown($document, 40);
+        triggerKeyDown(element, 40);
 
         var dropdownMenu = $document.find('#dropdown-menu');
 
@@ -647,8 +647,8 @@ describe('uib-dropdown', function() {
 
       it('should focus second list element when down arrow pressed twice', function() {
         clickDropdownToggle();
-        triggerKeyDown($document, 40);
-        triggerKeyDown($document, 40);
+        triggerKeyDown(element, 40);
+        triggerKeyDown(element, 40);
 
         var dropdownMenu = $document.find('#dropdown-menu');
 


### PR DESCRIPTION
Fixes #5778 Pressing ESC with a dropdown inside a modal dialog
- Move key handler from service to controller, and attach to element instead of $document, so that the key events are received before they are handled by the modal dialog. If ESC is pressed to close the dropdown, consume the event so that the modal dialog doesn't also close.
- Update the tests accordingly to generate key events on the element itself - this now matches the way the typeahead control is implemented and tested