### PR TITLE
feat(modal): Added default value for controllerAs

### DIFF
--- a/src/modal/docs/demo.js
+++ b/src/modal/docs/demo.js
@@ -13,7 +13,6 @@ angular.module('ui.bootstrap.demo').controller('ModalDemoCtrl', function ($uibMo
       ariaDescribedBy: 'modal-body',
       templateUrl: 'myModalContent.html',
       controller: 'ModalInstanceCtrl',
-      controllerAs: '$ctrl',
       size: size,
       appendTo: parentElem,
       resolve: {
@@ -56,7 +55,7 @@ angular.module('ui.bootstrap.demo').controller('ModalDemoCtrl', function ($uibMo
       templateUrl: 'stackedModal.html',
       size: 'sm',
       controller: function($scope) {
-        $scope.name = 'bottom';  
+        $scope.name = 'bottom';
       }
     });
 
@@ -67,7 +66,7 @@ angular.module('ui.bootstrap.demo').controller('ModalDemoCtrl', function ($uibMo
       templateUrl: 'stackedModal.html',
       size: 'sm',
       controller: function($scope) {
-        $scope.name = 'top';  
+        $scope.name = 'top';
       }
     });
   };

--- a/src/modal/docs/readme.md
+++ b/src/modal/docs/readme.md
@@ -54,7 +54,7 @@ The `$uibModal` service has only one method: `open(options)`.
   A controller for the modal instance, either a controller name as a string, or an inline controller function, optionally wrapped in array notation for dependency injection. Allows the controller-as syntax. Has a special `$uibModalInstance` injectable to access the modal instance.
 
 * `controllerAs`
-  _(Type: `string`, Example: `ctrl`)_ -
+  _(Type: `string`, Example: `ctrl`, Default: `$ctrl`)_ -
   An alternative to the controller-as syntax. Requires the `controller` option to be provided as well.
 
 * `keyboard` -

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -767,7 +767,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.multiMap', 'ui.bootstrap.sta
 
                   // the third param will make the controller instantiate later,private api
                   // @see https://github.com/angular/angular.js/blob/master/src/ng/controller.js#L126
-                  ctrlInstantiate = $controller(modalOptions.controller, ctrlLocals, true, modalOptions.controllerAs);
+                  ctrlInstantiate = $controller(modalOptions.controller, ctrlLocals, true, identifierForController(modalOptions.controller) || modalOptions.controllerAs || '$ctrl');
                   if (modalOptions.controllerAs && modalOptions.bindToController) {
                     ctrlInstance = ctrlInstantiate.instance;
                     ctrlInstance.$close = modalScope.$close;
@@ -825,6 +825,14 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.multiMap', 'ui.bootstrap.sta
         }
       ]
     };
+
+    var CNTRL_REG = /^(\S+)(\s+as\s+([\w$]+))?$/;
+    function identifierForController(controller) {
+      if (angular.isString(controller)) {
+        var match = CNTRL_REG.exec(controller);
+        if (match) {return match[3];}
+      }
+    }
 
     return $modalProvider;
   });

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -1066,12 +1066,12 @@ describe('$uibModal', function() {
 
     describe('controller', function() {
       it('should accept controllers and inject modal instances', function() {
-        var TestCtrl = function($scope, $uibModalInstance) {
-          $scope.fromCtrl = 'Content from ctrl';
-          $scope.isModalInstance = angular.isObject($uibModalInstance) && angular.isFunction($uibModalInstance.close);
-        };
+        $controllerProvider.register('TestCtrl', function($uibModalInstance) {
+          this.fromCtrl = 'Content from ctrl';
+          this.isModalInstance = angular.isObject($uibModalInstance) && angular.isFunction($uibModalInstance.close);
+        });
 
-        open({template: '<div>{{fromCtrl}} {{isModalInstance}}</div>', controller: TestCtrl});
+        open({template: '<div>{{$ctrl.fromCtrl}} {{$ctrl.isModalInstance}}</div>', controller: 'TestCtrl'});
         expect($document).toHaveModalOpenWithContent('Content from ctrl true', 'div');
       });
 


### PR DESCRIPTION
Closes #6434

Add the default value `$ctrl` for controllerAs in modal.

Change the test to not use $scope anymore.