### PR TITLE
fix(modal): focus defaults to the modal itself, not the first element

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -646,7 +646,6 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.stackedMap', 'ui.bootstrap.p
 
       $modalStack.modalRendered = function(modalInstance) {
         var modalWindow = openedWindows.get(modalInstance);
-        $modalStack.focusFirstFocusableElement($modalStack.loadFocusElementList(modalWindow));
         if (modalWindow) {
           modalWindow.value.renderDeferred.resolve();
         }

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -526,7 +526,7 @@ describe('$uibModal', function() {
 
       var modal = open({template: '<div>Content<button>inside modal</button></div>'});
       $rootScope.$digest();
-      expect(document.activeElement.tagName).toBe('BUTTON');
+      expect(document.activeElement.className.split(" ")).toContain('modal');
       expect($document).toHaveModalsOpen(1);
 
       triggerKeyDown($document, 27);
@@ -698,7 +698,7 @@ describe('$uibModal', function() {
         $rootScope.$digest();
         $animate.flush();
 
-        expect(document.activeElement.tagName).toBe('INPUT');
+        expect(document.activeElement.className.split(" ")).toContain('modal');
 
         close(modal, 'closed ok');
 


### PR DESCRIPTION
I recently bumped version from 2.1.4 to 2.2.0. 

In the updated version, modals set default focus to the [firstFocusableElement](https://github.com/angular-ui/bootstrap/compare/2.1.4...2.2.0#diff-15d409302580c93c654a382e2da68396R649). This seems like unwanted default behavior (for example, input elements may have additional focus behavior that I'd like not to trigger by default). 

Also, modals [already](https://github.com/angular-ui/bootstrap/blob/master/src/modal/modal.js#L201) had a viable and acceptable default state -- focus would be applied to the modal itself when `autofocus` wasn't explicitly set on any element. 

This change is a quick example of the minimal changes required to revert to simpler, less opinionated, default behavior. 
