### PR TITLE
Fix tab index when using string index

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -153,6 +153,8 @@ angular.module('ui.bootstrap.tabs', [])
         } else {
           scope.index = 0;
         }
+      } else {
+        scope.index = attrs.index;
       }
 
       if (angular.isUndefined(attrs.classes)) {


### PR DESCRIPTION
I am trying to use string index and found this bug.. 