### PR TITLE
feat(datepickerPopup): support ng-model-options="{updateOn: 'blur'}"

### DIFF
--- a/src/datepickerPopup/popup.js
+++ b/src/datepickerPopup/popup.js
@@ -89,10 +89,7 @@ function($scope, $element, $attrs, $compile, $log, $parse, $window, $document, $
       timezone = ngModelOptions.timezone;
       $scope.ngModelOptions = angular.copy(ngModelOptions);
       $scope.ngModelOptions.timezone = null;
-      if ($scope.ngModelOptions.updateOnDefault === true) {
-        $scope.ngModelOptions.updateOn = $scope.ngModelOptions.updateOn ?
-          $scope.ngModelOptions.updateOn + ' default' : 'default';
-      }
+      $scope.ngModelOptions.updateOn = 'default';
 
       popupEl.attr('ng-model-options', 'ngModelOptions');
     } else {

--- a/src/datepickerPopup/test/popup.spec.js
+++ b/src/datepickerPopup/test/popup.spec.js
@@ -573,6 +573,31 @@ describe('datepicker popup', function() {
     });
   });
 
+  describe('works with ngModelOptions updateOn : "blur"', function() {
+    var $timeout, wrapElement;
+
+    beforeEach(inject(function(_$document_, _$sniffer_, _$timeout_) {
+      $document = _$document_;
+      $timeout = _$timeout_;
+      $rootScope.isopen = true;
+      $rootScope.date = new Date('2010-09-30T10:00:00.000Z');
+      wrapElement = $compile('<div><input ng-model="date" ' +
+        'ng-model-options="{ updateOn: \'blur\' }" ' +
+        'uib-datepicker-popup is-open="isopen"><div>')($rootScope);
+      $rootScope.$digest();
+      assignElements(wrapElement);
+    }));
+
+    it('should close the popup and update the input when a day is clicked', function() {
+      clickOption(17);
+      assignElements(wrapElement);
+      expect(dropdownEl.length).toBe(0);
+      expect(inputEl.val()).toBe('2010-09-15');
+      inputEl.triggerHandler('blur');
+      expect($rootScope.date).toEqual(new Date('2010-09-15T10:00:00.000Z'));
+    });
+  });
+
   describe('attribute `datepickerOptions`', function() {
     describe('show-weeks', function() {
       beforeEach(function() {


### PR DESCRIPTION
As discussed in #4837, datepicker-popup currently does not support `ng-model-options="{updateOn: 'blur'}"` (popup can't be closed). The PR fixes this by always setting `updateOn: 'default'` on the popup.