### PR TITLE
fix:tooltip:change to make tooltip work when document contains multile body tags

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -328,7 +328,8 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
               tooltipLinkedScope = ttScope.$new();
               tooltip = tooltipLinker(tooltipLinkedScope, function(tooltip) {
                 if (appendToBody) {
-                  $document.find('body').append(tooltip);
+                  //https://github.com/angular-ui/bootstrap/issues/6597
+                  angular.element(document.body).append(tooltip);
                 } else {
                   element.after(tooltip);
                 }
@@ -348,7 +349,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
 
               if (tooltip) {
                 tooltip.remove();
-                
+
                 tooltip = null;
                 if (adjustmentTimeout) {
                   $timeout.cancel(adjustmentTimeout);
@@ -356,7 +357,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
               }
 
               openedTooltips.remove(ttScope);
-              
+
               if (tooltipLinkedScope) {
                 tooltipLinkedScope.$destroy();
                 tooltipLinkedScope = null;


### PR DESCRIPTION
issue raised:  https://github.com/angular-ui/bootstrap/issues/6597

change when page contains multiple body tags inside it. uib tooltip does not works when append-to-body option set to true. 
Previously when it finds multiple body tag, it is appending tooltip to wrong body tag hence not able to see it, also not removing appended tooltip element from DOM.
After applying fix it will always takes documents body tag instead of SVG element body tag. 

BREAKING CHANGE: When page contains multiple body tag of SVG foreignObject tooltip does not work.
