### PR TITLE
feat(tabs): pass the selected tab index to onDeselect

### DIFF
--- a/src/tabs/docs/readme.md
+++ b/src/tabs/docs/readme.md
@@ -33,7 +33,7 @@ AngularJS version of the tabs directive.
 
 * `deselect()`
   <small class="badge">$</small> -
-  An optional expression called when tab is deactivated. Supports $event in template for expression. You may call `$event.preventDefault()` in this event handler to prevent a tab change from occurring.
+  An optional expression called when tab is deactivated. Supports `$event` and `$selectedIndex` in template for expression. You may call `$event.preventDefault()` in this event handler to prevent a tab change from occurring. The `$selectedIndex` can be used to determine which tab was attempted to be opened.
 
 * `disable`
   <small class="badge">$</small>

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -11,7 +11,8 @@ angular.module('ui.bootstrap.tabs', [])
       var previousSelected = ctrl.tabs[previousIndex];
       if (previousSelected) {
         previousSelected.tab.onDeselect({
-          $event: evt
+          $event: evt,
+          $selectedIndex: index
         });
         if (evt && evt.isDefaultPrevented()) {
           return;

--- a/src/tabs/test/tabs.spec.js
+++ b/src/tabs/test/tabs.spec.js
@@ -46,14 +46,14 @@ describe('tabs', function() {
       };
       elm = $compile([
         '<uib-tabset class="hello" data-pizza="pepperoni" active="active">',
-        '  <uib-tab index="1" heading="First Tab {{first}}" classes="{{firstClass}}" select="selectFirst($event)" deselect="deselectFirst($event)">',
+        '  <uib-tab index="1" heading="First Tab {{first}}" classes="{{firstClass}}" select="selectFirst($event)" deselect="deselectFirst($event, $selectedIndex)">',
         '    first content is {{first}}',
         '  </uib-tab>',
-        '  <uib-tab index="2" classes="{{secondClass}}" select="selectSecond($event)" deselect="deselectSecond($event)">',
+        '  <uib-tab index="2" classes="{{secondClass}}" select="selectSecond($event)" deselect="deselectSecond($event, $selectedIndex)">',
         '    <uib-tab-heading><b>Second</b> Tab {{second}}</uib-tab-heading>',
         '    second content is {{second}}',
         '  </uib-tab>',
-        '  <uib-tab index="3" classes="{{thirdClass}}" deselect="deselectThird($event)">',
+        '  <uib-tab index="3" classes="{{thirdClass}}" deselect="deselectThird($event, $selectedIndex)">',
         '    <uib-tab-heading><b>Second</b> Tab {{third}}</uib-tab-heading>',
         '    third content is {{third}}',
         '  </uib-tab>',
@@ -118,12 +118,15 @@ describe('tabs', function() {
       titles().eq(1).find('> a').click();
       expect(scope.deselectFirst).toHaveBeenCalled();
       expect(scope.deselectFirst.calls.argsFor(0)[0].target).toBe(titles().eq(1).find('> a')[0]);
+      expect(scope.deselectFirst.calls.argsFor(0)[1]).toBe(1);
       titles().eq(0).find('> a').click();
       expect(scope.deselectSecond).toHaveBeenCalled();
       expect(scope.deselectSecond.calls.argsFor(0)[0].target).toBe(titles().eq(0).find('> a')[0]);
+      expect(scope.deselectSecond.calls.argsFor(0)[1]).toBe(0);
       titles().eq(1).find('> a').click();
       expect(scope.deselectFirst.calls.count()).toBe(2);
       expect(scope.deselectFirst.calls.argsFor(1)[0].target).toBe(titles().eq(1).find('> a')[0]);
+      expect(scope.deselectFirst.calls.argsFor(1)[1]).toBe(1);
     });
 
     it('should prevent tab deselection when $event.preventDefault() is called', function() {


### PR DESCRIPTION
-  Add the index of the tab the user attempted to open to the onDeselect call, which allows the user to be directed to the selected tab after some work is performed.

- Closes #5820