### PR TITLE
Add standalone month support (LLLL) to dateparser

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -82,6 +82,12 @@ angular.module('ui.bootstrap.dateparser', [])
         formatter: function(date) { return dateFilter(date, 'M'); }
       },
       {
+        key: 'LLLL',
+        regex: $locale.DATETIME_FORMATS.STANDALONEMONTH.join('|'),
+        apply: function(value) { this.month = $locale.DATETIME_FORMATS.STANDALONEMONTH.indexOf(value); },
+        formatter: function(date) { return dateFilter(date, 'LLLL'); }
+      },
+      {
         key: 'd!',
         regex: '[0-2]?[0-9]{1}|3[0-1]{1}',
         apply: function(value) { this.date = +value; },

--- a/src/dateparser/docs/README.md
+++ b/src/dateparser/docs/README.md
@@ -58,6 +58,9 @@ Certain format codes support i18n. Check this [guide](https://docs.angularjs.org
   _(Example: `3` or `03`)_ -
   Parses a numeric month, but allowing an optional leading zero
 
+* `LLLL`
+  _(Example: `February`, i18n support)_ - Stand-alone month in year (January-December). Requires Angular version 1.5.1 or higher.
+
 * `dd`
   _(Example: `05`, Leading 0)_ -
   Parses a numeric day.

--- a/src/dateparser/test/dateparser.spec.js
+++ b/src/dateparser/test/dateparser.spec.js
@@ -84,6 +84,16 @@ describe('date parser', function() {
       expectFilter(new Date(2011, 4, 2, 0), 'dd-M!-yy', '02-05-11');
       expectFilter(oldDate, 'yyyy/M!/dd', '0001/03/06');
     });
+    
+    it('should work correctly for `LLLL`', function() {
+      expectFilter(new Date(2013, 7, 24, 0), 'LLLL/dd/yyyy', 'August/24/2013');
+      expectFilter(new Date(2004, 10, 7, 0), 'dd.LLLL.yy', '07.November.04');
+      expectFilter(new Date(2011, 4, 18, 0), 'dd-LLLL-yy', '18-May-11');
+      expectFilter(new Date(1980, 1, 5, 0), 'LLLL/dd/yyyy', 'February/05/1980');
+      expectFilter(new Date(1955, 2, 5, 0), 'yyyy/LLLL/dd', '1955/March/05');
+      expectFilter(new Date(2011, 5, 2, 0), 'dd-LLLL-yy', '02-June-11');
+      expectFilter(oldDate, 'yyyy/LLLL/dd', '0001/March/06');
+    });
 
     it('should work correctly for `d`', function() {
       expectFilter(new Date(2013, 10, 17, 0), 'd.MMMM.yy', '17.November.13');


### PR DESCRIPTION
Standalone month format support was added to Angular in February. https://github.com/angular/angular.js/pull/14013
