### PR TITLE
fix(datepickerPopup): datepicker.html loading error

### DIFF
--- a/src/datepickerPopup/index-nocss.js
+++ b/src/datepickerPopup/index-nocss.js
@@ -5,6 +5,6 @@ require('./popup.js');
 
 var MODULE_NAME = 'ui.bootstrap.module.datepickerPopup';
 
-angular.module(MODULE_NAME, ['ui.bootstrap.datepickerPopup', 'uib/template/datepickerPopup/popup.html']);
+angular.module(MODULE_NAME, ['ui.bootstrap.datepickerPopup', 'uib/template/datepickerPopup/popup.html', 'ui.bootstrap.module.datepicker']);
 
 module.exports = MODULE_NAME;


### PR DESCRIPTION
fix 
```
Error: [$compile:tpload] Failed to load template: uib/template/datepicker/datepicker.html (HTTP status: 404 Not Found)
```
when

```js
require('angular-ui-bootstrap/src/datepickerPopup');
```