### PR TITLE
Replace lorempixel.com with unsplash.it

### DIFF
--- a/src/carousel/docs/demo.js
+++ b/src/carousel/docs/demo.js
@@ -8,7 +8,7 @@ angular.module('ui.bootstrap.demo').controller('CarouselDemoCtrl', function ($sc
   $scope.addSlide = function() {
     var newWidth = 600 + slides.length + 1;
     slides.push({
-      image: 'http://lorempixel.com/' + newWidth + '/300',
+      image: '//unsplash.it/' + newWidth + '/300',
       text: ['Nice image','Awesome photograph','That is so cool','I love that'][slides.length % 4],
       id: currIndex++
     });


### PR DESCRIPTION
_Created [as requested here](https://github.com/angular-ui/bootstrap/pull/5701#issuecomment-220815632) in #5701_

The live carousel documentation was emitting mixed content warnings
because the protocol was hard-coded to http. Changing the image paths
to be protocol-agnostic did not work because lorempixel.com's cert
has been expired for more than a year.

It seems to me that putting chosen images in the asset path would be
a better long-term fix, but this should eliminate the warnings for
now.