### PR TITLE
fix(dropdown): Fix alignment for dropdown-append-to-body with .dropdown-menu-right when there's a vertical scrollbar

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -191,7 +191,8 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
     if (appendTo && self.dropdownMenu) {
       var pos = $position.positionElements($element, self.dropdownMenu, 'bottom-left', true),
         css,
-        rightalign;
+        rightalign,
+        scrollbarWidth;
 
       css = {
         top: pos.top + 'px',
@@ -204,7 +205,8 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
         css.right = 'auto';
       } else {
         css.left = 'auto';
-        css.right = window.innerWidth -
+        scrollbarWidth = $position.scrollbarWidth(true);
+        css.right = window.innerWidth - scrollbarWidth -
           (pos.left + $element.prop('offsetWidth')) + 'px';
       }
 


### PR DESCRIPTION
Fixes #4317 

This is going to be difficult to add tests for as the width of the scrollbar (that's used to calculate the alignment) is browser dependent.

[Plunk](http://plnkr.co/edit/bNk7aXxMyDRg0q6XK7sV?p=preview) with fix in place.
