### PR TITLE
docs(demo): add link to ng-bootstrap

### DIFF
--- a/misc/demo/index.html
+++ b/misc/demo/index.html
@@ -147,6 +147,13 @@
                     <div class="page-header">
                         <h1>Getting started</h1>
                     </div>
+                    <h3>Angular 2</h3>
+                    <p>
+                        For Angular 2 support, check out
+                        <a href="https://ng-bootstrap.github.io" target="_blank">
+                          ng-bootstrap
+                        </a>, created by the UI Bootstrap team.
+                    </p>
                     <h3>Dependencies</h3>
                     <p>
                         This repository contains a set of <strong>native AngularJS directives</strong> based on


### PR DESCRIPTION
- Add link to ng-bootstrap project on demo site

This should address #6083.