### PR TITLE
feat($uibModal): bind resolve properties to controller when opening modal as component

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -460,7 +460,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.multiMap', 'ui.bootstrap.sta
           Array.prototype.forEach.call(
             Object.keys(modal.scope.$resolve),
             function(property) {
-              content.attr(property, '$resolve.' + property);
+              content.attr(snake_case(property), '$resolve.' + property);
             }
           );
         } else {

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -457,6 +457,12 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.multiMap', 'ui.bootstrap.sta
             close: '$close($value)',
             dismiss: '$dismiss($value)'
           });
+          Array.prototype.forEach.call(
+            Object.keys(modal.scope.$resolve),
+            function(property) {
+              content.attr(property, '$resolve.' + property);
+            }
+          );
         } else {
           content = modal.content;
         }


### PR DESCRIPTION

Bind resolve properties to controller of component opened with $uibModal.
This mimics current uiRouter usage of resolve so any component can receive
input data with $uibModal.  Previous behavior was to force component to
expose a resolve binding.

Closes #6540