### PR TITLE
Role value should be changed.

### DIFF
--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,4 +1,4 @@
-<div modal-render="{{$isRendered}}" tabindex="-1" role="content" class="modal"
+<div modal-render="{{$isRendered}}" tabindex="-1" role="contentinfo" class="modal"
     uib-modal-animation-class="fade"
     modal-in-class="in"
     ng-style="{'z-index': 1050 + index*10, display: 'block'}">

--- a/template/modal/window.html
+++ b/template/modal/window.html
@@ -1,4 +1,4 @@
-<div modal-render="{{$isRendered}}" tabindex="-1" role="dialog" class="modal"
+<div modal-render="{{$isRendered}}" tabindex="-1" role="content" class="modal"
     uib-modal-animation-class="fade"
     modal-in-class="in"
     ng-style="{'z-index': 1050 + index*10, display: 'block'}">


### PR DESCRIPTION
Currently role="dialog" causes an issue for screen readers like NVDA or Jaws to read the content that is inside of a modal. Proposing the value of role to be changed to role="contentinfo" so that applications like NVDA or JAWS will automatically start reading the contents of a modal once the modal opens.