### PR TITLE
fix(dropdown): remove focus trapping when dropdown is closed

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -337,6 +337,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
       scope.focusToggleElement();
       uibDropdownService.open(scope, $element, appendTo);
     } else {
+      uibDropdownService.close(scope, $element, appendTo);
       if (self.dropdownMenuTemplateUrl) {
         if (templateScope) {
           templateScope.$destroy();


### PR DESCRIPTION
This revert: https://github.com/angular-ui/bootstrap/commit/c824731ae8fed3d56bedaaf88fc8e86a4224e96d actually removes an extra line that is required to remove the event listeners when the dropdown is closed, the original commit only added one extra line: https://github.com/angular-ui/bootstrap/commit/44ab0a81061769dd038ac218a12131cde5bf9e67

This is a pretty bad regression and broke a lot of our app in a very hard to find way, any chance you could cut a new patch release once this is merged so that is doesn't bite anyone else. 

Thanks! 😃 

Fixes #6357
Fixes #6372
Fixes #6364