### PR TITLE
feat(rating): parameterize icon base class

### DIFF
--- a/src/rating/docs/readme.md
+++ b/src/rating/docs/readme.md
@@ -42,6 +42,11 @@ Rating directive that will take care of visualising a star rating bar.
   <small class="badge">$</small>
   _(Default: `true`)_ -
   Clicking the icon of the current rating will reset the rating to 0.
+  
+* `icon-base-class`
+  <small class="badge">$</small>
+  _(Default: `glyphicon`)_ -
+  A variable used in the template to specify the class applied to all icons. 
 
 * `state-off`
   <small class="badge">$</small>

--- a/src/rating/rating.js
+++ b/src/rating/rating.js
@@ -5,6 +5,7 @@ angular.module('ui.bootstrap.rating', [])
   stateOn: null,
   stateOff: null,
   enableReset: true,
+  iconBaseClass: 'glyphicon',
   titles: ['one', 'two', 'three', 'four', 'five']
 })
 
@@ -26,6 +27,7 @@ angular.module('ui.bootstrap.rating', [])
 
     this.stateOn = angular.isDefined($attrs.stateOn) ? $scope.$parent.$eval($attrs.stateOn) : ratingConfig.stateOn;
     this.stateOff = angular.isDefined($attrs.stateOff) ? $scope.$parent.$eval($attrs.stateOff) : ratingConfig.stateOff;
+    this.iconBaseClass = angular.isDefined($attrs.iconBaseClass) ? $scope.$parent.$eval($attrs.iconBaseClass) : ratingConfig.iconBaseClass;
     this.enableReset = angular.isDefined($attrs.enableReset) ?
       $scope.$parent.$eval($attrs.enableReset) : ratingConfig.enableReset;
     var tmpTitles = angular.isDefined($attrs.titles) ? $scope.$parent.$eval($attrs.titles) : ratingConfig.titles;
@@ -40,7 +42,7 @@ angular.module('ui.bootstrap.rating', [])
 
   this.buildTemplateObjects = function(states) {
     for (var i = 0, n = states.length; i < n; i++) {
-      states[i] = angular.extend({ index: i }, { stateOn: this.stateOn, stateOff: this.stateOff, title: this.getTitle(i) }, states[i]);
+      states[i] = angular.extend({ index: i }, { stateOn: this.stateOn, stateOff: this.stateOff, iconBaseClass: this.iconBaseClass, title: this.getTitle(i) }, states[i]);
     }
     return states;
   };

--- a/src/rating/test/rating.spec.js
+++ b/src/rating/test/rating.spec.js
@@ -365,4 +365,25 @@ describe('rating directive', function() {
       expect(getTitles()).toEqual(['one', 'two', 'three', 'four', 'five']);
     });
   });
+
+  describe('Default icon base class', function() {
+    it('should return the default icon base class for each star', function() {
+      var stars = getStars();
+      for (var i = 0, n = stars.length; i < n; i++) {
+        expect(stars.eq(i).hasClass('glyphicon'));
+      }
+    });
+  });
+
+  describe('Custom icon base class', function() {
+    it('should return the custom icon base class for each star', function() {
+      $rootScope.iconBaseClass = 'foo';
+      element = $compile('<span uib-rating ng-model="rate" icon-base-class="iconBaseClass"></span>')($rootScope);
+      $rootScope.$digest();
+      var stars = getStars();
+      for (var i = 0, n = stars.length; i < n; i++) {
+        expect(stars.eq(i).hasClass('foo'));
+      }
+    });
+  });
 });

--- a/template/rating/rating.html
+++ b/template/rating/rating.html
@@ -1,4 +1,4 @@
 <span ng-mouseleave="reset()" ng-keydown="onKeydown($event)" tabindex="0" role="slider" aria-valuemin="0" aria-valuemax="{{range.length}}" aria-valuenow="{{value}}" aria-valuetext="{{title}}">
     <span ng-repeat-start="r in range track by $index" class="sr-only">({{ $index < value ? '*' : ' ' }})</span>
-    <i ng-repeat-end ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" class="glyphicon" ng-class="$index < value && (r.stateOn || 'glyphicon-star') || (r.stateOff || 'glyphicon-star-empty')" ng-attr-title="{{r.title}}"></i>
+    <i ng-repeat-end ng-mouseenter="enter($index + 1)" ng-click="rate($index + 1)" ng-class="(r.iconBaseClass && r.iconBaseClass + ' ' || '') + ($index < value && (r.stateOn || 'glyphicon-star') || (r.stateOff || 'glyphicon-star-empty'))" ng-attr-title="{{r.title}}"></i>
 </span>


### PR DESCRIPTION
As of today it is not possible to use a different source of icon because the glyphicon class is systematically set in the rating template.

This patch adds a parameter in the directive for the icon base class, setting it to 'glyphicon' by default.