### PR TITLE
docs: add missing default config options for uib-popover and uib-tooltiop

### DIFF
--- a/src/popover/docs/readme.md
+++ b/src/popover/docs/readme.md
@@ -80,7 +80,8 @@ All these settings are available for the three types of popovers.
 
 * `popover-trigger`
   <small class="badge">$</small>
-  _(Default: `'click'`)_ -
+  <small class="badge">C</small>
+  _(Default: `'click'`, Config: `trigger`)_ -
   What should trigger a show of the popover? Supports a space separated list of event names, or objects (see below).
 
 **Note:** To configure the tooltips, you need to do it on `$uibTooltipProvider` (also see below).

--- a/src/tooltip/docs/readme.md
+++ b/src/tooltip/docs/readme.md
@@ -75,7 +75,8 @@ All these settings are available for the three types of tooltips.
 
 * `tooltip-trigger`
   <small class="badge">$</small>
-  _(Default: `'mouseenter'`)_ -
+  <small class="badge">C</small>
+  _(Default: `'click'`, Config: `trigger`)_ -
   What should trigger a show of the tooltip? Supports a space separated list of event names, or objects (see below).
 
 **Note:** To configure the tooltips, you need to do it on `$uibTooltipProvider` (also see below).


### PR DESCRIPTION
Yes this project is no longer active, but an update to the docs does not constitute a change to the library. A merge + update of the docs would be appreciated! <3