### PR TITLE
Properly position "uib-dropdown-menu" when it has class "dropdown-menu-right" and the parent element have hidden scrollbar

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -288,7 +288,7 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
         css.left = 'auto';
         scrollbarPadding = $position.scrollbarPadding(appendTo);
 
-        if (scrollbarPadding.heightOverflow && scrollbarPadding.scrollbarWidth) {
+        if (scrollbarPadding.rightScrollbar && scrollbarPadding.scrollbarWidth) {
           scrollbarWidth = scrollbarPadding.scrollbarWidth;
         }
 

--- a/src/position/position.js
+++ b/src/position/position.js
@@ -139,7 +139,11 @@ angular.module('ui.bootstrap.position', [])
           originalRight: paddingRight,
           heightOverflow: scrollParent.scrollHeight > scrollParent.clientHeight,
           bottom: paddingBottom + scrollbarWidth,
-          originalBottom: paddingBottom
+          originalBottom: paddingBottom,
+          bottomScrollbar: (elemStyle.overflowX == 'auto' || elemStyle.overflowX == 'visible' && elem.nodeName == 'BODY')
+            && scrollParent.scrollWidth > scrollParent.clientWidth || elemStyle.overflowX == 'scroll',
+          rightScrollbar: (elemStyle.overflowY == 'auto' || elemStyle.overflowY == 'visible' && elem.nodeName == 'BODY')
+            && scrollParent.scrollHeight > scrollParent.clientHeight || elemStyle.overflowY == 'scroll'
          };
       },
 


### PR DESCRIPTION
When dropdown-menu is positioned relatively to the right it takes into account the right scrollbar width. It detects scrollbar by checking whether content height is bigger than clientHeight but sometimes scrollbar can be absent even when content doesn't fit the element visible area when "overflow = hidden".

In this pull request I'm adding proper check for this case.