### PR TITLE
fix(datepicker): reset datepickerMode to original values on destroy

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -157,6 +157,12 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     }
     return false;
   };
+  
+  $scope.$watch("selectedDt", function(dt) {
+    if(!dt || ngModelCtrl.$invalid) {
+      setMode(_datepickerModeCache);
+    }
+  });
 
   this.init = function(ngModelCtrl_) {
     ngModelCtrl = ngModelCtrl_;
@@ -341,7 +347,6 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   });
 
   $scope.$on('$destroy', function() {
-    setMode(_datepickerModeCache);
     //Clear all watch listeners on destroy
     while (watchListeners.length) {
       watchListeners.shift()();

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -28,7 +28,8 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   var self = this,
       ngModelCtrl = { $setViewValue: angular.noop }, // nullModelCtrl;
       ngModelOptions = {},
-      watchListeners = [];
+      watchListeners = [],
+      _datepickerModeCache = null;
 
   $element.addClass('uib-datepicker');
   $attrs.$set('role', 'application');
@@ -68,6 +69,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
       case 'datepickerMode':
         $scope.datepickerMode = angular.isDefined($scope.datepickerOptions.datepickerMode) ?
           $scope.datepickerOptions.datepickerMode : datepickerConfig.datepickerMode;
+        _datepickerModeCache = $scope.datepickerMode;
         break;
       case 'formatDay':
       case 'formatDayHeader':
@@ -339,6 +341,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
   });
 
   $scope.$on('$destroy', function() {
+    setMode(_datepickerModeCache);
     //Clear all watch listeners on destroy
     while (watchListeners.length) {
       watchListeners.shift()();

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -158,8 +158,18 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     return false;
   };
   
-  $scope.$watch("selectedDt", function(dt) {
-    if(!dt || ngModelCtrl.$invalid) {
+  $scope.$watch(function() {
+    return ngModelCtrl.$modelValue;
+  }, function(dt) {
+    if(!dt) {
+      setMode(_datepickerModeCache);
+    }
+  }); 
+  
+  $scope.$watch(function() {
+    return ngModelCtrl.$invalid;
+  }, function(invalid) {
+    if(invalid) {
       setMode(_datepickerModeCache);
     }
   });

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1548,7 +1548,8 @@ describe('datepicker', function() {
       beforeEach(inject(function() {
         $rootScope.date = new Date('August 11, 2013');
         $rootScope.options = {
-          datepickerMode: 'month'
+          datepickerMode: 'month',
+          minDate: null
         };
         element = $compile('<div uib-datepicker ng-model="date" datepicker-options="options"></div>')($rootScope);
         $rootScope.$digest();
@@ -1561,6 +1562,23 @@ describe('datepicker', function() {
       it('updates binding', function() {
         clickTitleButton();
         expect($rootScope.options.datepickerMode).toBe('year');
+      });
+      
+      it('resets mode on null date', function() {
+        clickTitleButton();
+        expect($rootScope.options.datepickerMode).toBe('year');
+        $rootScope.date = null;
+        $rootScope.$digest();
+        expect($rootScope.options.datepickerMode).toBe('month');
+      });
+      
+      it('resets mode on invalid date', function() {
+        clickTitleButton();
+        expect($rootScope.options.datepickerMode).toBe('year');
+        
+        $rootScope.options.minDate = new Date('August 11, 2016');
+        $rootScope.$apply();
+        expect($rootScope.options.datepickerMode).toBe('month');
       });
     });
 

--- a/src/datepickerPopup/test/popup.spec.js
+++ b/src/datepickerPopup/test/popup.spec.js
@@ -1451,6 +1451,14 @@ describe('datepicker popup', function() {
       clickTitleButton();
       expect($rootScope.options.datepickerMode).toBe('year');
     });
+    
+    it('should be reset to original options value on scope destroy', function() {
+      expect($rootScope.options.datepickerMode).toEqual('month');
+      clickTitleButton();
+      expect($rootScope.options.datepickerMode).toEqual('year');
+      $rootScope.$destroy();
+      expect($rootScope.options.datepickerMode).toEqual('month');
+    });
   });
 
   describe('attribute `onOpenFocus`', function() {

--- a/src/datepickerPopup/test/popup.spec.js
+++ b/src/datepickerPopup/test/popup.spec.js
@@ -1451,14 +1451,6 @@ describe('datepicker popup', function() {
       clickTitleButton();
       expect($rootScope.options.datepickerMode).toBe('year');
     });
-    
-    it('should be reset to original options value on scope destroy', function() {
-      expect($rootScope.options.datepickerMode).toEqual('month');
-      clickTitleButton();
-      expect($rootScope.options.datepickerMode).toEqual('year');
-      $rootScope.$destroy();
-      expect($rootScope.options.datepickerMode).toEqual('month');
-    });
   });
 
   describe('attribute `onOpenFocus`', function() {


### PR DESCRIPTION
Add setMode call on destroy to reset the datepickerMode based on original value
from options.

Closes #5978
