### PR TITLE
fix(datepicker): initDate does not change

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -164,10 +164,14 @@ angular.module('ui.bootstrap.datepicker', ['ui.bootstrap.dateparser', 'ui.bootst
     ngModelOptions = extractOptions(ngModelCtrl);
 
     if ($scope.datepickerOptions.initDate) {
-      self.activeDate = dateParser.fromTimezone($scope.datepickerOptions.initDate, ngModelOptions.getOption('timezone')) || new Date();
+//          self.activeDate = dateParser.fromTimezone($scope.datepickerOptions.initDate, ngModelOptions.getOption('timezone')) || new Date();
+      var newInitDate = dateParser.fromTimezone($scope.datepickerOptions.initDate, ngModelOptions.getOption('timezone')) || new Date();
+      self.activeDate = angular.isDate(newInitDate) ? new Date(newInitDate.getTime()) : newInitDate;
       $scope.$watch('datepickerOptions.initDate', function(initDate) {
         if (initDate && (ngModelCtrl.$isEmpty(ngModelCtrl.$modelValue) || ngModelCtrl.$invalid)) {
-          self.activeDate = dateParser.fromTimezone(initDate, ngModelOptions.getOption('timezone'));
+//        self.activeDate = dateParser.fromTimezone(initDate, ngModelOptions.getOption('timezone'));
+          var updatedInitDate = dateParser.fromTimezone(initDate, ngModelOptions.getOption('timezone'));
+          self.activeDate = angular.isDate(updatedInitDate) ? new Date(updatedInitDate.getTime()) : updatedInitDate;
           self.refreshView();
         }
       });

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1535,10 +1535,13 @@ describe('datepicker', function() {
     });
 
     describe('`init-date`', function() {
+      var expectedYear = 1980;
+      var expectedMonth = 10;
+      var expectedDay = 22;
       beforeEach(inject(function() {
         $rootScope.date = null;
         $rootScope.options = {
-          initDate: new Date('November 9, 1980')
+          initDate: new Date(expectedYear, expectedMonth, expectedDay)
         };
         element = $compile('<div uib-datepicker ng-model="date" datepicker-options="options"></div>')($rootScope);
         $rootScope.$digest();
@@ -1550,7 +1553,24 @@ describe('datepicker', function() {
 
       it('shows the correct title', function() {
         expect(getTitle()).toBe('November 1980');
-      });
+    });
+
+    it('does not change on click Next', function(){
+        clickNextButton();
+        var initDate = $rootScope.options.initDate;
+        var actual = initDate.getFullYear() + '-' + (initDate.getMonth()+1) + '-' + initDate.getDate();
+        var expected = expectedYear + '-' + (expectedMonth+1) + '-' + expectedDay;
+
+        expect(actual).toBe(expected);
+    });
+    it('does not change on click Previous', function(){
+        clickPreviousButton();
+        var initDate = $rootScope.options.initDate;
+        var actual = initDate.getFullYear() + '-' + (initDate.getMonth()+1) + '-' + initDate.getDate();
+        var expected = expectedYear + '-' + (expectedMonth+1) + '-' + expectedDay;
+
+        expect(actual).toBe(expected);
+       });
     });
 
     describe('`datepicker-mode`', function() {


### PR DESCRIPTION
Closes 6636

change the datepicker activeDate so it uses a copy of the initDate instead of a reference to initDate.
This way when the user clicks Next or Previous, activeDate changes but initDate does not.

[https://github.com/angular-ui/bootstrap/issues/6636](6636)