### PR TITLE
Fix issue where focus is stolen from form elements after dropdown shown

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -347,7 +347,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
 
       self.selectedOption = null;
       
-      if (wasOpen) { openScope.focusToggleElement(); }
+      if (wasOpen) { scope.focusToggleElement(); }
 
     }
 

--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -105,7 +105,10 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
       return;
     }
 
-    openScope.isOpen = false;
+    if (openScope.isOpen) {
+      openScope.focusToggleElement()
+      openScope.isOpen = false;
+    }
 
     if (!$rootScope.$$phase) {
       openScope.$apply();
@@ -346,9 +349,6 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
       }
 
       self.selectedOption = null;
-      
-      if (wasOpen) { scope.focusToggleElement(); }
-
     }
 
     if (angular.isFunction(setIsOpen)) {

--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -106,7 +106,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
     }
 
     if (openScope.isOpen) {
-      openScope.focusToggleElement()
+      openScope.focusToggleElement();
       openScope.isOpen = false;
     }
 

--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -105,7 +105,6 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
       return;
     }
 
-    openScope.focusToggleElement();
     openScope.isOpen = false;
 
     if (!$rootScope.$$phase) {
@@ -347,6 +346,9 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
       }
 
       self.selectedOption = null;
+      
+      if (wasOpen) { openScope.focusToggleElement(); }
+
     }
 
     if (angular.isFunction(setIsOpen)) {


### PR DESCRIPTION
Discovered an issue where form elements were losing their focus. Discovered this was related to #5934 having added a feature to apply the focus to the toggle element, but as this event fires on all mouse clicks the focus was being set regardless of whether the dropdown was actually open at the time.