### PR TITLE
Fix datepicker timezone problems (5744)

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -264,7 +264,7 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
 
   $scope.select = function(date) {
     if ($scope.datepickerMode === self.minMode) {
-      var dt = ngModelCtrl.$viewValue ? dateParser.fromTimezone(new Date(ngModelCtrl.$viewValue), ngModelOptions.getOption('timezone')) : new Date(0, 0, 0, 0, 0, 0, 0);
+      var dt = ngModelCtrl.$viewValue ? dateParser.fromTimezone(new Date(ngModelCtrl.$viewValue), ngModelOptions.getOption('timezone')) : new Date();
       dt.setFullYear(date.getFullYear(), date.getMonth(), date.getDate());
       dt = dateParser.toTimezone(dt, ngModelOptions.getOption('timezone'));
       ngModelCtrl.$setViewValue(dt);


### PR DESCRIPTION
Hi,

I had a problem with timezones the other day at work and realised that other people have this problem and although it can be fixed outside of the framework I feel like it really should be part of it.

Basically if at any time the datepicker (or datepicker popup) is set to undefined/null -which they may be to represent no date has been chosen-, the previous code would result in a `Date` object with 0 as it's time but the timezone of the computer. This results in an incorrect UTC time which can cause problems for anyone trying to use the directive across multiple time zones (like we do at work).

This change should mean that if a date already exists it's timezone is used, but if there isn't the current time and timezone of the computer will be used instead.

Technically the whole left hand side could be replaced with just `new Date`, but I understand there may be a possibility that someone may be depending on the fact that the time component is always the same if the user switches between dates.

This change shouldn't really break anything since any users who were relying on this part (like we were at work) have either not discovered the problem or fixed it in their own codebase, either way this shouldn't really their current implementations.

Hope this helps :)

Thanks,
Mohamed