### PR TITLE
feat(tooltip): Prevent close tooltip with 'esc' key

### DIFF
--- a/src/stackedMap/stackedMap.js
+++ b/src/stackedMap/stackedMap.js
@@ -9,10 +9,11 @@ angular.module('ui.bootstrap.stackedMap', [])
         var stack = [];
 
         return {
-          add: function(key, value) {
+          add: function(key, value, options) {
             stack.push({
               key: key,
-              value: value
+              value: value,
+              options: options
             });
           },
           get: function(key) {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -80,7 +80,8 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
     function keypressListener(e) {
       if (e.which === 27) {
         var last = openedTooltips.top();
-        if (last) {
+        var enableEsc = last.options.enableEsc;
+        if (last && enableEsc) {
           last.value.close();
           last = null;
         }
@@ -146,6 +147,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
             var positionTimeout;
             var adjustmentTimeout;
             var appendToBody = angular.isDefined(options.appendToBody) ? options.appendToBody : false;
+            var enableEsc = !angular.isDefined(attrs[prefix + 'EnableEsc']);
             var triggers = getTriggers(undefined);
             var hasEnableExp = angular.isDefined(attrs[prefix + 'Enable']);
             var ttScope = scope.$new(true);
@@ -334,9 +336,9 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
                 }
               });
 
-              openedTooltips.add(ttScope, {
-                close: hide
-              });
+              openedTooltips.add(ttScope,
+                { close: hide },
+                { enableEsc: enableEsc });
 
               prepObservers();
             }
@@ -348,7 +350,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
 
               if (tooltip) {
                 tooltip.remove();
-                
+
                 tooltip = null;
                 if (adjustmentTimeout) {
                   $timeout.cancel(adjustmentTimeout);
@@ -356,7 +358,7 @@ angular.module('ui.bootstrap.tooltip', ['ui.bootstrap.position', 'ui.bootstrap.s
               }
 
               openedTooltips.remove(ttScope);
-              
+
               if (tooltipLinkedScope) {
                 tooltipLinkedScope.$destroy();
                 tooltipLinkedScope = null;


### PR DESCRIPTION
Motivation
========
Tooltip must be shown if \<input\> tag isn't valid, but if user press 'ESC' key it closes tooltip and reset validation.

This PR introduce new option 'tooltip-enable-esc'.

If user set 'tooltip-enable-esc' as false, tooltip will not closed.

By default 'tooltip-enable-esc' is true.

How to use
=======
``` html
        <input type="text"
               ng-model="amount"
               numbers-only
               tooltip-enable-esc="false"
               uib-tooltip="Amount field must be number"
               tooltip-enable="error"
               tooltip-is-open="error"
               tooltip-trigger="'none'"
               tooltip-placement="bottom" />
```
