### PR TITLE
* fix(datepickerPopup): use value instead of viewValue

### DIFF
--- a/src/datepickerPopup/popup.js
+++ b/src/datepickerPopup/popup.js
@@ -355,7 +355,7 @@ function($scope, $element, $attrs, $compile, $log, $parse, $window, $document, $
     }
 
     if (angular.isString(value)) {
-      return !isNaN(parseDateString(viewValue));
+      return !isNaN(parseDateString(value));
     }
 
     return false;


### PR DESCRIPTION
This looks like a bug to me. There is a check to test if `value` is a string but `viewValue` is passed to parseDateString.