### PR TITLE
Remove has-error class to match other input components

### DIFF
--- a/template/timepicker/timepicker.html
+++ b/template/timepicker/timepicker.html
@@ -9,15 +9,15 @@
       <td ng-show="showMeridian"></td>
     </tr>
     <tr>
-      <td class="form-group uib-time hours" ng-class="{'has-error': invalidHours}">
+      <td class="form-group uib-time hours">
         <input type="text" placeholder="HH" ng-model="hours" ng-change="updateHours()" class="form-control text-center" ng-readonly="::readonlyInput" maxlength="2" tabindex="{{::tabindex}}" ng-disabled="noIncrementHours()" ng-blur="blur()">
       </td>
       <td class="uib-separator">:</td>
-      <td class="form-group uib-time minutes" ng-class="{'has-error': invalidMinutes}">
+      <td class="form-group uib-time minutes">
         <input type="text" placeholder="MM" ng-model="minutes" ng-change="updateMinutes()" class="form-control text-center" ng-readonly="::readonlyInput" maxlength="2" tabindex="{{::tabindex}}" ng-disabled="noIncrementMinutes()" ng-blur="blur()">
       </td>
       <td ng-show="showSeconds" class="uib-separator">:</td>
-      <td class="form-group uib-time seconds" ng-class="{'has-error': invalidSeconds}" ng-show="showSeconds">
+      <td class="form-group uib-time seconds" ng-show="showSeconds">
         <input type="text" placeholder="SS" ng-model="seconds" ng-change="updateSeconds()" class="form-control text-center" ng-readonly="readonlyInput" maxlength="2" tabindex="{{::tabindex}}" ng-disabled="noIncrementSeconds()" ng-blur="blur()">
       </td>
       <td ng-show="showMeridian" class="uib-time am-pm"><button type="button" ng-class="{disabled: noToggleMeridian()}" class="btn btn-default text-center" ng-click="toggleMeridian()" ng-disabled="noToggleMeridian()" tabindex="{{::tabindex}}">{{meridian}}</button></td>


### PR DESCRIPTION
None of the other input components have ` ng-class="{'has-error': ....}"` display change when the input is invalid.  Removing it from timepicker.