### PR TITLE
Fix am-pm in differents locales

### DIFF
--- a/src/dateparser/dateparser.js
+++ b/src/dateparser/dateparser.js
@@ -178,7 +178,7 @@ angular.module('ui.bootstrap.dateparser', [])
             this.hours = 0;
           }
 
-          if (value === 'PM') {
+          if (value === $locale.DATETIME_FORMATS.AMPMS[1]) {
             this.hours += 12;
           }
         },


### PR DESCRIPTION
ui.bootstrap.dateparser

Actually  assumes that value for regext 'a' is 'PM', it does not consider different locales.

Thank you.
