### PR TITLE
fix(tab): pass the tabs real index to onDeselect

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -9,10 +9,12 @@ angular.module('ui.bootstrap.tabs', [])
     if (!destroyed) {
       var previousIndex = findTabIndex(oldIndex);
       var previousSelected = ctrl.tabs[previousIndex];
+      var selected = ctrl.tabs[index];
+
       if (previousSelected) {
         previousSelected.tab.onDeselect({
           $event: evt,
-          $selectedIndex: index
+          $selectedIndex: selected ? selected.index : undefined
         });
         if (evt && evt.isDefaultPrevented()) {
           return;
@@ -20,7 +22,6 @@ angular.module('ui.bootstrap.tabs', [])
         previousSelected.tab.active = false;
       }
 
-      var selected = ctrl.tabs[index];
       if (selected) {
         selected.tab.onSelect({
           $event: evt

--- a/src/tabs/test/tabs.spec.js
+++ b/src/tabs/test/tabs.spec.js
@@ -118,15 +118,15 @@ describe('tabs', function() {
       titles().eq(1).find('> a').click();
       expect(scope.deselectFirst).toHaveBeenCalled();
       expect(scope.deselectFirst.calls.argsFor(0)[0].target).toBe(titles().eq(1).find('> a')[0]);
-      expect(scope.deselectFirst.calls.argsFor(0)[1]).toBe(1);
+      expect(scope.deselectFirst.calls.argsFor(0)[1]).toBe(2);
       titles().eq(0).find('> a').click();
       expect(scope.deselectSecond).toHaveBeenCalled();
       expect(scope.deselectSecond.calls.argsFor(0)[0].target).toBe(titles().eq(0).find('> a')[0]);
-      expect(scope.deselectSecond.calls.argsFor(0)[1]).toBe(0);
+      expect(scope.deselectSecond.calls.argsFor(0)[1]).toBe(1);
       titles().eq(1).find('> a').click();
       expect(scope.deselectFirst.calls.count()).toBe(2);
       expect(scope.deselectFirst.calls.argsFor(1)[0].target).toBe(titles().eq(1).find('> a')[0]);
-      expect(scope.deselectFirst.calls.argsFor(1)[1]).toBe(1);
+      expect(scope.deselectFirst.calls.argsFor(1)[1]).toBe(2);
     });
 
     it('should prevent tab deselection when $event.preventDefault() is called', function() {


### PR DESCRIPTION
The $selectedIndex passed to the onDeselect callback is the same as the
index given in the tab template. One can use that index as it is for the
active value of the tabset.

Fixes #6107