### PR TITLE
datepicker popup return the focus to the wrong element 

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -276,8 +276,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
       $scope.$emit('uib:datepicker.mode');
     }
-
-    $scope.$broadcast('uib:datepicker.focus');
+    
   };
 
   $scope.move = function(direction) {

--- a/template/datepicker/datepicker.html
+++ b/template/datepicker/datepicker.html
@@ -1,4 +1,4 @@
-<div ng-switch="datepickerMode">
+<div ng-switch="datepickerMode" contenteditable="true" ng-keydown="keydown($event)">
   <div uib-daypicker ng-switch-when="day" tabindex="0" class="uib-daypicker"></div>
   <div uib-monthpicker ng-switch-when="month" tabindex="0" class="uib-monthpicker"></div>
   <div uib-yearpicker ng-switch-when="year" tabindex="0" class="uib-yearpicker"></div>

--- a/template/datepickerPopup/popup.html
+++ b/template/datepickerPopup/popup.html
@@ -1,4 +1,4 @@
-<ul class="uib-datepicker-popup dropdown-menu uib-position-measure" dropdown-nested ng-if="isOpen" ng-keydown="keydown($event)" ng-click="$event.stopPropagation()">
+<ul class="uib-datepicker-popup dropdown-menu uib-position-measure" dropdown-nested contenteditable="true" ng-if="isOpen" ng-keydown="keydown($event)" ng-click="$event.stopPropagation()">
   <li ng-transclude></li>
   <li ng-if="showButtonBar" class="uib-button-bar">
     <span class="btn-group pull-left">


### PR DESCRIPTION
datepicker popup return the focus to the wrong element after setting 
close-on-date-selection=true
datepicker-append-to-body=true
uid-datepicker-popup return the focus to the root uipicker element instead of the input.
this made after this [commit](https://github.com/angular-ui/bootstrap/commit/33cbd0f4a247112f140a5962d5787d8a573488a5)

way to reproduce:
close-on-date-selection=true
datepicker-append-to-body=true

1. click on input to select a date
2. select a date from the list

Observe :

On [line](https://github.com/angular-ui/bootstrap/blob/7e320e0e92fd4fffe82eb120c60dd0543e9a0bd8/src/datepickerPopup/popup.js#L218) the focus suppose to return to the input element but after your fix the focus is being set to the table which is being removed from the DOM after clicking on the button and the focus is passed to the parent element the body.

So i returned to the original [issue #5754](https://github.com/angular-ui/bootstrap/issues/5754) and tried to understand why ng-keydown is not being fired.
I realized that after clicking on date button the focused element is the button itself and because ng-keydown is being set to `self.element[0]` keydown event is not being invoked.

I managed to come with 2 solutions to this problem:
1. you can add to the element that holds the keydown a `contenteditable="true"` attribute and it's solving the problems because now ng-keydown is being invoked on any of `self.element[0]` children's.
2. you can set the keydown with jquery selector that includes `self.element[0];` children's and the `self.element[0]` itself.

I think the first approach it's better then the other.
i created this [plunker](http://embed.plnkr.co/9zwrjx1iQCAIa7S5PwEd/) to illustrate the first approach.