### PR TITLE
remove background color overwrite

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -149,8 +149,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.debounce', 'ui.bootstrap
       });
       element.css({
         'position': 'relative',
-        'vertical-align': 'top',
-        'background-color': 'transparent'
+        'vertical-align': 'top'
       });
 
       if (hintInputElem.attr('id')) {


### PR DESCRIPTION
this breaks disabled state with bootstrap

when trying to disable a typeahead, it won't be styled correctly by bootstrap
default greyed out will not apply on typeaheads