### PR TITLE
fix(modal): closing pressed on modal and released out of

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -101,7 +101,13 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.multiMap', 'ui.bootstrap.sta
         };
 
         // moved from template to fix issue #2280
-        element.on('click', scope.close);
+        element.on('mousedown', function(evt1) {
+          element.one('mouseup', function(evt2) {
+            if (evt1.target === evt2.target) {
+              scope.close.apply(this, arguments);
+            }
+          });
+        });
 
         // This property is only added to the scope for the purpose of detecting when this directive is rendered.
         // We can detect that by using this property in the template associated with this directive and then use

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -508,15 +508,31 @@ describe('$uibModal', function() {
 
     it('should support closing on backdrop click', function() {
       var modal = open({template: '<div>Content</div>'});
+      var selector = 'body > div.modal';
       expect($document).toHaveModalsOpen(1);
 
-      $document.find('body > div.modal').click();
+      $document.find(selector).mousedown();
+      $document.find(selector).mouseup();
+
       $animate.flush();
       $rootScope.$digest();
       $animate.flush();
       $rootScope.$digest();
 
       expect($document).toHaveModalsOpen(0);
+    });
+
+    it('should not close modal when initial click was on slider and mouseup on backdrop', function() {
+      var selector = 'body > div.modal';
+      open({template: '<div>Content</div>'});
+
+      expect($document).toHaveModalsOpen(1);
+
+      $document.find('div.modal-dialog').mousedown();
+      $document.find(selector).mouseup();
+      $document.find('div.modal-dialog').click();
+
+      expect($document).toHaveModalsOpen(1);
     });
 
     it('should return to the element which had focus before the dialog was invoked', function() {

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -523,14 +523,14 @@ describe('$uibModal', function() {
     });
 
     it('should not close modal when initial click was on slider and mouseup on backdrop', function() {
-      var selector = 'body > div.modal';
+      var selector = 'div.modal-dialog';
       open({template: '<div>Content</div>'});
 
       expect($document).toHaveModalsOpen(1);
 
-      $document.find('div.modal-dialog').mousedown();
-      $document.find(selector).mouseup();
-      $document.find('div.modal-dialog').click();
+      $document.find(selector).mousedown();
+      $document.find('body > div.modal').mouseup();
+      $document.find(selector).click();
 
       expect($document).toHaveModalsOpen(1);
     });


### PR DESCRIPTION
Fix bug when click started on modal content and released out of modal.

Closes [5810 issue](https://github.com/angular-ui/bootstrap/issues/5810)
Also [5911 PR](https://github.com/angular-ui/bootstrap/pull/5911)