### PR TITLE
make matches available to the typeahead-on-select callback

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -361,7 +361,8 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
         $item: item,
         $model: model,
         $label: parserResult.viewMapper(originalScope, locals),
-        $event: evt
+        $event: evt,
+        $matches: scope.matches
       });
 
       resetMatches();


### PR DESCRIPTION
Usage example:
```
typeahead-on-select="onSelect($item, $model, $label, $event, $matches)"
```
