### PR TITLE
feat(typeahead): Support for a `typeahead-should-select` function

### DIFF
--- a/src/typeahead/docs/readme.md
+++ b/src/typeahead/docs/readme.md
@@ -77,6 +77,11 @@ This directive works with promises, meaning you can retrieve matches using the `
   _(Default: `angular.noop`)_ -
   Binding to a variable that indicates if no matching results were found.
 
+* `typeahead-should-select($event)`
+  <small class="badge">$</small>
+  _(Default: `null`)_ -
+  A callback executed when a `keyup` event that might trigger a selection occurs. Selection will only occur if this function returns true.
+
 * `typeahead-on-select($item, $model, $label, $event)`
   <small class="badge">$</small>
   _(Default: `null`)_ -

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -457,6 +457,48 @@ describe('typeahead tests', function() {
     });
   });
 
+  describe('shouldSelect', function() {
+    it('should select a match when function returns true', function() {
+      $scope.shouldSelectFn = function() {
+        return true;
+      };
+      var element = prepareInputEl('<div><input ng-model="result" typeahead-should-select="shouldSelectFn($event)" uib-typeahead="item for item in source | filter:$viewValue"></div>');
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'b');
+      triggerKeyDown(element, 13);
+
+      expect($scope.result).toEqual('bar');
+      expect(inputEl.val()).toEqual('bar');
+      expect(element).toBeClosed();
+    });
+    it('should not select a match when function returns false', function() {
+      $scope.shouldSelectFn = function() {
+        return false;
+      };
+      var element = prepareInputEl('<div><input ng-model="result" typeahead-should-select="shouldSelectFn($event)" uib-typeahead="item for item in source | filter:$viewValue"></div>');
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'b');
+      triggerKeyDown(element, 13);
+
+      // no change
+      expect($scope.result).toEqual('b');
+      expect(inputEl.val()).toEqual('b');
+    });
+    it('should pass key event into select trigger function', function() {
+      $scope.shouldSelectFn = jasmine.createSpy('shouldSelectFn');//.and.returnValue(true);
+      var element = prepareInputEl('<div><input ng-model="result" typeahead-should-select="shouldSelectFn($event)" uib-typeahead="item for item in source | filter:$viewValue"></div>');
+      var inputEl = findInput(element);
+
+      changeInputValueTo(element, 'b');
+      triggerKeyDown(element, 13);
+
+      expect($scope.shouldSelectFn.calls.count()).toEqual(1);
+      expect($scope.shouldSelectFn.calls.argsFor(0)[0].which).toEqual(13);
+    });
+  });
+
   describe('selecting a match', function() {
     it('should select a match on enter', function() {
       var element = prepareInputEl('<div><input ng-model="result" uib-typeahead="item for item in source | filter:$viewValue"></div>');


### PR DESCRIPTION
By default behaves as before. If specified, allows a custom function
to be defined to determine whether the keydown event should trigger
selection

Closes #5671