### PR TITLE
fix(dropdown): avoid focus toggle element after dropdown is closed

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -88,7 +88,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
   var closeDropdown = function(evt) {
     // This method may still be called during the same mouse event that
     // unbound this event handler. So check openScope before proceeding.
-    if (!openScope) { return; }
+    if (!openScope || !openScope.isOpen) { return; }
 
     if (evt && openScope.getAutoClose() === 'disabled') { return; }
 


### PR DESCRIPTION
This PR fixed a bug: 

As you can see in this code, it will call "closeDropdown" every time a click event:
![image](https://cloud.githubusercontent.com/assets/2082295/22049720/48769840-dd70-11e6-8db3-7338b899e2b9.png)
Add I added the selection code for this function to avoid useless call:
![image](https://cloud.githubusercontent.com/assets/2082295/22049775/a47e15d2-dd70-11e6-9695-0ca4bcd6f2c8.png)

As you can see in line 108, it will always focus on the toggle element whenever you click if we do not check the open status.

Thanks,
Alex