### PR TITLE
Remove unused variable.

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -28,8 +28,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   var self = this,
       ngModelCtrl = { $setViewValue: angular.noop }, // nullModelCtrl;
       ngModelOptions = {},
-      watchListeners = [],
-      optionsUsed = !!$attrs.datepickerOptions;
+      watchListeners = [];
 
   $element.addClass('uib-datepicker');
   $attrs.$set('role', 'application');


### PR DESCRIPTION
The local variable 'optionsUsed' is unused in datepicker.js