### PR TITLE
fix(feat): add activeDate to customClass for custom styling

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -243,7 +243,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   };
 
   this.customClass = function(date) {
-    return $scope.customClass({date: date, mode: $scope.datepickerMode});
+    return $scope.customClass({date: date, mode: $scope.datepickerMode, activeDate: self.activeDate});
   };
 
   // Split array into smaller arrays


### PR DESCRIPTION
Proposed enhancement that passes the `activeDate` into the `customClass` function which decorates the `td`. Currently the `active class` is attached to the child button. The active date is a prominent feature of the calendar and thus feels important enough in the custom class context to justify this change. It's also an inexpensive addition that provides a non-invasive opportunity to address issues with the current `active class`.

In my case I'm using it as a non-breaking solution for the issue described in #3879 , where active class is added to the 1st of non-current months. This seems quite opinionated, but is an issue that would be breaking if fixed. Having the ability to wrap the class using the already existing `customClass` feature gives us an easy out.

```
custom-class="vm.calendar.getDayClass(date, mode, activeDate)"
```

```
vm.calendar.getDayClass = function (date, mode, activeDate) {
  var events = vm.calendar.events;

  // custom event classes
  for (var i = 0; i < events.length; i++) {
    var eventDate = new Date(events[i].date).setHours(0, 0, 0, 0);
    var calDate = new Date(date).setHours(0, 0, 0, 0);
    if (eventDate === calDate) {
      return events[i].status;
    }
  }

  // custom active class fix
  var activeMonth = new Date(activeDate).getMonth();
  var currentMonth = new Date().getMonth();
  if (activeMonth !== currentMonth) {
    return 'non-current-month';
  }

  // default
  return '';
};
```