### PR TITLE
fix(dropdown): align position with or without vertical scrollbar

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -195,7 +195,8 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
       var pos = $position.positionElements($element, self.dropdownMenu, 'bottom-left', true),
         css,
         rightalign,
-        scrollbarWidth;
+        scrollbarPadding,
+        scrollbarWidth = 0;
 
       css = {
         top: pos.top + 'px',
@@ -208,7 +209,12 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.position'])
         css.right = 'auto';
       } else {
         css.left = 'auto';
-        scrollbarWidth = $position.scrollbarWidth(true);
+        scrollbarPadding = $position.scrollbarPadding(appendTo);
+
+        if (scrollbarPadding.heightOverflow && scrollbarPadding.scrollbarWidth) {
+          scrollbarWidth = scrollbarPadding.scrollbarWidth;
+        }
+
         css.right = window.innerWidth - scrollbarWidth -
           (pos.left + $element.prop('offsetWidth')) + 'px';
       }

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -702,4 +702,33 @@ describe('uib-dropdown', function() {
       });
     });
   });
+
+  describe('using dropdown-append-to-body with dropdown-menu-right class', function() {
+    function dropdown() {
+      return $compile('<li style="float: right;" uib-dropdown dropdown-append-to-body><a href uib-dropdown-toggle>Toggle menu</a><ul uib-dropdown-menu class="dropdown-menu-right" id="dropdown-menu"><li><a href>Hello On Body</a></li></ul></li>')($rootScope);
+    }
+
+    beforeEach(function() {
+      element = dropdown();
+      $document.find('body').append(element);
+
+      var menu = $document.find('#dropdown-menu');
+      menu.css('position', 'absolute');
+    });
+
+    afterEach(function() {
+      element.remove();
+    });
+
+    it('should align the menu correctly when the body has no vertical scrollbar', function() {
+      var toggle = element.find('[uib-dropdown-toggle]');
+      var menu = $document.find('#dropdown-menu');
+      toggle.trigger('click');
+
+      // Get the offsets of the rightmost position of both the toggle and the menu (offset from the left of the window)
+      var toggleRight = Math.round(toggle.offset().left + toggle.outerWidth());
+      var menuRight = Math.round(menu.offset().left + menu.outerWidth());
+      expect(menuRight).toBe(toggleRight);
+    });
+  });
 });

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -703,6 +703,7 @@ describe('uib-dropdown', function() {
     });
   });
 
+  // issue #5942
   describe('using dropdown-append-to-body with dropdown-menu-right class', function() {
     function dropdown() {
       return $compile('<li style="float: right;" uib-dropdown dropdown-append-to-body><a href uib-dropdown-toggle>Toggle menu</a><ul uib-dropdown-menu class="dropdown-menu-right" id="dropdown-menu"><li><a href>Hello On Body</a></li></ul></li>')($rootScope);


### PR DESCRIPTION
Fixes #5942.

Plunkr showing the fix:
http://plnkr.co/edit/jlBJjMgpDnR133ByUATF?p=preview

Resubmitted after fixing eslint issues.

Some notes regarding the added test:
1. I've added a test that verifies that dropdown-menu-right works correctly when append-to-body is used. This test requires a real browser (since it must calculate the trigger and menu positions), so you may not wish to include it... On the other hand, it might be better than nothing.
2. The test doesn't cover the case where a vertical scroll bar is present. As far as I can tell, this is very problematic to test since it requires a real environment where we can correctly calculate the width of the scrollbar. This isn't the case when running in Karma.
