### PR TITLE
fix(modal): Improve ARIA support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm install --quiet -g grunt-cli karma
+  - npm install --quiet -g karma
 
 script: grunt
 sudo: false

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "main": "index.js",
   "scripts": {
+    "demo": "grunt after-test && static dist -a 0.0.0.0 -H '{\"Cache-Control\": \"no-cache, must-revalidate\"}'",
     "test": "grunt"
   },
   "repository": {
@@ -26,6 +27,7 @@
     "angular-mocks": "1.5.8",
     "angular-sanitize": "1.5.8",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-concat": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-uglify": "^1.0.1",
@@ -44,6 +46,7 @@
     "load-grunt-tasks": "^3.3.0",
     "lodash": "^4.1.0",
     "marked": "^0.3.5",
+    "node-static": "^0.7.8",
     "semver": "^5.0.1",
     "shelljs": "^0.6.0"
   },

--- a/src/modal/docs/demo.html
+++ b/src/modal/docs/demo.html
@@ -1,4 +1,4 @@
-<div ng-controller="ModalDemoCtrl as $ctrl">
+<div ng-controller="ModalDemoCtrl as $ctrl" class="modal-demo">
     <script type="text/ng-template" id="myModalContent.html">
         <div class="modal-header">
             <h3 class="modal-title" id="modal-title">I'm a modal!</h3>
@@ -16,11 +16,29 @@
             <button class="btn btn-warning" type="button" ng-click="$ctrl.cancel()">Cancel</button>
         </div>
     </script>
+    <script type="text/ng-template" id="stackedModal.html">
+        <div class="modal-header">
+            <h3 class="modal-title" id="modal-title-{{name}}">The {{name}} modal!</h3>
+        </div>
+        <div class="modal-body" id="modal-body-{{name}}">
+            Having multiple modals open at once is probably bad UX but it's technically possible.
+        </div>
+    </script>
 
     <button type="button" class="btn btn-default" ng-click="$ctrl.open()">Open me!</button>
     <button type="button" class="btn btn-default" ng-click="$ctrl.open('lg')">Large modal</button>
     <button type="button" class="btn btn-default" ng-click="$ctrl.open('sm')">Small modal</button>
+    <button type="button" 
+        class="btn btn-default" 
+        ng-click="$ctrl.open('sm', '.modal-parent')">
+            Modal appended to a custom parent
+    </button>
     <button type="button" class="btn btn-default" ng-click="$ctrl.toggleAnimation()">Toggle Animation ({{ $ctrl.animationsEnabled }})</button>
     <button type="button" class="btn btn-default" ng-click="$ctrl.openComponentModal()">Open a component modal!</button>
+    <button type="button" class="btn btn-default" ng-click="$ctrl.openMultipleModals()">
+        Open multiple modals at once 
+    </button>
     <div ng-show="$ctrl.selected">Selection from a modal: {{ $ctrl.selected }}</div>
+    <div class="modal-parent">
+    </div>
 </div>

--- a/src/modal/docs/demo.js
+++ b/src/modal/docs/demo.js
@@ -1,10 +1,12 @@
-angular.module('ui.bootstrap.demo').controller('ModalDemoCtrl', function ($uibModal, $log) {
+angular.module('ui.bootstrap.demo').controller('ModalDemoCtrl', function ($uibModal, $log, $document) {
   var $ctrl = this;
   $ctrl.items = ['item1', 'item2', 'item3'];
 
   $ctrl.animationsEnabled = true;
 
-  $ctrl.open = function (size) {
+  $ctrl.open = function (size, parentSelector) {
+    var parentElem = parentSelector ? 
+      angular.element($document[0].querySelector('.modal-demo ' + parentSelector)) : undefined;
     var modalInstance = $uibModal.open({
       animation: $ctrl.animationsEnabled,
       ariaLabelledBy: 'modal-title',
@@ -13,6 +15,7 @@ angular.module('ui.bootstrap.demo').controller('ModalDemoCtrl', function ($uibMo
       controller: 'ModalInstanceCtrl',
       controllerAs: '$ctrl',
       size: size,
+      appendTo: parentElem,
       resolve: {
         items: function () {
           return $ctrl.items;
@@ -42,6 +45,30 @@ angular.module('ui.bootstrap.demo').controller('ModalDemoCtrl', function ($uibMo
       $ctrl.selected = selectedItem;
     }, function () {
       $log.info('modal-component dismissed at: ' + new Date());
+    });
+  };
+
+  $ctrl.openMultipleModals = function () {
+    $uibModal.open({
+      animation: $ctrl.animationsEnabled,
+      ariaLabelledBy: 'modal-title-bottom',
+      ariaDescribedBy: 'modal-body-bottom',
+      templateUrl: 'stackedModal.html',
+      size: 'sm',
+      controller: function($scope) {
+        $scope.name = 'bottom';  
+      }
+    });
+
+    $uibModal.open({
+      animation: $ctrl.animationsEnabled,
+      ariaLabelledBy: 'modal-title-top',
+      ariaDescribedBy: 'modal-body-top',
+      templateUrl: 'stackedModal.html',
+      size: 'sm',
+      controller: function($scope) {
+        $scope.name = 'top';  
+      }
     });
   };
 

--- a/src/modal/docs/readme.md
+++ b/src/modal/docs/readme.md
@@ -1,5 +1,5 @@
 `$uibModal` is a service to create modal windows.
-Creating modals is straightforward: create a template, a controller and reference them when using `$uibModal`.
+Creating modals is straightforward: create a template and controller, and reference them when using `$uibModal`.
 
 The `$uibModal` service has only one method: `open(options)`.
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -526,7 +526,7 @@ describe('$uibModal', function() {
 
       var modal = open({template: '<div>Content<button>inside modal</button></div>'});
       $rootScope.$digest();
-      expect(document.activeElement.tagName).toBe('DIV');
+      expect(document.activeElement.tagName).toBe('BUTTON');
       expect($document).toHaveModalsOpen(1);
 
       triggerKeyDown($document, 27);
@@ -656,7 +656,7 @@ describe('$uibModal', function() {
     it('should not focus on the element that has autofocus attribute when the modal is opened and something in the modal already has focus and the animations have finished', function() {
       function openAndCloseModalWithAutofocusElement() {
 
-        var modal = open({template: '<div><input type="text" id="auto-focus-element" autofocus><input type="text" id="pre-focus-element" focus-me></div>'});
+        var modal = open({template: '<div><input type="text" id="pre-focus-element" focus-me><input type="text" id="auto-focus-element" autofocus></div>'});
         $rootScope.$digest();
         expect(angular.element('#auto-focus-element')).not.toHaveFocus();
         expect(angular.element('#pre-focus-element')).toHaveFocus();
@@ -698,7 +698,7 @@ describe('$uibModal', function() {
         $rootScope.$digest();
         $animate.flush();
 
-        expect(document.activeElement.tagName).toBe('DIV');
+        expect(document.activeElement.tagName).toBe('INPUT');
 
         close(modal, 'closed ok');
 


### PR DESCRIPTION
I will add more tests after I get initial acceptance on these changes.

I have tested on:

* VoiceOver iOS (latest iOS)
* VoiceOver macOS (latest OS X El Cap)
* JAWS 16 / Windows 7 / IE 11
* Angular 1.5.8

This fixes the following issues:

## VoiceOver does not read modal

1. Launch VoiceOver on iOS
2. Go to the demo page
3. Tap the "Open me!" button to open a modal

**Expected**: Screenreader reads the modal content automatically
**Actual**: Screenreader does not read the modal automatically; an assistive technology user would be confused as to what's going on.

To fix this, I added an [`aria-live`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) attribute. This makes the expected result occur above.

**Update**: Adding `aria-live` actually causes more problems than it solves. iOS VoiceOver reads the content, but it reads it out of order. JAWS will read the content in a bizarre way, repeating the `aria-labelledby` element over and over again, and omitting some of the `aria-describedby` text. macOS VoiceOver reads the modal just fine without `aria-live`. So I'm going to omit `aria-live` entirely.

## VoiceOver selects elements in background

1. Launch VoiceOver on iOS
2. Go to the demo page
3. Tap the "Open me!" button to open a modal
4. Scroll to the left and right to see different readable elements

**Expected**: Only elements within the modal are visible to the screen reader
**Actual**: User can scroll off the modal, reading elements that are supposed to be hidden

To fix this, I added `aria-hidden=true` to DOM elements to hide everything but the modal. When the modal is closed, I remove `aria-hidden`. To account for elements that may already be `aria-hidden`, and the possibility of multiple modals being opened at once, I use a counter on each element to be hidden. That way, when I go to do cleanup, I know if the element was already hidden, instead of doing a blanket `el.removeAttribute('aria-hidden')` on everything.

Unfortunately, VoiceOver will still read an element with text "August 2016". I don't know why it reads this element. The element is from the datepicker demo:

```html
<table role="grid" aria-labelledby="datepicker-103-1928-title" aria-activedescendant="datepicker-103-1928-25">
<!-- datepicker table contents -->
</table>
```

I tried removing the `aria-activedescendent` and `aria-live` attributes from other elements, but that did not stop this table from being read. After sinking a bit of time into this, I decided to leave it as-is for now, as people encountering this in the wild will be less common.

## VoiceOver puts the cursor on the modal
1. Launch VoiceOver on iOS or MacOS
2. Go to the demo page
3. Tap the "Open me!" button to open a modal
4. One finger swipe (on iOS) to the left and right or `VO+left/right arrow` (on MacOS) to move the VoiceOver cursor

**Expected**: The VoiceOver cursor is in the modal
**Actual**: The VoiceOver cursor is stuck on the content behind the modal, so the modal contents cannot be navigated.

## Known Issues
### Content Read Order
Using `aria-live` appears to make VoiceOver iOS read the modal content out of order. Related: http://stackoverflow.com/questions/38088439/accessibility-aria-live-reading-order-changes-on-ios. I am not sure that there's anything to be done about this; it pretty clearly seems like a bug. [Here are some experiments I've done with different options.](https://github.com/NickHeiner/a11y-hacking/blob/master/snippets/voiceover-live-region.html)

### Returning Focus To Opening Button
Focus is not returning to the button that opened the modal; VoiceOver iOS is reading a different button. I believe that this is related to adding `aria-hidden` to all background elements. I think that VoiceOver has a bug in the way it handles elements that are hidden and then unhidden throughout their lifespan. When I disable the code that adds `aria-hidden`, I cannot repro this issue. However, then we're back to the original problem of the VoiceOver cursor escaping the modal and traversing background content. I believe that this is the lesser of two evils.

Additionally, VoiceOver macOS handles this case just fine. So by doing this fix, we eliminate a problem for VoiceOver iOS and macOS, and add a smaller problem for VoiceOver iOS.

## Misc
I did a few small fixes to improve the developer experience working on this repo. I also fixed a few grammar nits. I can pull those out into a separate PR if you'd prefer.