### PR TITLE
fix(modal): prevent doubleclick from closing multiple nested modals

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -144,11 +144,15 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap', 'ui.bootstrap.p
         element.addClass(attrs.windowTopClass || '');
         scope.size = attrs.size;
 
+        // inserted to fix issue #6061
+        var backdropClosing = false;
         scope.close = function(evt) {
           var modal = $modalStack.getTop();
           if (modal && modal.value.backdrop &&
             modal.value.backdrop !== 'static' &&
-            evt.target === evt.currentTarget) {
+            evt.target === evt.currentTarget &&
+            !backdropClosing) {
+            backdropClosing = true;
             evt.preventDefault();
             evt.stopPropagation();
             $modalStack.dismiss(modal.key, 'backdrop click');


### PR DESCRIPTION
Hi,

In the normal Bootstrap library, double clicking on the backdrop of a nested modal results in just the nested modal closing. It waits for the modal-closing animation to complete, and once it is, the user can then click on the next backdrop to close the remaining modal. 

The current Angular UI code doesn't do this because every time _any_ backdrop is clicked, the top modal on the $modalStack is chosen for closing. 

This PR prevents this functionality by simply adding a boolean value backdropClosing that, when true, will prevent the code from executing another modal close. Returning backdropClosing to false is unnecessary and won't affect the next modal close.

Closes #6061