### PR TITLE
Fix for using outsideClick as a hide trigger.

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -533,7 +533,11 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
                     element.on(trigger, toggleTooltipBind);
                   } else if (trigger) {
                     element.on(trigger, showTooltipBind);
-                    element.on(triggers.hide[idx], hideTooltipBind);
+                    if (triggers.hide[idx] === 'outsideClick') {
+                      $document.on('click', bodyHideTooltipBind);
+                    } else {
+                      element.on(triggers.hide[idx], hideTooltipBind);
+                    }
                   }
 
                   element.on('keypress', function(e) {


### PR DESCRIPTION
Currently the implementation of binding the event listeners for tooltips only allows you to use `outsideClick` if it is the show trigger. This small change lets you use it as the hide trigger as well.