### PR TITLE
Remove extra </i> in template month.html for datepicker

### DIFF
--- a/template/datepicker/month.html
+++ b/template/datepicker/month.html
@@ -3,7 +3,7 @@
     <tr>
       <th><button type="button" class="btn btn-default btn-sm pull-left uib-left" ng-click="move(-1)" tabindex="-1"><i aria-hidden="true" class="glyphicon glyphicon-chevron-left"></i><span class="sr-only">previous</span></button></th>
       <th colspan="{{::yearHeaderColspan}}"><button id="{{::uniqueId}}-title" role="heading" aria-live="assertive" aria-atomic="true" type="button" class="btn btn-default btn-sm uib-title" ng-click="toggleMode()" ng-disabled="datepickerMode === maxMode" tabindex="-1"><strong>{{title}}</strong></button></th>
-      <th><button type="button" class="btn btn-default btn-sm pull-right uib-right" ng-click="move(1)" tabindex="-1"><i aria-hidden="true" class="glyphicon glyphicon-chevron-right"></i><span class="sr-only">next</span></i></button></th>
+      <th><button type="button" class="btn btn-default btn-sm pull-right uib-right" ng-click="move(1)" tabindex="-1"><i aria-hidden="true" class="glyphicon glyphicon-chevron-right"></i><span class="sr-only">next</span></button></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
[#6571](https://github.com/angular-ui/bootstrap/issues/6571)

Remove an extra `</i>` in template `month.html` for `datepicker`

Creating a buffered transitions array to handle clicking too quickly is unnecessary.
The code