### PR TITLE
This should satisfy Issue #6269.

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -11,6 +11,7 @@ angular.module('ui.bootstrap.timepicker', [])
   mousewheel: true,
   arrowkeys: true,
   showSpinners: true,
+  preventDisable: false,
   templateUrl: 'uib/template/timepicker/timepicker.html'
 })
 
@@ -53,6 +54,9 @@ angular.module('ui.bootstrap.timepicker', [])
     }
 
     $scope.readonlyInput = angular.isDefined($attrs.readonlyInput) ? $scope.$parent.$eval($attrs.readonlyInput) : timepickerConfig.readonlyInput;
+
+	$scope.preventDisable = angular.isDefined($attrs.preventDisable) ? $scope.$parent.$eval($attrs.preventDisable) : timepickerConfig.preventDisable;
+
     this.setupInputEvents(hoursInputEl, minutesInputEl, secondsInputEl);
   };
 
@@ -90,36 +94,42 @@ angular.module('ui.bootstrap.timepicker', [])
   }
 
   $scope.noIncrementHours = function() {
+	if ($scope.preventDisable) return false;
     var incrementedSelected = addMinutes(selected, hourStep * 60);
     return disabled || incrementedSelected > max ||
       incrementedSelected < selected && incrementedSelected < min;
   };
 
   $scope.noDecrementHours = function() {
+	if ($scope.preventDisable) return false;
     var decrementedSelected = addMinutes(selected, -hourStep * 60);
     return disabled || decrementedSelected < min ||
       decrementedSelected > selected && decrementedSelected > max;
   };
 
   $scope.noIncrementMinutes = function() {
+	if ($scope.preventDisable) return false;
     var incrementedSelected = addMinutes(selected, minuteStep);
     return disabled || incrementedSelected > max ||
       incrementedSelected < selected && incrementedSelected < min;
   };
 
   $scope.noDecrementMinutes = function() {
+	if ($scope.preventDisable) return false;
     var decrementedSelected = addMinutes(selected, -minuteStep);
     return disabled || decrementedSelected < min ||
       decrementedSelected > selected && decrementedSelected > max;
   };
 
   $scope.noIncrementSeconds = function() {
+	if ($scope.preventDisable) return false;
     var incrementedSelected = addSeconds(selected, secondStep);
     return disabled || incrementedSelected > max ||
       incrementedSelected < selected && incrementedSelected < min;
   };
 
   $scope.noDecrementSeconds = function() {
+	if ($scope.preventDisable) return false;
     var decrementedSelected = addSeconds(selected, -secondStep);
     return disabled || decrementedSelected < min ||
       decrementedSelected > selected && decrementedSelected > max;

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -94,42 +94,42 @@ angular.module('ui.bootstrap.timepicker', [])
   }
 
   $scope.noIncrementHours = function() {
-	if ($scope.preventDisable) return false;
+	if ($scope.preventDisable) { return false; }
     var incrementedSelected = addMinutes(selected, hourStep * 60);
     return disabled || incrementedSelected > max ||
       incrementedSelected < selected && incrementedSelected < min;
   };
 
   $scope.noDecrementHours = function() {
-	if ($scope.preventDisable) return false;
+	if ($scope.preventDisable) { return false; }
     var decrementedSelected = addMinutes(selected, -hourStep * 60);
     return disabled || decrementedSelected < min ||
       decrementedSelected > selected && decrementedSelected > max;
   };
 
   $scope.noIncrementMinutes = function() {
-	if ($scope.preventDisable) return false;
+	if ($scope.preventDisable) { return false; }
     var incrementedSelected = addMinutes(selected, minuteStep);
     return disabled || incrementedSelected > max ||
       incrementedSelected < selected && incrementedSelected < min;
   };
 
   $scope.noDecrementMinutes = function() {
-	if ($scope.preventDisable) return false;
+	if ($scope.preventDisable) { return false; }
     var decrementedSelected = addMinutes(selected, -minuteStep);
     return disabled || decrementedSelected < min ||
       decrementedSelected > selected && decrementedSelected > max;
   };
 
   $scope.noIncrementSeconds = function() {
-	if ($scope.preventDisable) return false;
+	if ($scope.preventDisable) { return false; }
     var incrementedSelected = addSeconds(selected, secondStep);
     return disabled || incrementedSelected > max ||
       incrementedSelected < selected && incrementedSelected < min;
   };
 
   $scope.noDecrementSeconds = function() {
-	if ($scope.preventDisable) return false;
+	if ($scope.preventDisable) { return false; }
     var decrementedSelected = addSeconds(selected, -secondStep);
     return disabled || decrementedSelected < min ||
       decrementedSelected > selected && decrementedSelected > max;


### PR DESCRIPTION
This adds a parameter called preventDisable.

The parameter defaults to false, but if set true, should keep the timekeeper from disabling the input fields.  This will be helpful for anyone needing better keyboard support.