### PR TITLE
fix(datepicker): support string in the non-HTML5 formatter

### DIFF
--- a/src/datepickerPopup/popup.js
+++ b/src/datepickerPopup/popup.js
@@ -119,7 +119,7 @@ function($scope, $element, $attrs, $compile, $log, $parse, $window, $document, $
           return value;
         }
 
-        if (angular.isNumber(value)) {
+        if (!angular.isObject(value)) {
           value = new Date(value);
         }
 


### PR DESCRIPTION
support string in the non-HTML5 formatter, e.g. JSON date